### PR TITLE
refactor: centralize GitHub token setup in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,7 @@ runs:
   using: 'composite'
   steps:
     - name: Prepare GitHub Token
+      id: prepare_token
       shell: bash
       env:
         PROVIDED_TOKEN: ${{ inputs.reviewer_github_token }}
@@ -52,12 +53,15 @@ runs:
           exit 1
         fi
 
-        # Export to GITHUB_ENV so it's available to all subsequent steps and used by 'gh' CLI
-        echo "GITHUB_TOKEN=$FINAL_TOKEN" >> $GITHUB_ENV
+        # Mask the token so it doesn't show up in logs
+        echo "::add-mask::$FINAL_TOKEN"
+        echo "token=$FINAL_TOKEN" >> $GITHUB_OUTPUT
     - name: Add Eyes Reaction
       if: github.event.pull_request.number != ''
       shell: bash
       continue-on-error: true
+      env:
+        GITHUB_TOKEN: ${{ steps.prepare_token.outputs.token }}
       run: |
         REACTION_ID=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/reactions -f content='eyes' --jq '.id // empty')
         if [ -n "$REACTION_ID" ]; then
@@ -101,6 +105,8 @@ runs:
     - name: Post AI Review Comment
       if: github.event.pull_request.number != ''
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ steps.prepare_token.outputs.token }}
       run: |
         TAG="<!-- cassandra-ai-review -->"
 
@@ -121,6 +127,8 @@ runs:
       if: always() && github.event.pull_request.number != ''
       shell: bash
       continue-on-error: true
+      env:
+        GITHUB_TOKEN: ${{ steps.prepare_token.outputs.token }}
       run: |
         if [ -n "$CASSANDRA_REACTION_ID" ]; then
           gh api -X DELETE repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/reactions/$CASSANDRA_REACTION_ID


### PR DESCRIPTION
Introduce a "Prepare GitHub Token" step at the beginning of the action to handle fallback logic and export GITHUB_TOKEN to the environment. This ensures all subsequent steps use a consistent, valid token and simplifies the configuration of individual steps.