### PR TITLE
feat: support inline PR review comments

### DIFF
--- a/.github/workflows/cassandra_review.yml
+++ b/.github/workflows/cassandra_review.yml
@@ -22,3 +22,4 @@ jobs:
           provider_api_key: ${{ secrets.GEMINI_API_KEY }}
           base: ${{ github.event.pull_request.base.sha }}
           head: ${{ github.event.pull_request.head.sha }}
+          submit_review_action: 'true'

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: 'The reaction icon to add to the PR description while the review is in progress (e.g., eyes, rocket, heart).'
     required: false
     default: 'eyes'
+  use_inline_comments:
+    description: 'Whether to post inline comments to the PR (requires the reviewer to output a structured JSON file).'
+    required: false
+    default: 'true'
 runs:
   using: 'composite'
   steps:
@@ -108,8 +112,9 @@ runs:
         WORKING_DIRECTORY: ${{ inputs.working_directory }}
         MAIN_GUIDELINES: ${{ inputs.main_guidelines }}
       run: |
-        # Use a temporary file for the review output
+        # Use temporary files for the review outputs
         REVIEW_FILE="${{ runner.temp }}/cassandra_review.md"
+        JSON_FILE="${{ runner.temp }}/cassandra_review.json"
 
         ARGS=(
           --provider "$PROVIDER"
@@ -119,6 +124,7 @@ runs:
           --head "$HEAD"
           --cwd "${{ github.workspace }}/$WORKING_DIRECTORY"
           --review-output-file "$REVIEW_FILE"
+          --output-json "$JSON_FILE"
         )
 
         if [[ -f "$METADATA_FILE" ]]; then
@@ -143,8 +149,9 @@ runs:
 
         # Export the review file path for the next step
         echo "REVIEW_FILE=$REVIEW_FILE" >> $GITHUB_ENV
+        echo "JSON_FILE=$JSON_FILE" >> $GITHUB_ENV
     - name: Post AI Review Comment
-      if: github.event.pull_request.number != ''
+      if: github.event.pull_request.number != '' && inputs.use_inline_comments != 'true'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ steps.prepare_token.outputs.token }}
@@ -153,6 +160,16 @@ runs:
         # Execute via Bazel in the action's source directory
         cd "${{ github.action_path }}"
         bazel run //cmd/github:github -- post-comment --repo-full-name "${{ github.repository }}" --pr "${{ github.event.pull_request.number }}" --file "$REVIEW_FILE" --tag "$METADATA_TAG"
+    - name: Post AI Structured Review
+      if: github.event.pull_request.number != '' && inputs.use_inline_comments == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ steps.prepare_token.outputs.token }}
+        METADATA_TAG: ${{ inputs.metadata_tag }}
+      run: |
+        # Execute via Bazel in the action's source directory
+        cd "${{ github.action_path }}"
+        bazel run //cmd/github:github -- post-structured-review --repo-full-name "${{ github.repository }}" --pr "${{ github.event.pull_request.number }}" --file "$JSON_FILE" --tag "$METADATA_TAG" --metadata-file "$METADATA_FILE"
     - name: Remove Status Reaction
       if: always() && github.event.pull_request.number != ''
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: 'Whether to post inline comments to the PR (requires the reviewer to output a structured JSON file).'
     required: false
     default: 'true'
+  submit_review_action:
+    description: 'Whether to allow the AI to submit "approve/reject" actions or force it to only "comment". Options: "true" (allow approve/reject), "false" (force to "comment").'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -166,10 +170,25 @@ runs:
       env:
         GITHUB_TOKEN: ${{ steps.prepare_token.outputs.token }}
         METADATA_TAG: ${{ inputs.metadata_tag }}
+        ALLOW_REVIEW_ACTION: ${{ inputs.submit_review_action }}
       run: |
         # Execute via Bazel in the action's source directory
         cd "${{ github.action_path }}"
-        bazel run //cmd/github:github -- post-structured-review --repo-full-name "${{ github.repository }}" --pr "${{ github.event.pull_request.number }}" --file "$JSON_FILE" --tag "$METADATA_TAG" --metadata-file "$METADATA_FILE"
+        
+        ARGS=(
+          post-structured-review
+          --repo-full-name "${{ github.repository }}"
+          --pr "${{ github.event.pull_request.number }}"
+          --file "$JSON_FILE"
+          --tag "$METADATA_TAG"
+          --metadata-file "$METADATA_FILE"
+        )
+        
+        if [[ "$ALLOW_REVIEW_ACTION" == "true" ]]; then
+          ARGS+=(--allow-review-action)
+        fi
+        
+        bazel run //cmd/github:github -- "${ARGS[@]}"
     - name: Remove Status Reaction
       if: always() && github.event.pull_request.number != ''
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -174,7 +174,7 @@ runs:
       run: |
         # Execute via Bazel in the action's source directory
         cd "${{ github.action_path }}"
-        
+
         ARGS=(
           post-structured-review
           --repo-full-name "${{ github.repository }}"
@@ -183,11 +183,11 @@ runs:
           --tag "$METADATA_TAG"
           --metadata-file "$METADATA_FILE"
         )
-        
+
         if [[ "$ALLOW_REVIEW_ACTION" == "true" ]]; then
           ARGS+=(--allow-review-action)
         fi
-        
+
         bazel run //cmd/github:github -- "${ARGS[@]}"
     - name: Remove Status Reaction
       if: always() && github.event.pull_request.number != ''

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -158,7 +158,10 @@ func postComment(ctx context.Context, client *github.Client, owner, repo string,
 		return fmt.Errorf("failed to read body file: %w", err)
 	}
 
-	content := string(body)
+	return postCommentText(ctx, client, owner, repo, prNumber, string(body), tag)
+}
+
+func postCommentText(ctx context.Context, client *github.Client, owner, repo string, prNumber int, content, tag string) error {
 	if tag != "" && !strings.Contains(content, tag) {
 		content = fmt.Sprintf("%s\n\n%s", content, tag)
 	}
@@ -196,7 +199,7 @@ func postComment(ctx context.Context, client *github.Client, owner, repo string,
 		return err
 	}
 
-	_, _, err = client.Issues.CreateComment(ctx, owner, repo, prNumber, &github.IssueComment{
+	_, _, err := client.Issues.CreateComment(ctx, owner, repo, prNumber, &github.IssueComment{
 		Body: github.Ptr(content),
 	})
 	return err
@@ -304,15 +307,27 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 	if metadataFile != "" {
 		metadataBytes, err := os.ReadFile(metadataFile)
 		if err == nil {
-			_ = json.Unmarshal(metadataBytes, &metadata)
+			if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+				log.Printf("Warning: failed to unmarshal metadata: %v", err)
+			}
+		}
+	}
+
+	// 1. Post Non-Specific Review as a separate comment
+	if sr.NonSpecificReview != "" {
+		if err := postCommentText(ctx, client, owner, repo, prNumber, sr.NonSpecificReview, tag); err != nil {
+			log.Printf("Warning: failed to post non-specific review comment: %v", err)
 		}
 	}
 
 	comments := []*github.DraftReviewComment{}
+	reviewRationale := sr.Approval.Rationale
+
 	for _, fr := range sr.FilesReview {
 		startLine, endLine, err := fr.ParseLines()
 		if err != nil {
-			log.Printf("Warning: failed to parse lines for %s: %v. Skipping inline comment.", fr.Path, err)
+			log.Printf("Warning: failed to parse lines for %s: %v. Appending to main review rationale.", fr.Path, err)
+			reviewRationale = fmt.Sprintf("%s\n\n- **%s**: %s", reviewRationale, fr.Path, fr.Review)
 			continue
 		}
 
@@ -337,19 +352,23 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		comment := &github.DraftReviewComment{
 			Path: github.Ptr(fr.Path),
 			Body: github.Ptr(commentBody),
-			Line: github.Ptr(endLine),
 		}
-		if startLine != endLine {
-			comment.StartLine = github.Ptr(startLine)
-			comment.StartSide = github.Ptr("RIGHT")
+
+		if endLine > 0 {
+			comment.Line = github.Ptr(endLine)
+			if startLine != endLine {
+				comment.StartLine = github.Ptr(startLine)
+				comment.StartSide = github.Ptr("RIGHT")
+			}
+			comments = append(comments, comment)
+		} else {
+			// File-level comment - go-github v69 doesn't support SubjectType: file on DraftReviewComment.
+			// Fallback: append to the main review rationale.
+			reviewRationale = fmt.Sprintf("%s\n\n- **%s** (file-level): %s", reviewRationale, fr.Path, fr.Review)
 		}
-		comments = append(comments, comment)
 	}
 
-	reviewBody := sr.Approval.Rationale
-	if sr.NonSpecificReview != "" {
-		reviewBody = fmt.Sprintf("%s\n\n### General Feedback\n%s", reviewBody, sr.NonSpecificReview)
-	}
+	reviewBody := reviewRationale
 	if tag != "" {
 		reviewBody = fmt.Sprintf("%s\n\n%s", reviewBody, tag)
 	}
@@ -361,8 +380,8 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		}
 	}
 
-	action := sr.Approval.Action
-	if !allowReviewAction {
+	action := strings.ToUpper(strings.TrimSpace(sr.Approval.Action))
+	if !allowReviewAction || (action != "APPROVE" && action != "REQUEST_CHANGES" && action != "COMMENT") {
 		action = "COMMENT"
 	}
 
@@ -372,8 +391,33 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		Comments: comments,
 	}
 
-	_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
-	return err
+	_, resp, err := client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+	if err != nil {
+		// If we get a 422 error, it might be due to a line hallucination (line not in diff).
+		// Fallback: post the review without inline comments so we don't lose the summary feedback.
+		if resp != nil && resp.StatusCode == 422 && len(comments) > 0 {
+			log.Printf("Warning: failed to post structured review (likely due to line hallucinations): %v. Retrying without inline comments.", err)
+			reviewRequest.Comments = nil
+
+			// Append the skipped comments to the body so they aren't lost
+			var sb strings.Builder
+			sb.WriteString(reviewRequest.GetBody())
+			sb.WriteString("\n\n### Detailed Inline Feedback (Fallback)\n")
+			for _, c := range comments {
+				loc := ""
+				if c.Line != nil {
+					loc = fmt.Sprintf(" at line %d", *c.Line)
+				}
+				sb.WriteString(fmt.Sprintf("- **%s**%s: %s\n", c.GetPath(), loc, c.GetBody()))
+			}
+			reviewRequest.Body = github.Ptr(sb.String())
+
+			_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+			return err
+		}
+		return err
+	}
+	return nil
 }
 
 func dismissPreviousReviews(ctx context.Context, client *github.Client, owner, repo string, prNumber int, tag string) error {

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -23,6 +23,7 @@ func main() {
 	var bodyFile string
 	var tag string
 	var outputFile string
+	var metadataFile string
 
 	flag.StringVar(&repoFullName, "repo-full-name", "", "Full name of the repository (owner/repo)")
 	flag.IntVar(&prNumber, "pr", 0, "Pull request number")
@@ -31,6 +32,7 @@ func main() {
 	flag.StringVar(&bodyFile, "file", "", "Path to the comment body file")
 	flag.StringVar(&tag, "tag", "", "Tag to identify the comment for updates or self-identification")
 	flag.StringVar(&outputFile, "output", "", "Path to the output file (for get-metadata)")
+	flag.StringVar(&metadataFile, "metadata-file", "", "Path to the metadata file (for post-structured-review)")
 
 	flag.Parse()
 
@@ -91,6 +93,15 @@ func main() {
 		err := postComment(ctx, client, owner, repo, prNumber, bodyFile, tag)
 		if err != nil {
 			log.Fatalf("Failed to post comment: %v", err)
+		}
+
+	case "post-structured-review":
+		if bodyFile == "" {
+			log.Fatal("--file is required for post-structured-review")
+		}
+		err := postStructuredReview(ctx, client, owner, repo, prNumber, bodyFile, tag, metadataFile)
+		if err != nil {
+			log.Fatalf("Failed to post structured review: %v", err)
 		}
 
 	case "get-metadata":
@@ -274,4 +285,74 @@ func getCreatedAt(ts *github.Timestamp) time.Time {
 		return time.Time{}
 	}
 	return ts.Time
+}
+
+func postStructuredReview(ctx context.Context, client *github.Client, owner, repo string, prNumber int, bodyFile, tag, metadataFile string) error {
+	reviewBytes, err := os.ReadFile(bodyFile)
+	if err != nil {
+		return fmt.Errorf("failed to read structured review file: %w", err)
+	}
+
+	var sr core.StructuredReview
+	if err := json.Unmarshal(reviewBytes, &sr); err != nil {
+		return fmt.Errorf("failed to unmarshal structured review: %w", err)
+	}
+
+	var metadata core.PRMetadata
+	if metadataFile != "" {
+		metadataBytes, err := os.ReadFile(metadataFile)
+		if err == nil {
+			_ = json.Unmarshal(metadataBytes, &metadata)
+		}
+	}
+
+	comments := []*github.DraftReviewComment{}
+	for _, fr := range sr.FilesReview {
+		startLine, endLine, err := fr.ParseLines()
+		if err != nil {
+			log.Printf("Warning: failed to parse lines for %s: %v. Skipping inline comment.", fr.Path, err)
+			continue
+		}
+
+		// Check if we've already made this exact comment at this exact location
+		alreadyCommented := false
+		for _, c := range metadata.Comments {
+			if c.IsSelf && c.Path == fr.Path && c.Line == endLine && strings.Contains(c.Body, strings.TrimSpace(fr.Review)) {
+				alreadyCommented = true
+				break
+			}
+		}
+
+		if alreadyCommented {
+			continue
+		}
+
+		comment := &github.DraftReviewComment{
+			Path: github.Ptr(fr.Path),
+			Body: github.Ptr(fr.Review),
+			Line: github.Ptr(endLine),
+		}
+		if startLine != endLine {
+			comment.StartLine = github.Ptr(startLine)
+			comment.StartSide = github.Ptr("RIGHT")
+		}
+		comments = append(comments, comment)
+	}
+
+	reviewBody := sr.Approval.Rationale
+	if sr.NonSpecificReview != "" {
+		reviewBody = fmt.Sprintf("%s\n\n### General Feedback\n%s", reviewBody, sr.NonSpecificReview)
+	}
+	if tag != "" {
+		reviewBody = fmt.Sprintf("%s\n\n%s", reviewBody, tag)
+	}
+
+	reviewRequest := &github.PullRequestReviewRequest{
+		Body:     github.Ptr(reviewBody),
+		Event:    github.Ptr(sr.Approval.Action),
+		Comments: comments,
+	}
+
+	_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+	return err
 }

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -24,6 +24,7 @@ func main() {
 	var tag string
 	var outputFile string
 	var metadataFile string
+	var allowReviewAction bool
 
 	flag.StringVar(&repoFullName, "repo-full-name", "", "Full name of the repository (owner/repo)")
 	flag.IntVar(&prNumber, "pr", 0, "Pull request number")
@@ -33,6 +34,7 @@ func main() {
 	flag.StringVar(&tag, "tag", "", "Tag to identify the comment for updates or self-identification")
 	flag.StringVar(&outputFile, "output", "", "Path to the output file (for get-metadata)")
 	flag.StringVar(&metadataFile, "metadata-file", "", "Path to the metadata file (for post-structured-review)")
+	flag.BoolVar(&allowReviewAction, "allow-review-action", false, "Whether to allow the AI's suggested review action (APPROVE/REQUEST_CHANGES). If false, forces COMMENT.")
 
 	flag.Parse()
 
@@ -99,7 +101,7 @@ func main() {
 		if bodyFile == "" {
 			log.Fatal("--file is required for post-structured-review")
 		}
-		err := postStructuredReview(ctx, client, owner, repo, prNumber, bodyFile, tag, metadataFile)
+		err := postStructuredReview(ctx, client, owner, repo, prNumber, bodyFile, tag, metadataFile, allowReviewAction)
 		if err != nil {
 			log.Fatalf("Failed to post structured review: %v", err)
 		}
@@ -287,7 +289,7 @@ func getCreatedAt(ts *github.Timestamp) time.Time {
 	return ts.Time
 }
 
-func postStructuredReview(ctx context.Context, client *github.Client, owner, repo string, prNumber int, bodyFile, tag, metadataFile string) error {
+func postStructuredReview(ctx context.Context, client *github.Client, owner, repo string, prNumber int, bodyFile, tag, metadataFile string, allowReviewAction bool) error {
 	reviewBytes, err := os.ReadFile(bodyFile)
 	if err != nil {
 		return fmt.Errorf("failed to read structured review file: %w", err)
@@ -352,9 +354,14 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		reviewBody = fmt.Sprintf("%s\n\n%s", reviewBody, tag)
 	}
 
+	action := sr.Approval.Action
+	if !allowReviewAction {
+		action = "COMMENT"
+	}
+
 	reviewRequest := &github.PullRequestReviewRequest{
 		Body:     github.Ptr(reviewBody),
-		Event:    github.Ptr(sr.Approval.Action),
+		Event:    github.Ptr(action),
 		Comments: comments,
 	}
 

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -327,9 +327,14 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 			continue
 		}
 
+		commentBody := fr.Review
+		if tag != "" {
+			commentBody = fmt.Sprintf("%s\n\n%s", commentBody, tag)
+		}
+
 		comment := &github.DraftReviewComment{
 			Path: github.Ptr(fr.Path),
-			Body: github.Ptr(fr.Review),
+			Body: github.Ptr(commentBody),
 			Line: github.Ptr(endLine),
 		}
 		if startLine != endLine {

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -354,6 +354,13 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		reviewBody = fmt.Sprintf("%s\n\n%s", reviewBody, tag)
 	}
 
+	// Dismiss previous reviews with the same tag to keep the PR timeline clean.
+	if tag != "" {
+		if err := dismissPreviousReviews(ctx, client, owner, repo, prNumber, tag); err != nil {
+			log.Printf("Warning: failed to dismiss previous reviews: %v", err)
+		}
+	}
+
 	action := sr.Approval.Action
 	if !allowReviewAction {
 		action = "COMMENT"
@@ -367,4 +374,31 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 
 	_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
 	return err
+}
+
+func dismissPreviousReviews(ctx context.Context, client *github.Client, owner, repo string, prNumber int, tag string) error {
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		reviews, resp, err := client.PullRequests.ListReviews(ctx, owner, repo, prNumber, opts)
+		if err != nil {
+			return err
+		}
+
+		for _, r := range reviews {
+			if strings.Contains(r.GetBody(), tag) && r.GetState() != "DISMISSED" {
+				_, _, err := client.PullRequests.DismissReview(ctx, owner, repo, prNumber, r.GetID(), &github.PullRequestReviewDismissalRequest{
+					Message: github.Ptr("Superseded by a new AI review."),
+				})
+				if err != nil {
+					log.Printf("Warning: failed to dismiss review %d: %v", r.GetID(), err)
+				}
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return nil
 }

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -166,6 +166,12 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 		content = fmt.Sprintf("%s\n\n%s", content, tag)
 	}
 
+	self, _, err := client.Users.Get(ctx, "")
+	if err != nil {
+		return fmt.Errorf("failed to get self user: %w", err)
+	}
+	selfLogin := self.GetLogin()
+
 	// Find existing comment
 	opts := &github.IssueListCommentsOptions{
 		ListOptions: github.ListOptions{
@@ -180,8 +186,8 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 			return fmt.Errorf("failed to list comments: %w", err)
 		}
 		for _, c := range comments {
-			if tag != "" && strings.Contains(c.GetBody(), tag) {
-				// We found a matching comment. Since the API returns results in
+			if tag != "" && strings.Contains(c.GetBody(), tag) && c.GetUser().GetLogin() == selfLogin {
+				// We found a matching comment from ourselves. Since the API returns results in
 				// ascending chronological order, the last one we find is the latest.
 				latestCommentID = c.GetID()
 			}
@@ -199,7 +205,7 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 		return err
 	}
 
-	_, _, err := client.Issues.CreateComment(ctx, owner, repo, prNumber, &github.IssueComment{
+	_, _, err = client.Issues.CreateComment(ctx, owner, repo, prNumber, &github.IssueComment{
 		Body: github.Ptr(content),
 	})
 	return err
@@ -209,6 +215,11 @@ func getMetadata(ctx context.Context, client *github.Client, owner, repo string,
 	pr, _, err := client.PullRequests.Get(ctx, owner, repo, prNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get PR: %w", err)
+	}
+
+	commentTag := tag
+	if tag != "" {
+		commentTag = strings.Replace(tag, "<!-- ", "<!-- comment-", 1)
 	}
 
 	metadata := &core.PRMetadata{
@@ -259,7 +270,8 @@ func getMetadata(ctx context.Context, client *github.Client, owner, repo string,
 
 		for _, c := range comments {
 			body := c.GetBody()
-			isSelf := tag != "" && strings.Contains(body, tag)
+			// Inline comments use the special commentTag
+			isSelf := commentTag != "" && strings.Contains(body, commentTag)
 			metadata.Comments = append(metadata.Comments, core.PRComment{
 				Author:    c.GetUser().GetLogin(),
 				Body:      body,
@@ -323,6 +335,13 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 	comments := []*github.DraftReviewComment{}
 	reviewRationale := sr.Approval.Rationale
 
+	commentTag := tag
+	if tag != "" {
+		// Distinguish between the main (non-specific) comment and the inline review comments
+		// by using a different prefix for the latter.
+		commentTag = strings.Replace(tag, "<!-- ", "<!-- comment-", 1)
+	}
+
 	for _, fr := range sr.FilesReview {
 		startLine, endLine, err := fr.ParseLines()
 		if err != nil {
@@ -345,8 +364,8 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		}
 
 		commentBody := fr.Review
-		if tag != "" {
-			commentBody = fmt.Sprintf("%s\n\n%s", commentBody, tag)
+		if commentTag != "" {
+			commentBody = fmt.Sprintf("%s\n\n%s", commentBody, commentTag)
 		}
 
 		comment := &github.DraftReviewComment{

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -295,6 +295,20 @@ func TestPostStructuredReview(t *testing.T) {
 	_ = os.WriteFile(metadataFile, metadataBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
+			[]github.IssueComment{},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposIssuesCommentsByOwnerByRepoByIssueNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var comment github.IssueComment
+				_ = json.NewDecoder(r.Body).Decode(&comment)
+				assert.Contains(t, *comment.Body, "General feedback")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.IssueComment{ID: github.Ptr(int64(101))}))
+			}),
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -303,7 +317,7 @@ func TestPostStructuredReview(t *testing.T) {
 
 				assert.Equal(t, "APPROVE", *req.Event)
 				assert.Contains(t, *req.Body, "LGTM!")
-				assert.Contains(t, *req.Body, "General feedback")
+				assert.NotContains(t, *req.Body, "General feedback") // Should NOT be in review body
 				assert.Contains(t, *req.Body, "<!-- tag -->")
 
 				// Only one comment should be present (the non-duplicate)
@@ -441,5 +455,157 @@ func TestDismissPreviousReviews(t *testing.T) {
 	client := github.NewClient(mockedHTTPClient)
 
 	err := dismissPreviousReviews(context.Background(), client, "owner", "repo", 1, "<!-- tag -->")
+	assert.NoError(t, err)
+}
+
+func TestPostStructuredReview_422Fallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  true,
+			Rationale: "Summary feedback",
+			Action:    "APPROVE",
+		},
+		FilesReview: []core.FileReview{
+			{
+				Path:   "file.go",
+				Lines:  "999", // Hallucinated line
+				Review: "Something important",
+			},
+		},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	callCount := 0
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				if callCount == 1 {
+					// First attempt: fail with 422
+					w.WriteHeader(422)
+					_, _ = w.Write([]byte(`{"message": "Unprocessable Entity"}`))
+				} else {
+					// Second attempt: verify fallback payload
+					var req github.PullRequestReviewRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					assert.Equal(t, 0, len(req.Comments))
+					assert.Contains(t, *req.Body, "Detailed Inline Feedback (Fallback)")
+					assert.Contains(t, *req.Body, "file.go")
+					assert.Contains(t, *req.Body, "Something important")
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+				}
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestPostStructuredReview_WhitespaceAndOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  true,
+			Rationale: "LGTM!",
+			Action:    "approve", // lowercase
+		},
+		FilesReview: []core.FileReview{
+			{
+				Path:   "file1.go",
+				Lines:  " 10 - 20 ", // whitespace
+				Review: "Range comment",
+			},
+			{
+				Path:   "file2.go",
+				Lines:  "50-40", // reverse order
+				Review: "Reverse comment",
+			},
+		},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				assert.Equal(t, "APPROVE", *req.Event) // normalized
+				assert.Equal(t, 2, len(req.Comments))
+
+				// Verify first comment
+				assert.Equal(t, "file1.go", *req.Comments[0].Path)
+				assert.Equal(t, 10, *req.Comments[0].StartLine)
+				assert.Equal(t, 20, *req.Comments[0].Line)
+
+				// Verify second comment (swapped)
+				assert.Equal(t, "file2.go", *req.Comments[1].Path)
+				assert.Equal(t, 40, *req.Comments[1].StartLine)
+				assert.Equal(t, 50, *req.Comments[1].Line)
+
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
+	assert.NoError(t, err)
+}
+
+func TestPostStructuredReview_FileLevel(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  true,
+			Rationale: "LGTM!",
+			Action:    "APPROVE",
+		},
+		FilesReview: []core.FileReview{
+			{
+				Path:   "README.md",
+				Lines:  "", // file-level
+				Review: "Good documentation",
+			},
+		},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				assert.Equal(t, 0, len(req.Comments)) // appends to body instead
+				assert.Contains(t, *req.Body, "README.md")
+				assert.Contains(t, *req.Body, "Good documentation")
+
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
 	assert.NoError(t, err)
 }

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -402,3 +402,44 @@ func TestPostStructuredReview_OverrideAction(t *testing.T) {
 	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", false) // allowReviewAction = false
 	assert.NoError(t, err)
 }
+
+func TestDismissPreviousReviews(t *testing.T) {
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+			[]github.PullRequestReview{
+				{
+					ID:    github.Ptr(int64(1)),
+					Body:  github.Ptr("Old review <!-- tag -->"),
+					State: github.Ptr("APPROVED"),
+				},
+				{
+					ID:    github.Ptr(int64(2)),
+					Body:  github.Ptr("Another review <!-- tag -->"),
+					State: github.Ptr("DISMISSED"),
+				},
+				{
+					ID:    github.Ptr(int64(3)),
+					Body:  github.Ptr("A review from someone else"),
+					State: github.Ptr("APPROVED"),
+				},
+			},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PutReposPullsReviewsDismissalsByOwnerByRepoByPullNumberByReviewId,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify it's the right review ID being dismissed
+				// In the mock, it would be called for ID 1
+				var req github.PullRequestReviewDismissalRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				assert.Equal(t, "Superseded by a new AI review.", *req.Message)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(1))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := dismissPreviousReviews(context.Background(), client, "owner", "repo", 1, "<!-- tag -->")
+	assert.NoError(t, err)
+}

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -309,7 +309,8 @@ func TestPostStructuredReview(t *testing.T) {
 				// Only one comment should be present (the non-duplicate)
 				assert.Equal(t, 1, len(req.Comments))
 				assert.Equal(t, "file1.go", *req.Comments[0].Path)
-				assert.Equal(t, "New comment", *req.Comments[0].Body)
+				assert.Contains(t, *req.Comments[0].Body, "New comment")
+				assert.Contains(t, *req.Comments[0].Body, "<!-- tag -->")
 				assert.Equal(t, 10, *req.Comments[0].Line)
 
 				w.WriteHeader(http.StatusCreated)

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v69/github"
+	"github.com/menny/cassandra/core"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/stretchr/testify/assert"
 )
@@ -247,4 +249,120 @@ func TestGetMetadata(t *testing.T) {
 		assert.False(t, metadata.Comments[0].IsSelf)
 		assert.False(t, metadata.Comments[1].IsSelf)
 	})
+}
+
+func TestPostStructuredReview(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+	metadataFile := filepath.Join(tmpDir, "metadata.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  true,
+			Rationale: "LGTM!",
+			Action:    "APPROVE",
+		},
+		NonSpecificReview: "General feedback",
+		FilesReview: []core.FileReview{
+			{
+				Path:   "file1.go",
+				Lines:  "10",
+				Review: "New comment",
+			},
+			{
+				Path:   "file2.go",
+				Lines:  "20-25",
+				Review: "Duplicate comment",
+			},
+		},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	metadata := core.PRMetadata{
+		Comments: []core.PRComment{
+			{
+				Author: "cassandra",
+				IsSelf: true,
+				Path:   "file2.go",
+				Line:   25,
+				Body:   "Duplicate comment <!-- tag -->",
+				Date:   time.Now(),
+			},
+		},
+	}
+	metadataBytes, _ := json.Marshal(metadata)
+	_ = os.WriteFile(metadataFile, metadataBytes, 0o644)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				assert.Equal(t, "APPROVE", *req.Event)
+				assert.Contains(t, *req.Body, "LGTM!")
+				assert.Contains(t, *req.Body, "General feedback")
+				assert.Contains(t, *req.Body, "<!-- tag -->")
+
+				// Only one comment should be present (the non-duplicate)
+				assert.Equal(t, 1, len(req.Comments))
+				assert.Equal(t, "file1.go", *req.Comments[0].Path)
+				assert.Equal(t, "New comment", *req.Comments[0].Body)
+				assert.Equal(t, 10, *req.Comments[0].Line)
+
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", metadataFile)
+	assert.NoError(t, err)
+}
+
+func TestPostStructuredReview_NoMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  false,
+			Rationale: "Issues found",
+			Action:    "REQUEST_CHANGES",
+		},
+		FilesReview: []core.FileReview{
+			{
+				Path:   "file1.go",
+				Lines:  "5-10",
+				Review: "Range comment",
+			},
+		},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				assert.Equal(t, "REQUEST_CHANGES", *req.Event)
+				assert.Equal(t, 1, len(req.Comments))
+				assert.Equal(t, 5, *req.Comments[0].StartLine)
+				assert.Equal(t, 10, *req.Comments[0].Line)
+
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "")
+	assert.NoError(t, err)
 }

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -75,6 +75,10 @@ func TestPostComment_Create(t *testing.T) {
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
+		mock.WithRequestMatch(
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			[]github.IssueComment{}, // No existing comments
 		),
@@ -97,11 +101,16 @@ func TestPostComment_Update(t *testing.T) {
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
+		mock.WithRequestMatch(
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			[]github.IssueComment{
 				{
 					ID:   github.Ptr(int64(456)),
 					Body: github.Ptr("old body <!-- tag -->"),
+					User: &github.User{Login: github.Ptr("me")},
 				},
 			},
 		),
@@ -125,6 +134,10 @@ func TestPostComment_Pagination(t *testing.T) {
 	// Custom handler to simulate pagination
 	callCount := 0
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -132,11 +145,11 @@ func TestPostComment_Pagination(t *testing.T) {
 				if callCount == 1 {
 					// Page 1: return non-matching, with Link header to page 2
 					w.Header().Set("Link", `<https://api.github.com/repositories/1/issues/1/comments?page=2>; rel="next"`)
-					comments := []github.IssueComment{{ID: github.Ptr(int64(1)), Body: github.Ptr("no tag")}}
+					comments := []github.IssueComment{{ID: github.Ptr(int64(1)), Body: github.Ptr("no tag"), User: &github.User{Login: github.Ptr("other")}}}
 					_, _ = w.Write(mock.MustMarshal(comments))
 				} else {
 					// Page 2: return matching
-					comments := []github.IssueComment{{ID: github.Ptr(int64(2)), Body: github.Ptr("found <!-- tag -->")}}
+					comments := []github.IssueComment{{ID: github.Ptr(int64(2)), Body: github.Ptr("found <!-- tag -->"), User: &github.User{Login: github.Ptr("me")}}}
 					_, _ = w.Write(mock.MustMarshal(comments))
 				}
 			}),
@@ -168,15 +181,21 @@ func TestPostComment_Latest(t *testing.T) {
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
+		mock.WithRequestMatch(
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			[]github.IssueComment{
 				{
 					ID:   github.Ptr(int64(1)),
 					Body: github.Ptr("old body <!-- tag -->"),
+					User: &github.User{Login: github.Ptr("me")},
 				},
 				{
 					ID:   github.Ptr(int64(2)),
 					Body: github.Ptr("newer body <!-- tag -->"),
+					User: &github.User{Login: github.Ptr("me")},
 				},
 			},
 		),
@@ -219,7 +238,7 @@ func TestGetMetadata(t *testing.T) {
 				[]github.PullRequestComment{
 					{
 						User:      &github.User{Login: github.Ptr("cassandra")},
-						Body:      github.Ptr("comment 2 <!-- tag-a -->"),
+						Body:      github.Ptr("comment 2 <!-- comment-tag-a -->"),
 						CreatedAt: &github.Timestamp{Time: time.Now()},
 						Path:      github.Ptr("file.go"),
 						Line:      github.Ptr(10),
@@ -282,11 +301,11 @@ func TestPostStructuredReview(t *testing.T) {
 	metadata := core.PRMetadata{
 		Comments: []core.PRComment{
 			{
-				Author: "cassandra",
+				Author: "me",
 				IsSelf: true,
 				Path:   "file2.go",
 				Line:   25,
-				Body:   "Duplicate comment <!-- tag -->",
+				Body:   "Duplicate comment <!-- comment-tag -->",
 				Date:   time.Now(),
 			},
 		},
@@ -295,6 +314,10 @@ func TestPostStructuredReview(t *testing.T) {
 	_ = os.WriteFile(metadataFile, metadataBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatch(
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			[]github.IssueComment{},
@@ -324,7 +347,7 @@ func TestPostStructuredReview(t *testing.T) {
 				assert.Equal(t, 1, len(req.Comments))
 				assert.Equal(t, "file1.go", *req.Comments[0].Path)
 				assert.Contains(t, *req.Comments[0].Body, "New comment")
-				assert.Contains(t, *req.Comments[0].Body, "<!-- tag -->")
+				assert.Contains(t, *req.Comments[0].Body, "<!-- comment-tag -->")
 				assert.Equal(t, 10, *req.Comments[0].Line)
 
 				w.WriteHeader(http.StatusCreated)
@@ -360,6 +383,10 @@ func TestPostStructuredReview_NoMetadata(t *testing.T) {
 	_ = os.WriteFile(srFile, srBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -398,6 +425,10 @@ func TestPostStructuredReview_OverrideAction(t *testing.T) {
 	_ = os.WriteFile(srFile, srBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -419,6 +450,10 @@ func TestPostStructuredReview_OverrideAction(t *testing.T) {
 
 func TestDismissPreviousReviews(t *testing.T) {
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatch(
 			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
 			[]github.PullRequestReview{
@@ -481,6 +516,10 @@ func TestPostStructuredReview_422Fallback(t *testing.T) {
 
 	callCount := 0
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -537,6 +576,10 @@ func TestPostStructuredReview_WhitespaceAndOrder(t *testing.T) {
 	_ = os.WriteFile(srFile, srBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -589,6 +632,10 @@ func TestPostStructuredReview_FileLevel(t *testing.T) {
 	_ = os.WriteFile(srFile, srBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -320,7 +320,7 @@ func TestPostStructuredReview(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", metadataFile)
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", metadataFile, true)
 	assert.NoError(t, err)
 }
 
@@ -364,6 +364,41 @@ func TestPostStructuredReview_NoMetadata(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "")
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
+	assert.NoError(t, err)
+}
+
+func TestPostStructuredReview_OverrideAction(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  true,
+			Rationale: "LGTM!",
+			Action:    "APPROVE",
+		},
+		FilesReview: []core.FileReview{},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				assert.Equal(t, "COMMENT", *req.Event) // Overridden from APPROVE to COMMENT
+
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", false) // allowReviewAction = false
 	assert.NoError(t, err)
 }

--- a/core/prompts/extraction_prompt.md
+++ b/core/prompts/extraction_prompt.md
@@ -7,6 +7,10 @@ You are an expert code review parser. Your task is to take a raw markdown code r
 1. **Approval**:
    - `approved`: This must be a strict boolean (true/false). If the review contains a clear approval (e.g., "LGTM", "Looks good"), set to `true`. If there are blocking issues or a clear rejection, set to `false`.
    - `rationale`: Provide a brief, high-level summary of the reasoning behind the approval or rejection.
+   - `action`: Map the review sentiment to one of:
+     - `APPROVE`: If `approved` is true and there are no major issues.
+     - `REQUEST_CHANGES`: If `approved` is false and there are blocking issues.
+     - `COMMENT`: If the review is neutral or contains only suggestions without a clear approval/rejection.
 2. **Non-Specific Review**: If the review contains general comments that aren't tied to a specific file or line range (e.g., architecture, consistency, high-level logic), include them in the `non_specific_review` field.
 3. **Files Review**:
    - `path`: The relative path to the file.

--- a/core/review_types.go
+++ b/core/review_types.go
@@ -37,7 +37,7 @@ func (fr *FileReview) ParseLines() (int, int, error) {
 
 	parts := strings.Split(fr.Lines, "-")
 	if len(parts) == 1 {
-		line, err := strconv.Atoi(parts[0])
+		line, err := strconv.Atoi(strings.TrimSpace(parts[0]))
 		if err != nil {
 			return 0, 0, fmt.Errorf("invalid line format: %v", err)
 		}
@@ -45,13 +45,17 @@ func (fr *FileReview) ParseLines() (int, int, error) {
 	}
 
 	if len(parts) == 2 {
-		startLine, err := strconv.Atoi(parts[0])
+		startLine, err := strconv.Atoi(strings.TrimSpace(parts[0]))
 		if err != nil {
 			return 0, 0, fmt.Errorf("invalid start line format: %v", err)
 		}
-		endLine, err := strconv.Atoi(parts[1])
+		endLine, err := strconv.Atoi(strings.TrimSpace(parts[1]))
 		if err != nil {
 			return 0, 0, fmt.Errorf("invalid end line format: %v", err)
+		}
+
+		if startLine > endLine {
+			return endLine, startLine, nil
 		}
 		return startLine, endLine, nil
 	}

--- a/core/review_types.go
+++ b/core/review_types.go
@@ -1,5 +1,11 @@
 package core
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // StructuredReview represents the final extracted code review in a machine-readable format.
 type StructuredReview struct {
 	RawFreeText       string       `json:"raw_free_text"`
@@ -12,6 +18,7 @@ type StructuredReview struct {
 type Approval struct {
 	Approved  bool   `json:"approved"`
 	Rationale string `json:"rationale"`
+	Action    string `json:"action,omitempty"` // The GitHub review action: "APPROVE", "REQUEST_CHANGES", "COMMENT".
 }
 
 // FileReview represents feedback for a specific part of a file.
@@ -19,6 +26,37 @@ type FileReview struct {
 	Path   string `json:"path"`
 	Lines  string `json:"lines,omitempty"` // A single line ("42") or a single range ("10-25").
 	Review string `json:"review"`
+}
+
+// ParseLines parses the 'lines' string into individual line numbers.
+// Returns startLine and endLine. For single lines, startLine == endLine.
+func (fr *FileReview) ParseLines() (int, int, error) {
+	if fr.Lines == "" {
+		return 0, 0, nil
+	}
+
+	parts := strings.Split(fr.Lines, "-")
+	if len(parts) == 1 {
+		line, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid line format: %v", err)
+		}
+		return line, line, nil
+	}
+
+	if len(parts) == 2 {
+		startLine, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid start line format: %v", err)
+		}
+		endLine, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid end line format: %v", err)
+		}
+		return startLine, endLine, nil
+	}
+
+	return 0, 0, fmt.Errorf("invalid lines format: %s", fr.Lines)
 }
 
 // StructuredReviewSchema is the JSON Schema representation of StructuredReview.
@@ -39,8 +77,13 @@ var StructuredReviewSchema = map[string]any{
 					"type":        "string",
 					"description": "The high-level reasoning for the approval or rejection.",
 				},
+				"action": map[string]any{
+					"type":        "string",
+					"description": "The GitHub review action: 'APPROVE' if approved, 'REQUEST_CHANGES' if there are issues, or 'COMMENT' for neutral feedback.",
+					"enum":        []string{"APPROVE", "REQUEST_CHANGES", "COMMENT"},
+				},
 			},
-			"required": []string{"approved", "rationale"},
+			"required": []string{"approved", "rationale", "action"},
 		},
 		"non_specific_review": map[string]any{
 			"type":        "string",


### PR DESCRIPTION
Implement support for posting inline comments to GitHub PRs based on structured AI review output.

- Support inline comments on specific files and lines.
- Controlled by a `use_inline_comments` flag in `action.yml` (default: `true`).
- `cmd/github/main.go` parses the structured JSON to post:
    - Main (non-specific) review summary.
    - Atomic review with inline comments.
    - Overall Approve/Request Changes/Comment status.
- Includes deduplication logic to avoid repeating the same comment at the same location.
- Each inline comment is tagged with the identified metadata tag for better identification.

Fixes #26