### PR TITLE
feat: add skepticism of internal knowledge to reviewer prompt

### DIFF
--- a/core/prompts/prompts_test.go
+++ b/core/prompts/prompts_test.go
@@ -59,6 +59,7 @@ func TestBuildSystemPrompt(t *testing.T) {
 	require.True(t, strings.Contains(prompt, "You are a code review bot - named Cassandra - for the provided codebase."))
 	require.True(t, strings.Contains(prompt, "<code_review_guidelines>"))
 	require.True(t, strings.Contains(prompt, "Is this code maintainable, easy to work with, and safe?"))
+	require.True(t, strings.Contains(prompt, "Skepticism of Internal Knowledge"))
 
 	// Check that reviewers is inside code_review_guidelines:
 	guidelinesIndex := strings.Index(prompt, "<code_review_guidelines>")

--- a/core/prompts/reviewer_prompt.md
+++ b/core/prompts/reviewer_prompt.md
@@ -25,7 +25,11 @@ When multiple tool calls are needed, request them all in a single response — t
 - **No File Lists**: Do not list the files reviewed at the end of the review. The final verdict must be standalone.
 - **No Formatting or Linting**: Do not review code formatting (indentation, bracing, whitespace) or issues typically handled by a linter (unused imports, minor naming conventions), unless explicitly instructed by the guidelines. Your internal "style" should never override the author's choice. Focus on logic, architecture, security, and intent.
 - **Guideline Adherence**: The frequency and severity of items should follow the philosophy and "Tolerance" section of the provided guidelines.
-- **Stale Knowledge**: Do not assume your internal training data regarding external, rapidly-changing entities (such as AI model IDs, library versions, or API schemas) is up-to-date. Do not issue blocking items or flag such values as "incorrect" based solely on your internal knowledge. Only flag them if they contradict the project's own documentation, configuration, or established patterns verified via tools.
+- **Skepticism of Internal Knowledge**: You MUST be very skeptical of your internal training data regarding external, rapidly-changing entities. This includes but is not limited to:
+    - **Versions**: Frameworks, compilers, languages, and libraries (e.g., Go version requirements, library API changes).
+    - **Model IDs**: Names or capabilities of specific AI models.
+    - **Current Events**: Recent software releases, security vulnerabilities, or industry shifts.
+  Do not issue blocking items or flag such values as "incorrect" based solely on your internal knowledge. Only flag them if they contradict the project's own documentation, configuration (e.g., `go.mod`, `MODULE.bazel`), or established patterns verified via tools.
 - If the input includes a PR title and description, review them too: flag inconsistencies with the actual code change, typos, and grammar errors.
 
 ## Output format


### PR DESCRIPTION
Rename 'Stale Knowledge' to 'Skepticism of Internal Knowledge' and explicitly list volatile entities (versions, model IDs, current events) that the model should be skeptical about. This ensures the AI reviewer does not flag items as "incorrect" based solely on its internal training data if they can't be verified against the project's own documentation.

Fixes #30 