### PR TITLE
feat: support robust inline PR review comments

### DIFF
--- a/.github/workflows/cassandra_review.yml
+++ b/.github/workflows/cassandra_review.yml
@@ -22,3 +22,4 @@ jobs:
           provider_api_key: ${{ secrets.GEMINI_API_KEY }}
           base: ${{ github.event.pull_request.base.sha }}
           head: ${{ github.event.pull_request.head.sha }}
+          submit_review_action: 'true'

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -19,7 +19,8 @@ The system is designed as a CLI-driven, autonomous AI worker. It acts essentiall
 - **Actions**:
   - `add-reaction`: Adds a visual status indicator (e.g., 'eyes') to the PR body.
   - `remove-reaction`: Cleans up reactions after the review completes.
-  - `post-comment`: Manages a "persistent" comment by searching for a unique tag (e.g., `<!-- cassandra-ai-review-Workflow-Name -->`) and either creating a new comment or updating an existing one. This allows multiple review workflows to operate independently on the same PR.
+  - `post-comment`: Manages a "persistent" architectural comment. It ensures a single source of truth by updating the latest comment matching a unique tag (e.g., `<!-- cassandra-main-... -->`) and deleting any redundant duplicates.
+  - `post-structured-review`: Posts a formal GitHub Pull Request Review. It supports inline line-level comments, handles review dismissals, and implements multi-level fallback logic for API resilience.
 - Built as a separate binary to minimize the footprint and dependencies required for basic GitHub interactions.
 
 ### 3. Core AI Engine (`core/agent.go`)
@@ -95,7 +96,8 @@ When the `--output-json` flag is provided, the system performs a post-processing
   "raw_free_text": "...",
   "approval": {
     "approved": true,
-    "rationale": "..."
+    "rationale": "...",
+    "action": "APPROVE | REQUEST_CHANGES | COMMENT"
   },
   "non_specific_review": "...",
   "files_review": [
@@ -109,3 +111,14 @@ When the `--output-json` flag is provided, the system performs a post-processing
 ```
 
 This post-processing ensures the main reasoning pass remains unconstrained, while providing a machine-readable format for integration with other tools (e.g., CI/CD pipelines, GitHub Actions).
+
+## Review Resilience & State Management
+
+The GitHub interaction layer is designed to be highly resilient against common CI failure modes:
+
+1. **API Permission Fallbacks**: If the `GITHUB_TOKEN` is not permitted to submit formal "Approve" actions (a common default setting), the utility automatically downgrades the review to a neutral `COMMENT` while preserving all feedback.
+2. **Line Hallucination Recovery**: If the LLM suggests a comment on a line that is not part of the PR diff (a 422 error), the system automatically retries the submission without inline comments, appending the feedback to the main review body instead.
+3. **Clean PR State**:
+   - **Type-Specific Tagging**: Uses distinct tag prefixes (`cassandra-main-` and `cassandra-inline-`) to unambiguously identify different comment types.
+   - **Automatic Cleanup**: Before posting a new review, the system dismisses previous bot reviews and can optionally delete stale inline comments to keep the conversation tab focused.
+   - **Identity Verification**: When possible, it verifies both the `Tag` and the `Author` identity (handling `403 Forbidden` on `/user` gracefully) to ensure it only modifies its own comments.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An autonomous code review tool built in Go. This tool provides structured, actio
 - **Provider Agnostic**: Natively supports Anthropic and Google models through a unified abstraction.
 - **Agentic Context Gathering**: The LLM agent operates in a ReAct loop and has access to repository tools (like reading files, glob matching, and pattern searching with `grep`) to autonomously gather surrounding context about your codebase before finalizing feedback.
 - **Visual Status Indicators**: Automatically adds an "eyes" reaction to Pull Requests while the review is in progress, providing immediate feedback.
+- **Inline PR Reviews**: Supports formal GitHub PR Reviews with line-level feedback, including automatic dismissal of stale reviews and deduplication of comments.
 - **CI/CD Ready**: Supports outputting reviews directly to files or as structured JSON, making it easy to integrate with GitHub Actions or other CI pipelines.
 
 ## Requirements
@@ -71,6 +72,9 @@ To review changes between a base and a head commit/branch:
 | `metadata_tag` | Tag to identify Cassandra comments (inner text only, will be wrapped in `<!-- ... -->`) | `cassandra-ai-review-${{ github.workflow }}` | No |
 | `reaction_icon` | The reaction icon to add to the PR description while the review is in progress (e.g., `eyes`, `rocket`, `heart`) | `eyes` | No |
 | `reviewer_github_token` | GitHub token for posting comments and reactions | `${{ github.token }}` | No |
+| `use_inline_comments` | Whether to post inline comments to the PR (requires structured JSON output) | `true` | No |
+| `submit_review_action` | Whether to allow formal "approve/reject" actions or force neutral "comment" | `false` | No |
+| `delete_old_comments` | Whether to delete previous bot-authored inline comments before posting a new review | `true` | No |
 
 
 ### Supported Models

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: 'The reaction icon to add to the PR description while the review is in progress (e.g., eyes, rocket, heart).'
     required: false
     default: 'eyes'
+  use_inline_comments:
+    description: 'Whether to post inline comments to the PR (requires the reviewer to output a structured JSON file).'
+    required: false
+    default: 'true'
 runs:
   using: 'composite'
   steps:
@@ -108,8 +112,9 @@ runs:
         WORKING_DIRECTORY: ${{ inputs.working_directory }}
         MAIN_GUIDELINES: ${{ inputs.main_guidelines }}
       run: |
-        # Use a temporary file for the review output
+        # Use temporary files for the review outputs
         REVIEW_FILE="${{ runner.temp }}/cassandra_review.md"
+        JSON_FILE="${{ runner.temp }}/cassandra_review.json"
 
         ARGS=(
           --provider "$PROVIDER"
@@ -119,6 +124,7 @@ runs:
           --head "$HEAD"
           --cwd "${{ github.workspace }}/$WORKING_DIRECTORY"
           --review-output-file "$REVIEW_FILE"
+          --output-json "$JSON_FILE"
         )
 
         if [[ -f "$METADATA_FILE" ]]; then
@@ -143,8 +149,9 @@ runs:
 
         # Export the review file path for the next step
         echo "REVIEW_FILE=$REVIEW_FILE" >> $GITHUB_ENV
+        echo "JSON_FILE=$JSON_FILE" >> $GITHUB_ENV
     - name: Post AI Review Comment
-      if: github.event.pull_request.number != ''
+      if: github.event.pull_request.number != '' && inputs.use_inline_comments != 'true'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ steps.prepare_token.outputs.token }}
@@ -153,6 +160,16 @@ runs:
         # Execute via Bazel in the action's source directory
         cd "${{ github.action_path }}"
         bazel run //cmd/github:github -- post-comment --repo-full-name "${{ github.repository }}" --pr "${{ github.event.pull_request.number }}" --file "$REVIEW_FILE" --tag "$METADATA_TAG"
+    - name: Post AI Structured Review
+      if: github.event.pull_request.number != '' && inputs.use_inline_comments == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ steps.prepare_token.outputs.token }}
+        METADATA_TAG: ${{ inputs.metadata_tag }}
+      run: |
+        # Execute via Bazel in the action's source directory
+        cd "${{ github.action_path }}"
+        bazel run //cmd/github:github -- post-structured-review --repo-full-name "${{ github.repository }}" --pr "${{ github.event.pull_request.number }}" --file "$JSON_FILE" --tag "$METADATA_TAG" --metadata-file "$METADATA_FILE"
     - name: Remove Status Reaction
       if: always() && github.event.pull_request.number != ''
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: 'Whether to post inline comments to the PR (requires the reviewer to output a structured JSON file).'
     required: false
     default: 'true'
+  submit_review_action:
+    description: 'Whether to allow the AI to submit "approve/reject" actions or force it to only "comment". Options: "true" (allow approve/reject), "false" (force to "comment").'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -166,10 +170,25 @@ runs:
       env:
         GITHUB_TOKEN: ${{ steps.prepare_token.outputs.token }}
         METADATA_TAG: ${{ inputs.metadata_tag }}
+        ALLOW_REVIEW_ACTION: ${{ inputs.submit_review_action }}
       run: |
         # Execute via Bazel in the action's source directory
         cd "${{ github.action_path }}"
-        bazel run //cmd/github:github -- post-structured-review --repo-full-name "${{ github.repository }}" --pr "${{ github.event.pull_request.number }}" --file "$JSON_FILE" --tag "$METADATA_TAG" --metadata-file "$METADATA_FILE"
+        
+        ARGS=(
+          post-structured-review
+          --repo-full-name "${{ github.repository }}"
+          --pr "${{ github.event.pull_request.number }}"
+          --file "$JSON_FILE"
+          --tag "$METADATA_TAG"
+          --metadata-file "$METADATA_FILE"
+        )
+        
+        if [[ "$ALLOW_REVIEW_ACTION" == "true" ]]; then
+          ARGS+=(--allow-review-action)
+        fi
+        
+        bazel run //cmd/github:github -- "${ARGS[@]}"
     - name: Remove Status Reaction
       if: always() && github.event.pull_request.number != ''
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -175,6 +175,7 @@ runs:
         GITHUB_TOKEN: ${{ steps.prepare_token.outputs.token }}
         METADATA_TAG: ${{ inputs.metadata_tag }}
         ALLOW_REVIEW_ACTION: ${{ inputs.submit_review_action }}
+        DELETE_OLD_COMMENTS: ${{ inputs.delete_old_comments }}
       run: |
         # Execute via Bazel in the action's source directory
         cd "${{ github.action_path }}"
@@ -188,11 +189,11 @@ runs:
           --metadata-file "$METADATA_FILE"
         )
 
-        if [[ "${{ inputs.submit_review_action }}" == "true" ]]; then
+        if [[ "$ALLOW_REVIEW_ACTION" == "true" ]]; then
           ARGS+=(--allow-review-action)
         fi
 
-        if [[ "${{ inputs.delete_old_comments }}" == "true" ]]; then
+        if [[ "$DELETE_OLD_COMMENTS" == "true" ]]; then
           ARGS+=(--delete-old-comments)
         else
           ARGS+=(--delete-old-comments=false)

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: 'Whether to allow the AI to submit "approve/reject" actions or force it to only "comment". Options: "true" (allow approve/reject), "false" (force to "comment").'
     required: false
     default: 'false'
+  delete_old_comments:
+    description: 'Whether to delete previous bot-authored inline comments before posting a new review to keep the PR clean.'
+    required: false
+    default: 'true'
 runs:
   using: 'composite'
   steps:
@@ -184,8 +188,14 @@ runs:
           --metadata-file "$METADATA_FILE"
         )
 
-        if [[ "$ALLOW_REVIEW_ACTION" == "true" ]]; then
+        if [[ "${{ inputs.submit_review_action }}" == "true" ]]; then
           ARGS+=(--allow-review-action)
+        fi
+
+        if [[ "${{ inputs.delete_old_comments }}" == "true" ]]; then
+          ARGS+=(--delete-old-comments)
+        else
+          ARGS+=(--delete-old-comments=false)
         fi
 
         bazel run //cmd/github:github -- "${ARGS[@]}"

--- a/action.yml
+++ b/action.yml
@@ -174,7 +174,7 @@ runs:
       run: |
         # Execute via Bazel in the action's source directory
         cd "${{ github.action_path }}"
-        
+
         ARGS=(
           post-structured-review
           --repo-full-name "${{ github.repository }}"
@@ -183,11 +183,11 @@ runs:
           --tag "$METADATA_TAG"
           --metadata-file "$METADATA_FILE"
         )
-        
+
         if [[ "$ALLOW_REVIEW_ACTION" == "true" ]]; then
           ARGS+=(--allow-review-action)
         fi
-        
+
         bazel run //cmd/github:github -- "${ARGS[@]}"
     - name: Remove Status Reaction
       if: always() && github.event.pull_request.number != ''

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -158,7 +158,10 @@ func postComment(ctx context.Context, client *github.Client, owner, repo string,
 		return fmt.Errorf("failed to read body file: %w", err)
 	}
 
-	content := string(body)
+	return postCommentText(ctx, client, owner, repo, prNumber, string(body), tag)
+}
+
+func postCommentText(ctx context.Context, client *github.Client, owner, repo string, prNumber int, content, tag string) error {
 	if tag != "" && !strings.Contains(content, tag) {
 		content = fmt.Sprintf("%s\n\n%s", content, tag)
 	}
@@ -196,7 +199,7 @@ func postComment(ctx context.Context, client *github.Client, owner, repo string,
 		return err
 	}
 
-	_, _, err = client.Issues.CreateComment(ctx, owner, repo, prNumber, &github.IssueComment{
+	_, _, err := client.Issues.CreateComment(ctx, owner, repo, prNumber, &github.IssueComment{
 		Body: github.Ptr(content),
 	})
 	return err
@@ -304,15 +307,27 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 	if metadataFile != "" {
 		metadataBytes, err := os.ReadFile(metadataFile)
 		if err == nil {
-			_ = json.Unmarshal(metadataBytes, &metadata)
+			if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+				log.Printf("Warning: failed to unmarshal metadata: %v", err)
+			}
+		}
+	}
+
+	// 1. Post Non-Specific Review as a separate comment
+	if sr.NonSpecificReview != "" {
+		if err := postCommentText(ctx, client, owner, repo, prNumber, sr.NonSpecificReview, tag); err != nil {
+			log.Printf("Warning: failed to post non-specific review comment: %v", err)
 		}
 	}
 
 	comments := []*github.DraftReviewComment{}
+	reviewRationale := sr.Approval.Rationale
+
 	for _, fr := range sr.FilesReview {
 		startLine, endLine, err := fr.ParseLines()
 		if err != nil {
-			log.Printf("Warning: failed to parse lines for %s: %v. Skipping inline comment.", fr.Path, err)
+			log.Printf("Warning: failed to parse lines for %s: %v. Appending to main review rationale.", fr.Path, err)
+			reviewRationale = fmt.Sprintf("%s\n\n- **%s**: %s", reviewRationale, fr.Path, fr.Review)
 			continue
 		}
 
@@ -337,19 +352,23 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		comment := &github.DraftReviewComment{
 			Path: github.Ptr(fr.Path),
 			Body: github.Ptr(commentBody),
-			Line: github.Ptr(endLine),
 		}
-		if startLine != endLine {
-			comment.StartLine = github.Ptr(startLine)
-			comment.StartSide = github.Ptr("RIGHT")
+
+		if endLine > 0 {
+			comment.Line = github.Ptr(endLine)
+			if startLine != endLine {
+				comment.StartLine = github.Ptr(startLine)
+				comment.StartSide = github.Ptr("RIGHT")
+			}
+			comments = append(comments, comment)
+		} else {
+			// File-level comment - go-github v69 doesn't support SubjectType: file on DraftReviewComment.
+			// Fallback: append to the main review rationale.
+			reviewRationale = fmt.Sprintf("%s\n\n- **%s** (file-level): %s", reviewRationale, fr.Path, fr.Review)
 		}
-		comments = append(comments, comment)
 	}
 
-	reviewBody := sr.Approval.Rationale
-	if sr.NonSpecificReview != "" {
-		reviewBody = fmt.Sprintf("%s\n\n### General Feedback\n%s", reviewBody, sr.NonSpecificReview)
-	}
+	reviewBody := reviewRationale
 	if tag != "" {
 		reviewBody = fmt.Sprintf("%s\n\n%s", reviewBody, tag)
 	}
@@ -361,8 +380,8 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		}
 	}
 
-	action := sr.Approval.Action
-	if !allowReviewAction {
+	action := strings.ToUpper(strings.TrimSpace(sr.Approval.Action))
+	if !allowReviewAction || (action != "APPROVE" && action != "REQUEST_CHANGES" && action != "COMMENT") {
 		action = "COMMENT"
 	}
 
@@ -372,8 +391,33 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		Comments: comments,
 	}
 
-	_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
-	return err
+	_, resp, err := client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+	if err != nil {
+		// If we get a 422 error, it might be due to a line hallucination (line not in diff).
+		// Fallback: post the review without inline comments so we don't lose the summary feedback.
+		if resp != nil && resp.StatusCode == 422 && len(comments) > 0 {
+			log.Printf("Warning: failed to post structured review (likely due to line hallucinations): %v. Retrying without inline comments.", err)
+			reviewRequest.Comments = nil
+
+			// Append the skipped comments to the body so they aren't lost
+			var sb strings.Builder
+			sb.WriteString(reviewRequest.GetBody())
+			sb.WriteString("\n\n### Detailed Inline Feedback (Fallback)\n")
+			for _, c := range comments {
+				loc := ""
+				if c.Line != nil {
+					loc = fmt.Sprintf(" at line %d", *c.Line)
+				}
+				sb.WriteString(fmt.Sprintf("- **%s**%s: %s\n", c.GetPath(), loc, c.GetBody()))
+			}
+			reviewRequest.Body = github.Ptr(sb.String())
+
+			_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+			return err
+		}
+		return err
+	}
+	return nil
 }
 
 func dismissPreviousReviews(ctx context.Context, client *github.Client, owner, repo string, prNumber int, tag string) error {

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -449,18 +449,24 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 			isPermissionError := strings.Contains(errStr, "not permitted to approve")
 			hasComments := len(reviewRequest.Comments) > 0
 
-			if !isPermissionError && !hasComments {
-				// No changes to make to the request, so a retry will just fail again.
-				return err
-			}
-
 			if isPermissionError {
 				log.Printf("Warning: GITHUB_TOKEN is not permitted to approve PRs. Falling back to COMMENT review.")
 				reviewRequest.Event = github.Ptr("COMMENT")
+
+				// Try again with COMMENT action, keeping inline comments
+				_, resp, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+				if err == nil {
+					return nil
+				}
+				// If it still fails with 422, it's likely a line hallucination issue
+				if resp == nil || resp.StatusCode != 422 {
+					return err
+				}
+				errStr = err.Error()
 			}
 
 			if hasComments {
-				log.Printf("Warning: failed to post structured review (hallucinations or permissions): %v. Retrying without inline comments.", errStr)
+				log.Printf("Warning: failed to post structured review (likely due to line hallucinations): %v. Retrying without inline comments.", errStr)
 				reviewRequest.Comments = nil
 				var sb strings.Builder
 				sb.WriteString(reviewBody)
@@ -469,10 +475,10 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 					sb.WriteString(fmt.Sprintf("- **%s** (%s): %s\n", fr.Path, fr.Lines, fr.Review))
 				}
 				reviewRequest.Body = github.Ptr(sb.String())
-			}
 
-			_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
-			return err
+				_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+				return err
+			}
 		}
 		return err
 	}

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -23,6 +23,7 @@ func main() {
 	var bodyFile string
 	var tag string
 	var outputFile string
+	var metadataFile string
 
 	flag.StringVar(&repoFullName, "repo-full-name", "", "Full name of the repository (owner/repo)")
 	flag.IntVar(&prNumber, "pr", 0, "Pull request number")
@@ -31,6 +32,7 @@ func main() {
 	flag.StringVar(&bodyFile, "file", "", "Path to the comment body file")
 	flag.StringVar(&tag, "tag", "", "Tag to identify the comment for updates or self-identification")
 	flag.StringVar(&outputFile, "output", "", "Path to the output file (for get-metadata)")
+	flag.StringVar(&metadataFile, "metadata-file", "", "Path to the metadata file (for post-structured-review)")
 
 	flag.Parse()
 
@@ -91,6 +93,15 @@ func main() {
 		err := postComment(ctx, client, owner, repo, prNumber, bodyFile, tag)
 		if err != nil {
 			log.Fatalf("Failed to post comment: %v", err)
+		}
+
+	case "post-structured-review":
+		if bodyFile == "" {
+			log.Fatal("--file is required for post-structured-review")
+		}
+		err := postStructuredReview(ctx, client, owner, repo, prNumber, bodyFile, tag, metadataFile)
+		if err != nil {
+			log.Fatalf("Failed to post structured review: %v", err)
 		}
 
 	case "get-metadata":
@@ -274,4 +285,74 @@ func getCreatedAt(ts *github.Timestamp) time.Time {
 		return time.Time{}
 	}
 	return ts.Time
+}
+
+func postStructuredReview(ctx context.Context, client *github.Client, owner, repo string, prNumber int, bodyFile, tag, metadataFile string) error {
+	reviewBytes, err := os.ReadFile(bodyFile)
+	if err != nil {
+		return fmt.Errorf("failed to read structured review file: %w", err)
+	}
+
+	var sr core.StructuredReview
+	if err := json.Unmarshal(reviewBytes, &sr); err != nil {
+		return fmt.Errorf("failed to unmarshal structured review: %w", err)
+	}
+
+	var metadata core.PRMetadata
+	if metadataFile != "" {
+		metadataBytes, err := os.ReadFile(metadataFile)
+		if err == nil {
+			_ = json.Unmarshal(metadataBytes, &metadata)
+		}
+	}
+
+	comments := []*github.DraftReviewComment{}
+	for _, fr := range sr.FilesReview {
+		startLine, endLine, err := fr.ParseLines()
+		if err != nil {
+			log.Printf("Warning: failed to parse lines for %s: %v. Skipping inline comment.", fr.Path, err)
+			continue
+		}
+
+		// Check if we've already made this exact comment at this exact location
+		alreadyCommented := false
+		for _, c := range metadata.Comments {
+			if c.IsSelf && c.Path == fr.Path && c.Line == endLine && strings.Contains(c.Body, strings.TrimSpace(fr.Review)) {
+				alreadyCommented = true
+				break
+			}
+		}
+
+		if alreadyCommented {
+			continue
+		}
+
+		comment := &github.DraftReviewComment{
+			Path: github.Ptr(fr.Path),
+			Body: github.Ptr(fr.Review),
+			Line: github.Ptr(endLine),
+		}
+		if startLine != endLine {
+			comment.StartLine = github.Ptr(startLine)
+			comment.StartSide = github.Ptr("RIGHT")
+		}
+		comments = append(comments, comment)
+	}
+
+	reviewBody := sr.Approval.Rationale
+	if sr.NonSpecificReview != "" {
+		reviewBody = fmt.Sprintf("%s\n\n### General Feedback\n%s", reviewBody, sr.NonSpecificReview)
+	}
+	if tag != "" {
+		reviewBody = fmt.Sprintf("%s\n\n%s", reviewBody, tag)
+	}
+
+	reviewRequest := &github.PullRequestReviewRequest{
+		Body:     github.Ptr(reviewBody),
+		Event:    github.Ptr(sr.Approval.Action),
+		Comments: comments,
+	}
+
+	_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+	return err
 }

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -24,6 +24,7 @@ func main() {
 	var tag string
 	var outputFile string
 	var metadataFile string
+	var allowReviewAction bool
 
 	flag.StringVar(&repoFullName, "repo-full-name", "", "Full name of the repository (owner/repo)")
 	flag.IntVar(&prNumber, "pr", 0, "Pull request number")
@@ -33,6 +34,7 @@ func main() {
 	flag.StringVar(&tag, "tag", "", "Tag to identify the comment for updates or self-identification")
 	flag.StringVar(&outputFile, "output", "", "Path to the output file (for get-metadata)")
 	flag.StringVar(&metadataFile, "metadata-file", "", "Path to the metadata file (for post-structured-review)")
+	flag.BoolVar(&allowReviewAction, "allow-review-action", false, "Whether to allow the AI's suggested review action (APPROVE/REQUEST_CHANGES). If false, forces COMMENT.")
 
 	flag.Parse()
 
@@ -99,7 +101,7 @@ func main() {
 		if bodyFile == "" {
 			log.Fatal("--file is required for post-structured-review")
 		}
-		err := postStructuredReview(ctx, client, owner, repo, prNumber, bodyFile, tag, metadataFile)
+		err := postStructuredReview(ctx, client, owner, repo, prNumber, bodyFile, tag, metadataFile, allowReviewAction)
 		if err != nil {
 			log.Fatalf("Failed to post structured review: %v", err)
 		}
@@ -287,7 +289,7 @@ func getCreatedAt(ts *github.Timestamp) time.Time {
 	return ts.Time
 }
 
-func postStructuredReview(ctx context.Context, client *github.Client, owner, repo string, prNumber int, bodyFile, tag, metadataFile string) error {
+func postStructuredReview(ctx context.Context, client *github.Client, owner, repo string, prNumber int, bodyFile, tag, metadataFile string, allowReviewAction bool) error {
 	reviewBytes, err := os.ReadFile(bodyFile)
 	if err != nil {
 		return fmt.Errorf("failed to read structured review file: %w", err)
@@ -352,9 +354,14 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		reviewBody = fmt.Sprintf("%s\n\n%s", reviewBody, tag)
 	}
 
+	action := sr.Approval.Action
+	if !allowReviewAction {
+		action = "COMMENT"
+	}
+
 	reviewRequest := &github.PullRequestReviewRequest{
 		Body:     github.Ptr(reviewBody),
-		Event:    github.Ptr(sr.Approval.Action),
+		Event:    github.Ptr(action),
 		Comments: comments,
 	}
 

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -327,9 +327,14 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 			continue
 		}
 
+		commentBody := fr.Review
+		if tag != "" {
+			commentBody = fmt.Sprintf("%s\n\n%s", commentBody, tag)
+		}
+
 		comment := &github.DraftReviewComment{
 			Path: github.Ptr(fr.Path),
-			Body: github.Ptr(fr.Review),
+			Body: github.Ptr(commentBody),
 			Line: github.Ptr(endLine),
 		}
 		if startLine != endLine {

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -25,6 +25,7 @@ func main() {
 	var outputFile string
 	var metadataFile string
 	var allowReviewAction bool
+	var deleteOldComments bool
 
 	flag.StringVar(&repoFullName, "repo-full-name", "", "Full name of the repository (owner/repo)")
 	flag.IntVar(&prNumber, "pr", 0, "Pull request number")
@@ -35,6 +36,7 @@ func main() {
 	flag.StringVar(&outputFile, "output", "", "Path to the output file (for get-metadata)")
 	flag.StringVar(&metadataFile, "metadata-file", "", "Path to the metadata file (for post-structured-review)")
 	flag.BoolVar(&allowReviewAction, "allow-review-action", false, "Whether to allow the AI's suggested review action (APPROVE/REQUEST_CHANGES). If false, forces COMMENT.")
+	flag.BoolVar(&deleteOldComments, "delete-old-comments", true, "Whether to delete previous bot-authored inline comments before posting a new review.")
 
 	flag.Parse()
 
@@ -101,7 +103,7 @@ func main() {
 		if bodyFile == "" {
 			log.Fatal("--file is required for post-structured-review")
 		}
-		err := postStructuredReview(ctx, client, owner, repo, prNumber, bodyFile, tag, metadataFile, allowReviewAction)
+		err := postStructuredReview(ctx, client, owner, repo, prNumber, bodyFile, tag, metadataFile, allowReviewAction, deleteOldComments)
 		if err != nil {
 			log.Fatalf("Failed to post structured review: %v", err)
 		}
@@ -322,7 +324,7 @@ func getCreatedAt(ts *github.Timestamp) time.Time {
 	return ts.Time
 }
 
-func postStructuredReview(ctx context.Context, client *github.Client, owner, repo string, prNumber int, bodyFile, tag, metadataFile string, allowReviewAction bool) error {
+func postStructuredReview(ctx context.Context, client *github.Client, owner, repo string, prNumber int, bodyFile, tag, metadataFile string, allowReviewAction, deleteOldComments bool) error {
 	reviewBytes, err := os.ReadFile(bodyFile)
 	if err != nil {
 		return fmt.Errorf("failed to read structured review file: %w", err)
@@ -345,7 +347,26 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		}
 	}
 
-	// 1. Post Non-Specific Review as a separate comment
+	// 1. Dismiss previous reviews BEFORE providing new review
+	if tag != "" {
+		if err := dismissPreviousReviews(ctx, client, owner, repo, prNumber, tag, 0); err != nil {
+			log.Printf("Warning: failed to dismiss previous reviews: %v", err)
+		}
+	}
+
+	// 2. Delete old inline comments if requested
+	if tag != "" && deleteOldComments {
+		inlineTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-inline-", 1)
+		for _, c := range metadata.Comments {
+			if c.IsSelf && strings.Contains(c.Body, inlineTag) {
+				if _, err := client.PullRequests.DeleteComment(ctx, owner, repo, c.ID); err != nil {
+					log.Printf("Warning: failed to delete old inline comment %d: %v", c.ID, err)
+				}
+			}
+		}
+	}
+
+	// 3. Post Non-Specific Review as a separate comment
 	if sr.NonSpecificReview != "" {
 		mainTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-main-", 1)
 		if err := postCommentText(ctx, client, owner, repo, prNumber, sr.NonSpecificReview, mainTag); err != nil {
@@ -370,29 +391,7 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 			commentBody = fmt.Sprintf("%s\n\n%s", commentBody, inlineTag)
 		}
 
-		// Check if we've already made a comment at this exact location
-		var existingComment *core.PRComment
-		for _, c := range metadata.Comments {
-			if c.IsSelf && c.Path == fr.Path && c.Line == endLine && !c.IsOutdated && strings.Contains(c.Body, inlineTag) {
-				existingComment = &c
-				break
-			}
-		}
-
-		if existingComment != nil {
-			// Update existing comment if content changed
-			if strings.TrimSpace(existingComment.Body) != strings.TrimSpace(commentBody) {
-				_, _, err := client.PullRequests.EditComment(ctx, owner, repo, existingComment.ID, &github.PullRequestComment{
-					Body: github.Ptr(commentBody),
-				})
-				if err != nil {
-					log.Printf("Warning: failed to update inline comment %d: %v", existingComment.ID, err)
-				}
-			}
-			continue
-		}
-
-		// New location: create new comment in the review
+		// New location (or after deletion): create new comment in the review
 		comment := &github.DraftReviewComment{
 			Path: github.Ptr(fr.Path),
 			Body: github.Ptr(commentBody),
@@ -427,59 +426,34 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		Comments: comments,
 	}
 
-	newReview, resp, err := client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+	_, resp, err := client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
 	if err != nil {
 		// 422 Fallback logic
 		if resp != nil && resp.StatusCode == 422 {
 			errStr := err.Error()
-			needsRetry := false
+			isPermissionError := strings.Contains(errStr, "not permitted to approve")
 
-			if strings.Contains(errStr, "not permitted to approve") {
+			if isPermissionError {
 				log.Printf("Warning: GITHUB_TOKEN is not permitted to approve PRs. Falling back to COMMENT review.")
 				reviewRequest.Event = github.Ptr("COMMENT")
-				needsRetry = true
 			}
 
 			if len(reviewRequest.Comments) > 0 {
-				var errRetry error
-				if needsRetry {
-					_, _, errRetry = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+				log.Printf("Warning: failed to post structured review (hallucinations or permissions): %v. Retrying without inline comments.", errStr)
+				reviewRequest.Comments = nil
+				var sb strings.Builder
+				sb.WriteString(reviewBody)
+				sb.WriteString("\n\n### Detailed Inline Feedback (Fallback)\n")
+				for _, fr := range sr.FilesReview {
+					sb.WriteString(fmt.Sprintf("- **%s** (%s): %s\n", fr.Path, fr.Lines, fr.Review))
 				}
-
-				if errRetry != nil || !needsRetry {
-					log.Printf("Warning: failed to post structured review (likely due to line hallucinations): %v. Retrying without inline comments.", errStr)
-					reviewRequest.Comments = nil
-					var sb strings.Builder
-					sb.WriteString(reviewRequest.GetBody())
-					sb.WriteString("\n\n### Detailed Inline Feedback (Fallback)\n")
-					for _, c := range comments {
-						loc := ""
-						if c.Line != nil {
-							loc = fmt.Sprintf(" at line %d", *c.Line)
-						}
-						sb.WriteString(fmt.Sprintf("- **%s**%s: %s\n", c.GetPath(), loc, c.GetBody()))
-					}
-					reviewRequest.Body = github.Ptr(sb.String())
-					newReview, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
-				}
-			} else if needsRetry {
-				newReview, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+				reviewRequest.Body = github.Ptr(sb.String())
 			}
-		}
-		if err != nil {
+
+			_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
 			return err
 		}
-	}
-
-	// Dismiss previous reviews with the same tag
-	if tag != "" {
-		newReviewID := int64(0)
-		if newReview != nil {
-			newReviewID = newReview.GetID()
-		}
-		if err := dismissPreviousReviews(ctx, client, owner, repo, prNumber, tag, newReviewID); err != nil {
-			log.Printf("Warning: failed to dismiss previous reviews: %v", err)
-		}
+		return err
 	}
 
 	return nil

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -420,27 +420,57 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 
 	_, resp, err := client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
 	if err != nil {
-		// If we get a 422 error, it might be due to a line hallucination (line not in diff).
-		// Fallback: post the review without inline comments so we don't lose the summary feedback.
-		if resp != nil && resp.StatusCode == 422 && len(comments) > 0 {
-			log.Printf("Warning: failed to post structured review (likely due to line hallucinations): %v. Retrying without inline comments.", err)
-			reviewRequest.Comments = nil
+		// If we get a 422 error, it might be due to:
+		// 1. GITHUB_TOKEN not having permission to APPROVE (common in default settings).
+		// 2. Line hallucinations (line not in diff).
+		if resp != nil && resp.StatusCode == 422 {
+			errStr := err.Error()
+			needsRetry := false
 
-			// Append the skipped comments to the body so they aren't lost
-			var sb strings.Builder
-			sb.WriteString(reviewRequest.GetBody())
-			sb.WriteString("\n\n### Detailed Inline Feedback (Fallback)\n")
-			for _, c := range comments {
-				loc := ""
-				if c.Line != nil {
-					loc = fmt.Sprintf(" at line %d", *c.Line)
-				}
-				sb.WriteString(fmt.Sprintf("- **%s**%s: %s\n", c.GetPath(), loc, c.GetBody()))
+			// Handle permission issue
+			if strings.Contains(errStr, "not permitted to approve") {
+				log.Printf("Warning: GITHUB_TOKEN is not permitted to approve PRs. Falling back to COMMENT review.")
+				reviewRequest.Event = github.Ptr("COMMENT")
+				needsRetry = true
 			}
-			reviewRequest.Body = github.Ptr(sb.String())
 
-			_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
-			return err
+			// If it still fails (or we suspect line issues), try without inline comments
+			if len(reviewRequest.Comments) > 0 {
+				// We'll try the first retry with comments if only the Event changed.
+				// But we need a second-level fallback if lines are the problem.
+				_, _, errRetry := client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+				if errRetry != nil && needsRetry {
+					// First retry failed, maybe due to lines.
+					errStr = errRetry.Error()
+				}
+
+				if errRetry != nil || !needsRetry {
+					log.Printf("Warning: failed to post structured review (likely due to line hallucinations): %v. Retrying without inline comments.", errStr)
+					reviewRequest.Comments = nil
+
+					// Append the skipped comments to the body so they aren't lost
+					var sb strings.Builder
+					sb.WriteString(reviewRequest.GetBody())
+					sb.WriteString("\n\n### Detailed Inline Feedback (Fallback)\n")
+					for _, c := range comments {
+						loc := ""
+						if c.Line != nil {
+							loc = fmt.Sprintf(" at line %d", *c.Line)
+						}
+						sb.WriteString(fmt.Sprintf("- **%s**%s: %s\n", c.GetPath(), loc, c.GetBody()))
+					}
+					reviewRequest.Body = github.Ptr(sb.String())
+
+					_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+					return err
+				}
+				return nil
+			}
+
+			if needsRetry {
+				_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+				return err
+			}
 		}
 		return err
 	}

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -354,6 +354,13 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		reviewBody = fmt.Sprintf("%s\n\n%s", reviewBody, tag)
 	}
 
+	// Dismiss previous reviews with the same tag to keep the PR timeline clean.
+	if tag != "" {
+		if err := dismissPreviousReviews(ctx, client, owner, repo, prNumber, tag); err != nil {
+			log.Printf("Warning: failed to dismiss previous reviews: %v", err)
+		}
+	}
+
 	action := sr.Approval.Action
 	if !allowReviewAction {
 		action = "COMMENT"
@@ -367,4 +374,31 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 
 	_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
 	return err
+}
+
+func dismissPreviousReviews(ctx context.Context, client *github.Client, owner, repo string, prNumber int, tag string) error {
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		reviews, resp, err := client.PullRequests.ListReviews(ctx, owner, repo, prNumber, opts)
+		if err != nil {
+			return err
+		}
+
+		for _, r := range reviews {
+			if strings.Contains(r.GetBody(), tag) && r.GetState() != "DISMISSED" {
+				_, _, err := client.PullRequests.DismissReview(ctx, owner, repo, prNumber, r.GetID(), &github.PullRequestReviewDismissalRequest{
+					Message: github.Ptr("Superseded by a new AI review."),
+				})
+				if err != nil {
+					log.Printf("Warning: failed to dismiss review %d: %v", r.GetID(), err)
+				}
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return nil
 }

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -432,13 +432,19 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		if resp != nil && resp.StatusCode == 422 {
 			errStr := err.Error()
 			isPermissionError := strings.Contains(errStr, "not permitted to approve")
+			hasComments := len(reviewRequest.Comments) > 0
+
+			if !isPermissionError && !hasComments {
+				// No changes to make to the request, so a retry will just fail again.
+				return err
+			}
 
 			if isPermissionError {
 				log.Printf("Warning: GITHUB_TOKEN is not permitted to approve PRs. Falling back to COMMENT review.")
 				reviewRequest.Event = github.Ptr("COMMENT")
 			}
 
-			if len(reviewRequest.Comments) > 0 {
+			if hasComments {
 				log.Printf("Warning: failed to post structured review (hallucinations or permissions): %v. Retrying without inline comments.", errStr)
 				reviewRequest.Comments = nil
 				var sb strings.Builder

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -167,10 +167,12 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 	}
 
 	self, _, err := client.Users.Get(ctx, "")
+	selfLogin := ""
 	if err != nil {
-		return fmt.Errorf("failed to get self user: %w", err)
+		log.Printf("Warning: failed to get self user (likely due to GITHUB_TOKEN permissions): %v. Deduplication will rely solely on the tag.", err)
+	} else {
+		selfLogin = self.GetLogin()
 	}
-	selfLogin := self.GetLogin()
 
 	// Find existing comment
 	opts := &github.IssueListCommentsOptions{
@@ -186,10 +188,14 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 			return fmt.Errorf("failed to list comments: %w", err)
 		}
 		for _, c := range comments {
-			if tag != "" && strings.Contains(c.GetBody(), tag) && c.GetUser().GetLogin() == selfLogin {
-				// We found a matching comment from ourselves. Since the API returns results in
-				// ascending chronological order, the last one we find is the latest.
-				latestCommentID = c.GetID()
+			if tag != "" && strings.Contains(c.GetBody(), tag) {
+				// If we have a selfLogin, we use it to be sure.
+				// If not, we trust the unique tag.
+				if selfLogin == "" || c.GetUser().GetLogin() == selfLogin {
+					// We found a matching comment. Since the API returns results in
+					// ascending chronological order, the last one we find is the latest.
+					latestCommentID = c.GetID()
+				}
 			}
 		}
 		if resp.NextPage == 0 {
@@ -318,7 +324,9 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 	var metadata core.PRMetadata
 	if metadataFile != "" {
 		metadataBytes, err := os.ReadFile(metadataFile)
-		if err == nil {
+		if err != nil {
+			log.Printf("Warning: failed to read metadata file: %v. Deduplication will be limited.", err)
+		} else {
 			if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
 				log.Printf("Warning: failed to unmarshal metadata: %v", err)
 			}

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -166,6 +166,12 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 		content = fmt.Sprintf("%s\n\n%s", content, tag)
 	}
 
+	self, _, err := client.Users.Get(ctx, "")
+	if err != nil {
+		return fmt.Errorf("failed to get self user: %w", err)
+	}
+	selfLogin := self.GetLogin()
+
 	// Find existing comment
 	opts := &github.IssueListCommentsOptions{
 		ListOptions: github.ListOptions{
@@ -180,8 +186,8 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 			return fmt.Errorf("failed to list comments: %w", err)
 		}
 		for _, c := range comments {
-			if tag != "" && strings.Contains(c.GetBody(), tag) {
-				// We found a matching comment. Since the API returns results in
+			if tag != "" && strings.Contains(c.GetBody(), tag) && c.GetUser().GetLogin() == selfLogin {
+				// We found a matching comment from ourselves. Since the API returns results in
 				// ascending chronological order, the last one we find is the latest.
 				latestCommentID = c.GetID()
 			}
@@ -199,7 +205,7 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 		return err
 	}
 
-	_, _, err := client.Issues.CreateComment(ctx, owner, repo, prNumber, &github.IssueComment{
+	_, _, err = client.Issues.CreateComment(ctx, owner, repo, prNumber, &github.IssueComment{
 		Body: github.Ptr(content),
 	})
 	return err
@@ -209,6 +215,11 @@ func getMetadata(ctx context.Context, client *github.Client, owner, repo string,
 	pr, _, err := client.PullRequests.Get(ctx, owner, repo, prNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get PR: %w", err)
+	}
+
+	commentTag := tag
+	if tag != "" {
+		commentTag = strings.Replace(tag, "<!-- ", "<!-- comment-", 1)
 	}
 
 	metadata := &core.PRMetadata{
@@ -259,7 +270,8 @@ func getMetadata(ctx context.Context, client *github.Client, owner, repo string,
 
 		for _, c := range comments {
 			body := c.GetBody()
-			isSelf := tag != "" && strings.Contains(body, tag)
+			// Inline comments use the special commentTag
+			isSelf := commentTag != "" && strings.Contains(body, commentTag)
 			metadata.Comments = append(metadata.Comments, core.PRComment{
 				Author:    c.GetUser().GetLogin(),
 				Body:      body,
@@ -323,6 +335,13 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 	comments := []*github.DraftReviewComment{}
 	reviewRationale := sr.Approval.Rationale
 
+	commentTag := tag
+	if tag != "" {
+		// Distinguish between the main (non-specific) comment and the inline review comments
+		// by using a different prefix for the latter.
+		commentTag = strings.Replace(tag, "<!-- ", "<!-- comment-", 1)
+	}
+
 	for _, fr := range sr.FilesReview {
 		startLine, endLine, err := fr.ParseLines()
 		if err != nil {
@@ -345,8 +364,8 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		}
 
 		commentBody := fr.Review
-		if tag != "" {
-			commentBody = fmt.Sprintf("%s\n\n%s", commentBody, tag)
+		if commentTag != "" {
+			commentBody = fmt.Sprintf("%s\n\n%s", commentBody, commentTag)
 		}
 
 		comment := &github.DraftReviewComment{

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -469,10 +469,13 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 				log.Printf("Warning: failed to post structured review (likely due to line hallucinations): %v. Retrying without inline comments.", errStr)
 				reviewRequest.Comments = nil
 				var sb strings.Builder
-				sb.WriteString(reviewBody)
+				sb.WriteString(reviewRequest.GetBody())
 				sb.WriteString("\n\n### Detailed Inline Feedback (Fallback)\n")
 				for _, fr := range sr.FilesReview {
-					sb.WriteString(fmt.Sprintf("- **%s** (%s): %s\n", fr.Path, fr.Lines, fr.Review))
+					_, endLine, err := fr.ParseLines()
+					if err == nil && endLine > 0 {
+						sb.WriteString(fmt.Sprintf("- **%s** (%s): %s\n", fr.Path, fr.Lines, fr.Review))
+					}
 				}
 				reviewRequest.Body = github.Ptr(sb.String())
 

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -52,12 +52,11 @@ func main() {
 		log.Fatal("Action required (add-reaction, remove-reaction, post-comment, get-metadata)")
 	}
 
-	// Process tag: only the inner text is provided, we wrap it in HTML comment tags.
+	// Process tag: only the inner text is provided.
 	// Default to 'cassandra-ai-review' if empty.
 	if tag == "" {
 		tag = "cassandra-ai-review"
 	}
-	tag = fmt.Sprintf("<!-- %s -->", tag)
 
 	action := flag.Arg(0)
 	ctx := context.Background()
@@ -141,6 +140,20 @@ func parseRepo(fullName string) (owner, repo string, err error) {
 	return parts[0], parts[1], nil
 }
 
+// wrapTag wraps a raw slug into a hidden HTML comment tag with an optional prefix.
+// It sanitizes the slug to ensure it cannot break out of the HTML comment.
+func wrapTag(slug, prefix string) string {
+	// Sanitize slug:
+	// 1. Replace '--' with '__' because HTML comments cannot contain '--'.
+	// 2. Remove '<' and '>' to prevent breakout.
+	s := strings.ReplaceAll(slug, "--", "__")
+	s = strings.ReplaceAll(s, "<", "")
+	s = strings.ReplaceAll(s, ">", "")
+	s = strings.TrimSpace(s)
+
+	return fmt.Sprintf("<!-- %s%s -->", prefix, s)
+}
+
 func addReaction(ctx context.Context, client *github.Client, owner, repo string, prNumber int, content string) (int64, error) {
 	reaction, _, err := client.Reactions.CreateIssueReaction(ctx, owner, repo, prNumber, content)
 	if err != nil {
@@ -160,7 +173,7 @@ func postComment(ctx context.Context, client *github.Client, owner, repo string,
 		return fmt.Errorf("failed to read body file: %w", err)
 	}
 
-	mainTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-main-", 1)
+	mainTag := wrapTag(tag, "cassandra-main-")
 	return postCommentText(ctx, client, owner, repo, prNumber, string(body), mainTag)
 }
 
@@ -237,8 +250,9 @@ func getMetadata(ctx context.Context, client *github.Client, owner, repo string,
 		return nil, fmt.Errorf("failed to get PR: %w", err)
 	}
 
-	mainTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-main-", 1)
-	inlineTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-inline-", 1)
+	mainTag := wrapTag(tag, "cassandra-main-")
+	inlineTag := wrapTag(tag, "cassandra-inline-")
+	reviewTag := wrapTag(tag, "")
 
 	metadata := &core.PRMetadata{
 		PRNumber:      prNumber,
@@ -261,7 +275,7 @@ func getMetadata(ctx context.Context, client *github.Client, owner, repo string,
 
 		for _, c := range comments {
 			body := c.GetBody()
-			isSelf := tag != "" && (strings.Contains(body, tag) || strings.Contains(body, mainTag))
+			isSelf := tag != "" && (strings.Contains(body, mainTag) || strings.Contains(body, reviewTag))
 			metadata.Comments = append(metadata.Comments, core.PRComment{
 				ID:     c.GetID(),
 				Author: c.GetUser().GetLogin(),
@@ -289,7 +303,7 @@ func getMetadata(ctx context.Context, client *github.Client, owner, repo string,
 
 		for _, c := range comments {
 			body := c.GetBody()
-			isSelf := tag != "" && (strings.Contains(body, tag) || strings.Contains(body, inlineTag))
+			isSelf := tag != "" && strings.Contains(body, inlineTag)
 			metadata.Comments = append(metadata.Comments, core.PRComment{
 				ID:         c.GetID(),
 				Author:     c.GetUser().GetLogin(),
@@ -347,16 +361,19 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		}
 	}
 
+	reviewTag := wrapTag(tag, "")
+	inlineTag := wrapTag(tag, "cassandra-inline-")
+	mainTag := wrapTag(tag, "cassandra-main-")
+
 	// 1. Dismiss previous reviews BEFORE providing new review
 	if tag != "" {
-		if err := dismissPreviousReviews(ctx, client, owner, repo, prNumber, tag, 0); err != nil {
+		if err := dismissPreviousReviews(ctx, client, owner, repo, prNumber, reviewTag, 0); err != nil {
 			log.Printf("Warning: failed to dismiss previous reviews: %v", err)
 		}
 	}
 
 	// 2. Delete old inline comments if requested
 	if tag != "" && deleteOldComments {
-		inlineTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-inline-", 1)
 		for _, c := range metadata.Comments {
 			if c.IsSelf && strings.Contains(c.Body, inlineTag) {
 				if _, err := client.PullRequests.DeleteComment(ctx, owner, repo, c.ID); err != nil {
@@ -368,7 +385,6 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 
 	// 3. Post Non-Specific Review as a separate comment
 	if sr.NonSpecificReview != "" {
-		mainTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-main-", 1)
 		if err := postCommentText(ctx, client, owner, repo, prNumber, sr.NonSpecificReview, mainTag); err != nil {
 			log.Printf("Warning: failed to post non-specific review comment: %v", err)
 		}
@@ -376,7 +392,6 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 
 	comments := []*github.DraftReviewComment{}
 	reviewRationale := sr.Approval.Rationale
-	inlineTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-inline-", 1)
 
 	for _, fr := range sr.FilesReview {
 		startLine, endLine, err := fr.ParseLines()
@@ -387,7 +402,7 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		}
 
 		commentBody := fr.Review
-		if inlineTag != "" {
+		if tag != "" {
 			commentBody = fmt.Sprintf("%s\n\n%s", commentBody, inlineTag)
 		}
 
@@ -412,7 +427,7 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 
 	reviewBody := reviewRationale
 	if tag != "" {
-		reviewBody = fmt.Sprintf("%s\n\n%s", reviewBody, tag)
+		reviewBody = fmt.Sprintf("%s\n\n%s", reviewBody, reviewTag)
 	}
 
 	action := strings.ToUpper(strings.TrimSpace(sr.Approval.Action))

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -158,7 +158,8 @@ func postComment(ctx context.Context, client *github.Client, owner, repo string,
 		return fmt.Errorf("failed to read body file: %w", err)
 	}
 
-	return postCommentText(ctx, client, owner, repo, prNumber, string(body), tag)
+	mainTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-main-", 1)
+	return postCommentText(ctx, client, owner, repo, prNumber, string(body), mainTag)
 }
 
 func postCommentText(ctx context.Context, client *github.Client, owner, repo string, prNumber int, content, tag string) error {
@@ -182,6 +183,7 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 	}
 
 	var latestCommentID int64
+	var redundantCommentIDs []int64
 	for {
 		comments, resp, err := client.Issues.ListComments(ctx, owner, repo, prNumber, opts)
 		if err != nil {
@@ -192,6 +194,9 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 				// If we have a selfLogin, we use it to be sure.
 				// If not, we trust the unique tag.
 				if selfLogin == "" || c.GetUser().GetLogin() == selfLogin {
+					if latestCommentID != 0 {
+						redundantCommentIDs = append(redundantCommentIDs, latestCommentID)
+					}
 					// We found a matching comment. Since the API returns results in
 					// ascending chronological order, the last one we find is the latest.
 					latestCommentID = c.GetID()
@@ -202,6 +207,13 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 			break
 		}
 		opts.Page = resp.NextPage
+	}
+
+	// Delete redundant comments first
+	for _, id := range redundantCommentIDs {
+		if _, err := client.Issues.DeleteComment(ctx, owner, repo, id); err != nil {
+			log.Printf("Warning: failed to delete redundant comment %d: %v", id, err)
+		}
 	}
 
 	if latestCommentID != 0 {
@@ -223,10 +235,8 @@ func getMetadata(ctx context.Context, client *github.Client, owner, repo string,
 		return nil, fmt.Errorf("failed to get PR: %w", err)
 	}
 
-	commentTag := tag
-	if tag != "" {
-		commentTag = strings.Replace(tag, "<!-- ", "<!-- comment-", 1)
-	}
+	mainTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-main-", 1)
+	inlineTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-inline-", 1)
 
 	metadata := &core.PRMetadata{
 		PRNumber:      prNumber,
@@ -249,8 +259,9 @@ func getMetadata(ctx context.Context, client *github.Client, owner, repo string,
 
 		for _, c := range comments {
 			body := c.GetBody()
-			isSelf := tag != "" && strings.Contains(body, tag)
+			isSelf := tag != "" && (strings.Contains(body, tag) || strings.Contains(body, mainTag))
 			metadata.Comments = append(metadata.Comments, core.PRComment{
+				ID:     c.GetID(),
 				Author: c.GetUser().GetLogin(),
 				Body:   body,
 				IsSelf: isSelf,
@@ -276,16 +287,17 @@ func getMetadata(ctx context.Context, client *github.Client, owner, repo string,
 
 		for _, c := range comments {
 			body := c.GetBody()
-			// Inline comments use the special commentTag
-			isSelf := commentTag != "" && strings.Contains(body, commentTag)
+			isSelf := tag != "" && (strings.Contains(body, tag) || strings.Contains(body, inlineTag))
 			metadata.Comments = append(metadata.Comments, core.PRComment{
-				Author:    c.GetUser().GetLogin(),
-				Body:      body,
-				IsSelf:    isSelf,
-				Date:      getCreatedAt(c.CreatedAt),
-				Path:      c.GetPath(),
-				Line:      c.GetLine(),
-				StartLine: c.GetStartLine(),
+				ID:         c.GetID(),
+				Author:     c.GetUser().GetLogin(),
+				Body:       body,
+				IsSelf:     isSelf,
+				Date:       getCreatedAt(c.CreatedAt),
+				Path:       c.GetPath(),
+				Line:       c.GetLine(),
+				StartLine:  c.GetStartLine(),
+				IsOutdated: c.Position == nil && c.OriginalPosition != nil,
 			})
 		}
 
@@ -335,20 +347,15 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 
 	// 1. Post Non-Specific Review as a separate comment
 	if sr.NonSpecificReview != "" {
-		if err := postCommentText(ctx, client, owner, repo, prNumber, sr.NonSpecificReview, tag); err != nil {
+		mainTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-main-", 1)
+		if err := postCommentText(ctx, client, owner, repo, prNumber, sr.NonSpecificReview, mainTag); err != nil {
 			log.Printf("Warning: failed to post non-specific review comment: %v", err)
 		}
 	}
 
 	comments := []*github.DraftReviewComment{}
 	reviewRationale := sr.Approval.Rationale
-
-	commentTag := tag
-	if tag != "" {
-		// Distinguish between the main (non-specific) comment and the inline review comments
-		// by using a different prefix for the latter.
-		commentTag = strings.Replace(tag, "<!-- ", "<!-- comment-", 1)
-	}
+	inlineTag := strings.Replace(tag, "<!-- ", "<!-- cassandra-inline-", 1)
 
 	for _, fr := range sr.FilesReview {
 		startLine, endLine, err := fr.ParseLines()
@@ -358,24 +365,34 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 			continue
 		}
 
-		// Check if we've already made this exact comment at this exact location
-		alreadyCommented := false
+		commentBody := fr.Review
+		if inlineTag != "" {
+			commentBody = fmt.Sprintf("%s\n\n%s", commentBody, inlineTag)
+		}
+
+		// Check if we've already made a comment at this exact location
+		var existingComment *core.PRComment
 		for _, c := range metadata.Comments {
-			if c.IsSelf && c.Path == fr.Path && c.Line == endLine && strings.Contains(c.Body, strings.TrimSpace(fr.Review)) {
-				alreadyCommented = true
+			if c.IsSelf && c.Path == fr.Path && c.Line == endLine && !c.IsOutdated && strings.Contains(c.Body, inlineTag) {
+				existingComment = &c
 				break
 			}
 		}
 
-		if alreadyCommented {
+		if existingComment != nil {
+			// Update existing comment if content changed
+			if strings.TrimSpace(existingComment.Body) != strings.TrimSpace(commentBody) {
+				_, _, err := client.PullRequests.EditComment(ctx, owner, repo, existingComment.ID, &github.PullRequestComment{
+					Body: github.Ptr(commentBody),
+				})
+				if err != nil {
+					log.Printf("Warning: failed to update inline comment %d: %v", existingComment.ID, err)
+				}
+			}
 			continue
 		}
 
-		commentBody := fr.Review
-		if commentTag != "" {
-			commentBody = fmt.Sprintf("%s\n\n%s", commentBody, commentTag)
-		}
-
+		// New location: create new comment in the review
 		comment := &github.DraftReviewComment{
 			Path: github.Ptr(fr.Path),
 			Body: github.Ptr(commentBody),
@@ -389,8 +406,7 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 			}
 			comments = append(comments, comment)
 		} else {
-			// File-level comment - go-github v69 doesn't support SubjectType: file on DraftReviewComment.
-			// Fallback: append to the main review rationale.
+			// Fallback for file-level
 			reviewRationale = fmt.Sprintf("%s\n\n- **%s** (file-level): %s", reviewRationale, fr.Path, fr.Review)
 		}
 	}
@@ -398,13 +414,6 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 	reviewBody := reviewRationale
 	if tag != "" {
 		reviewBody = fmt.Sprintf("%s\n\n%s", reviewBody, tag)
-	}
-
-	// Dismiss previous reviews with the same tag to keep the PR timeline clean.
-	if tag != "" {
-		if err := dismissPreviousReviews(ctx, client, owner, repo, prNumber, tag); err != nil {
-			log.Printf("Warning: failed to dismiss previous reviews: %v", err)
-		}
 	}
 
 	action := strings.ToUpper(strings.TrimSpace(sr.Approval.Action))
@@ -418,37 +427,28 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		Comments: comments,
 	}
 
-	_, resp, err := client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
+	newReview, resp, err := client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
 	if err != nil {
-		// If we get a 422 error, it might be due to:
-		// 1. GITHUB_TOKEN not having permission to APPROVE (common in default settings).
-		// 2. Line hallucinations (line not in diff).
+		// 422 Fallback logic
 		if resp != nil && resp.StatusCode == 422 {
 			errStr := err.Error()
 			needsRetry := false
 
-			// Handle permission issue
 			if strings.Contains(errStr, "not permitted to approve") {
 				log.Printf("Warning: GITHUB_TOKEN is not permitted to approve PRs. Falling back to COMMENT review.")
 				reviewRequest.Event = github.Ptr("COMMENT")
 				needsRetry = true
 			}
 
-			// If it still fails (or we suspect line issues), try without inline comments
 			if len(reviewRequest.Comments) > 0 {
-				// We'll try the first retry with comments if only the Event changed.
-				// But we need a second-level fallback if lines are the problem.
-				_, _, errRetry := client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
-				if errRetry != nil && needsRetry {
-					// First retry failed, maybe due to lines.
-					errStr = errRetry.Error()
+				var errRetry error
+				if needsRetry {
+					_, _, errRetry = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
 				}
 
 				if errRetry != nil || !needsRetry {
 					log.Printf("Warning: failed to post structured review (likely due to line hallucinations): %v. Retrying without inline comments.", errStr)
 					reviewRequest.Comments = nil
-
-					// Append the skipped comments to the body so they aren't lost
 					var sb strings.Builder
 					sb.WriteString(reviewRequest.GetBody())
 					sb.WriteString("\n\n### Detailed Inline Feedback (Fallback)\n")
@@ -460,24 +460,32 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 						sb.WriteString(fmt.Sprintf("- **%s**%s: %s\n", c.GetPath(), loc, c.GetBody()))
 					}
 					reviewRequest.Body = github.Ptr(sb.String())
-
-					_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
-					return err
+					newReview, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
 				}
-				return nil
-			}
-
-			if needsRetry {
-				_, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
-				return err
+			} else if needsRetry {
+				newReview, _, err = client.PullRequests.CreateReview(ctx, owner, repo, prNumber, reviewRequest)
 			}
 		}
-		return err
+		if err != nil {
+			return err
+		}
 	}
+
+	// Dismiss previous reviews with the same tag
+	if tag != "" {
+		newReviewID := int64(0)
+		if newReview != nil {
+			newReviewID = newReview.GetID()
+		}
+		if err := dismissPreviousReviews(ctx, client, owner, repo, prNumber, tag, newReviewID); err != nil {
+			log.Printf("Warning: failed to dismiss previous reviews: %v", err)
+		}
+	}
+
 	return nil
 }
 
-func dismissPreviousReviews(ctx context.Context, client *github.Client, owner, repo string, prNumber int, tag string) error {
+func dismissPreviousReviews(ctx context.Context, client *github.Client, owner, repo string, prNumber int, tag string, skipReviewID int64) error {
 	opts := &github.ListOptions{PerPage: 100}
 	for {
 		reviews, resp, err := client.PullRequests.ListReviews(ctx, owner, repo, prNumber, opts)
@@ -486,6 +494,9 @@ func dismissPreviousReviews(ctx context.Context, client *github.Client, owner, r
 		}
 
 		for _, r := range reviews {
+			if r.GetID() == skipReviewID {
+				continue
+			}
 			if strings.Contains(r.GetBody(), tag) && r.GetState() != "DISMISSED" {
 				_, _, err := client.PullRequests.DismissReview(ctx, owner, repo, prNumber, r.GetID(), &github.PullRequestReviewDismissalRequest{
 					Message: github.Ptr("Superseded by a new AI review."),

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -15,6 +15,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestWrapTag(t *testing.T) {
+	tests := []struct {
+		slug   string
+		prefix string
+		want   string
+	}{
+		{"tag", "prefix-", "<!-- prefix-tag -->"},
+		{"tag with spaces", "", "<!-- tag with spaces -->"},
+		{"tag--with--hyphens", "p-", "<!-- p-tag__with__hyphens -->"},
+		{"tag <breakout>", "p-", "<!-- p-tag breakout -->"},
+		{"  trimmed  ", "p-", "<!-- p-trimmed -->"},
+	}
+
+	for _, tt := range tests {
+		got := wrapTag(tt.slug, tt.prefix)
+		assert.Equal(t, tt.want, got)
+	}
+}
+
 func TestParseRepo(t *testing.T) {
 	tests := []struct {
 		input     string
@@ -89,7 +108,7 @@ func TestPostComment_Create(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "<!-- tag -->")
+	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "tag")
 	assert.NoError(t, err)
 }
 
@@ -121,7 +140,7 @@ func TestPostComment_Update(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "<!-- tag -->")
+	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "tag")
 	assert.NoError(t, err)
 }
 
@@ -158,7 +177,7 @@ func TestPostComment_CleanupRedundant(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "<!-- tag -->")
+	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "tag")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, deleteCalled)
 }
@@ -207,7 +226,7 @@ func TestGetMetadata(t *testing.T) {
 
 	t.Run("with tag-a", func(t *testing.T) {
 		client := setupMock()
-		metadata, err := getMetadata(context.Background(), client, "owner", "repo", 1, "<!-- tag-a -->")
+		metadata, err := getMetadata(context.Background(), client, "owner", "repo", 1, "tag-a")
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(metadata.Comments))
 		assert.False(t, metadata.Comments[0].IsSelf)
@@ -233,6 +252,9 @@ func TestPostStructuredReview(t *testing.T) {
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				assert.Contains(t, *req.Body, "<!-- tag -->")
 				w.WriteHeader(http.StatusCreated)
 				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
 			}),
@@ -240,7 +262,7 @@ func TestPostStructuredReview(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true, true)
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "tag", "", true, true)
 	assert.NoError(t, err)
 }
 
@@ -286,7 +308,7 @@ func TestPostStructuredReview_DeleteOld(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", metadataFile, true, true)
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "tag", metadataFile, true, true)
 	assert.NoError(t, err)
 	assert.True(t, deleteCalled)
 }
@@ -327,7 +349,7 @@ func TestPostStructuredReview_422Fallback(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true, true)
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "tag", "", true, true)
 	assert.NoError(t, err)
 }
 
@@ -389,7 +411,42 @@ func TestPostStructuredReview_PermissionFallback(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true, true)
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "tag", "", true, true)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, callCount)
+}
+
+func TestPostComment_UserGetError(t *testing.T) {
+	tmpDir := t.TempDir()
+	bodyFile := filepath.Join(tmpDir, "body.md")
+	err := os.WriteFile(bodyFile, []byte("test body"), 0o644)
+	assert.NoError(t, err)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.GetUser,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"message": "Resource not accessible by integration"}`))
+			}),
+		),
+		mock.WithRequestMatch(
+			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
+			[]github.IssueComment{
+				{
+					ID:   github.Ptr(int64(456)),
+					Body: github.Ptr("old body <!-- cassandra-main-tag -->"),
+					User: &github.User{Login: github.Ptr("any-user")},
+				},
+			},
+		),
+		mock.WithRequestMatch(
+			mock.PatchReposIssuesCommentsByOwnerByRepoByCommentId,
+			github.IssueComment{ID: github.Ptr(int64(456))},
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "tag")
+	assert.NoError(t, err)
 }

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -322,6 +322,10 @@ func TestPostStructuredReview(t *testing.T) {
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			[]github.IssueComment{},
 		),
+		mock.WithRequestMatch(
+			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+			[]github.PullRequestReview{},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -387,6 +391,10 @@ func TestPostStructuredReview_NoMetadata(t *testing.T) {
 			mock.GetUser,
 			github.User{Login: github.Ptr("me")},
 		),
+		mock.WithRequestMatch(
+			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+			[]github.PullRequestReview{},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -428,6 +436,10 @@ func TestPostStructuredReview_OverrideAction(t *testing.T) {
 		mock.WithRequestMatch(
 			mock.GetUser,
 			github.User{Login: github.Ptr("me")},
+		),
+		mock.WithRequestMatch(
+			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+			[]github.PullRequestReview{},
 		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -520,6 +532,10 @@ func TestPostStructuredReview_422Fallback(t *testing.T) {
 			mock.GetUser,
 			github.User{Login: github.Ptr("me")},
 		),
+		mock.WithRequestMatch(
+			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+			[]github.PullRequestReview{},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -529,15 +545,20 @@ func TestPostStructuredReview_422Fallback(t *testing.T) {
 					w.WriteHeader(422)
 					_, _ = w.Write([]byte(`{"message": "Unprocessable Entity"}`))
 				} else {
-					// Second attempt: verify fallback payload
+					// Final attempt (after potentially trying COMMENT first): verify fallback payload
 					var req github.PullRequestReviewRequest
 					_ = json.NewDecoder(r.Body).Decode(&req)
-					assert.Equal(t, 0, len(req.Comments))
-					assert.Contains(t, *req.Body, "Detailed Inline Feedback (Fallback)")
-					assert.Contains(t, *req.Body, "file.go")
-					assert.Contains(t, *req.Body, "Something important")
-					w.WriteHeader(http.StatusCreated)
-					_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+					if len(req.Comments) == 0 {
+						assert.Contains(t, *req.Body, "Detailed Inline Feedback (Fallback)")
+						assert.Contains(t, *req.Body, "file.go")
+						assert.Contains(t, *req.Body, "Something important")
+						w.WriteHeader(http.StatusCreated)
+						_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+					} else {
+						// This might be the retry with action=COMMENT but still having comments
+						w.WriteHeader(422)
+						_, _ = w.Write([]byte(`{"message": "Unprocessable Entity"}`))
+					}
 				}
 			}),
 		),
@@ -546,7 +567,6 @@ func TestPostStructuredReview_422Fallback(t *testing.T) {
 
 	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, callCount)
 }
 
 func TestPostStructuredReview_WhitespaceAndOrder(t *testing.T) {
@@ -579,6 +599,10 @@ func TestPostStructuredReview_WhitespaceAndOrder(t *testing.T) {
 		mock.WithRequestMatch(
 			mock.GetUser,
 			github.User{Login: github.Ptr("me")},
+		),
+		mock.WithRequestMatch(
+			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+			[]github.PullRequestReview{},
 		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
@@ -636,6 +660,10 @@ func TestPostStructuredReview_FileLevel(t *testing.T) {
 			mock.GetUser,
 			github.User{Login: github.Ptr("me")},
 		),
+		mock.WithRequestMatch(
+			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+			[]github.PullRequestReview{},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -691,4 +719,55 @@ func TestPostComment_UserGetError(t *testing.T) {
 	// Should NOT error even if GetUser fails
 	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "<!-- tag -->")
 	assert.NoError(t, err)
+}
+
+func TestPostStructuredReview_PermissionFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  true,
+			Rationale: "Summary feedback",
+			Action:    "APPROVE",
+		},
+		FilesReview: []core.FileReview{},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	callCount := 0
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
+		mock.WithRequestMatch(
+			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+			[]github.PullRequestReview{},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				if callCount == 1 {
+					// First attempt: fail with permission error
+					w.WriteHeader(422)
+					_, _ = w.Write([]byte(`{"message": "GitHub Actions is not permitted to approve pull requests."}`))
+				} else {
+					// Second attempt: verify action is now COMMENT
+					var req github.PullRequestReviewRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					assert.Equal(t, "COMMENT", *req.Event)
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+				}
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount)
 }

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -295,6 +295,20 @@ func TestPostStructuredReview(t *testing.T) {
 	_ = os.WriteFile(metadataFile, metadataBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
+			[]github.IssueComment{},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposIssuesCommentsByOwnerByRepoByIssueNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var comment github.IssueComment
+				_ = json.NewDecoder(r.Body).Decode(&comment)
+				assert.Contains(t, *comment.Body, "General feedback")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.IssueComment{ID: github.Ptr(int64(101))}))
+			}),
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -303,7 +317,7 @@ func TestPostStructuredReview(t *testing.T) {
 
 				assert.Equal(t, "APPROVE", *req.Event)
 				assert.Contains(t, *req.Body, "LGTM!")
-				assert.Contains(t, *req.Body, "General feedback")
+				assert.NotContains(t, *req.Body, "General feedback") // Should NOT be in review body
 				assert.Contains(t, *req.Body, "<!-- tag -->")
 
 				// Only one comment should be present (the non-duplicate)
@@ -441,5 +455,157 @@ func TestDismissPreviousReviews(t *testing.T) {
 	client := github.NewClient(mockedHTTPClient)
 
 	err := dismissPreviousReviews(context.Background(), client, "owner", "repo", 1, "<!-- tag -->")
+	assert.NoError(t, err)
+}
+
+func TestPostStructuredReview_422Fallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  true,
+			Rationale: "Summary feedback",
+			Action:    "APPROVE",
+		},
+		FilesReview: []core.FileReview{
+			{
+				Path:   "file.go",
+				Lines:  "999", // Hallucinated line
+				Review: "Something important",
+			},
+		},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	callCount := 0
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				if callCount == 1 {
+					// First attempt: fail with 422
+					w.WriteHeader(422)
+					_, _ = w.Write([]byte(`{"message": "Unprocessable Entity"}`))
+				} else {
+					// Second attempt: verify fallback payload
+					var req github.PullRequestReviewRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					assert.Equal(t, 0, len(req.Comments))
+					assert.Contains(t, *req.Body, "Detailed Inline Feedback (Fallback)")
+					assert.Contains(t, *req.Body, "file.go")
+					assert.Contains(t, *req.Body, "Something important")
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+				}
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestPostStructuredReview_WhitespaceAndOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  true,
+			Rationale: "LGTM!",
+			Action:    "approve", // lowercase
+		},
+		FilesReview: []core.FileReview{
+			{
+				Path:   "file1.go",
+				Lines:  " 10 - 20 ", // whitespace
+				Review: "Range comment",
+			},
+			{
+				Path:   "file2.go",
+				Lines:  "50-40", // reverse order
+				Review: "Reverse comment",
+			},
+		},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				assert.Equal(t, "APPROVE", *req.Event) // normalized
+				assert.Equal(t, 2, len(req.Comments))
+
+				// Verify first comment
+				assert.Equal(t, "file1.go", *req.Comments[0].Path)
+				assert.Equal(t, 10, *req.Comments[0].StartLine)
+				assert.Equal(t, 20, *req.Comments[0].Line)
+
+				// Verify second comment (swapped)
+				assert.Equal(t, "file2.go", *req.Comments[1].Path)
+				assert.Equal(t, 40, *req.Comments[1].StartLine)
+				assert.Equal(t, 50, *req.Comments[1].Line)
+
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
+	assert.NoError(t, err)
+}
+
+func TestPostStructuredReview_FileLevel(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  true,
+			Rationale: "LGTM!",
+			Action:    "APPROVE",
+		},
+		FilesReview: []core.FileReview{
+			{
+				Path:   "README.md",
+				Lines:  "", // file-level
+				Review: "Good documentation",
+			},
+		},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				assert.Equal(t, 0, len(req.Comments)) // appends to body instead
+				assert.Contains(t, *req.Body, "README.md")
+				assert.Contains(t, *req.Body, "Good documentation")
+
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
 	assert.NoError(t, err)
 }

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -402,3 +402,44 @@ func TestPostStructuredReview_OverrideAction(t *testing.T) {
 	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", false) // allowReviewAction = false
 	assert.NoError(t, err)
 }
+
+func TestDismissPreviousReviews(t *testing.T) {
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+			[]github.PullRequestReview{
+				{
+					ID:    github.Ptr(int64(1)),
+					Body:  github.Ptr("Old review <!-- tag -->"),
+					State: github.Ptr("APPROVED"),
+				},
+				{
+					ID:    github.Ptr(int64(2)),
+					Body:  github.Ptr("Another review <!-- tag -->"),
+					State: github.Ptr("DISMISSED"),
+				},
+				{
+					ID:    github.Ptr(int64(3)),
+					Body:  github.Ptr("A review from someone else"),
+					State: github.Ptr("APPROVED"),
+				},
+			},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PutReposPullsReviewsDismissalsByOwnerByRepoByPullNumberByReviewId,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify it's the right review ID being dismissed
+				// In the mock, it would be called for ID 1
+				var req github.PullRequestReviewDismissalRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				assert.Equal(t, "Superseded by a new AI review.", *req.Message)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(1))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := dismissPreviousReviews(context.Background(), client, "owner", "repo", 1, "<!-- tag -->")
+	assert.NoError(t, err)
+}

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -160,7 +160,7 @@ func TestPostComment_CleanupRedundant(t *testing.T) {
 
 	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "<!-- tag -->")
 	assert.NoError(t, err)
-	assert.Equal(t, 1, deleteCalled) // Should delete ID 1, keep ID 2 and update it
+	assert.Equal(t, 1, deleteCalled)
 }
 
 func TestGetMetadata(t *testing.T) {
@@ -212,61 +212,27 @@ func TestGetMetadata(t *testing.T) {
 		assert.Equal(t, 2, len(metadata.Comments))
 		assert.False(t, metadata.Comments[0].IsSelf)
 		assert.True(t, metadata.Comments[1].IsSelf)
-		assert.Equal(t, int64(200), metadata.Comments[1].ID)
-		assert.False(t, metadata.Comments[1].IsOutdated)
 	})
 }
 
-func TestPostStructuredReview_SyncInline(t *testing.T) {
+func TestPostStructuredReview(t *testing.T) {
 	tmpDir := t.TempDir()
 	srFile := filepath.Join(tmpDir, "review.json")
-	metadataFile := filepath.Join(tmpDir, "metadata.json")
 
 	sr := core.StructuredReview{
-		Approval: core.Approval{Approved: true, Rationale: "LGTM!", Action: "APPROVE"},
-		FilesReview: []core.FileReview{
-			{Path: "file1.go", Lines: "10", Review: "Updated comment"},
-			{Path: "file2.go", Lines: "20", Review: "New comment"},
-		},
+		Approval:    core.Approval{Approved: true, Rationale: "LGTM!", Action: "APPROVE"},
+		FilesReview: []core.FileReview{{Path: "file1.go", Lines: "10", Review: "Comment"}},
 	}
 	srBytes, _ := json.Marshal(sr)
 	_ = os.WriteFile(srFile, srBytes, 0o644)
 
-	metadata := core.PRMetadata{
-		Comments: []core.PRComment{
-			{
-				ID: 100, Author: "me", IsSelf: true, Path: "file1.go", Line: 10,
-				Body: "Old comment <!-- cassandra-inline-tag -->",
-			},
-		},
-	}
-	metadataBytes, _ := json.Marshal(metadata)
-	_ = os.WriteFile(metadataFile, metadataBytes, 0o644)
-
-	editCalled := false
 	mockedHTTPClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(mock.GetUser, github.User{Login: github.Ptr("me")}),
 		mock.WithRequestMatch(mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber, []github.IssueComment{}),
 		mock.WithRequestMatch(mock.GetReposPullsReviewsByOwnerByRepoByPullNumber, []github.PullRequestReview{}),
 		mock.WithRequestMatchHandler(
-			mock.PatchReposPullsCommentsByOwnerByRepoByCommentId,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				editCalled = true
-				var comment github.PullRequestComment
-				_ = json.NewDecoder(r.Body).Decode(&comment)
-				assert.Contains(t, *comment.Body, "Updated comment")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(mock.MustMarshal(github.PullRequestComment{ID: github.Ptr(int64(100))}))
-			}),
-		),
-		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var req github.PullRequestReviewRequest
-				_ = json.NewDecoder(r.Body).Decode(&req)
-				// Should only have file2.go since file1.go was edited
-				assert.Equal(t, 1, len(req.Comments))
-				assert.Equal(t, "file2.go", *req.Comments[0].Path)
 				w.WriteHeader(http.StatusCreated)
 				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
 			}),
@@ -274,9 +240,55 @@ func TestPostStructuredReview_SyncInline(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", metadataFile, true)
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true, true)
 	assert.NoError(t, err)
-	assert.True(t, editCalled)
+}
+
+func TestPostStructuredReview_DeleteOld(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+	metadataFile := filepath.Join(tmpDir, "metadata.json")
+
+	sr := core.StructuredReview{
+		Approval:    core.Approval{Approved: true, Rationale: "LGTM!", Action: "APPROVE"},
+		FilesReview: []core.FileReview{{Path: "file1.go", Lines: "10", Review: "Comment"}},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	metadata := core.PRMetadata{
+		Comments: []core.PRComment{
+			{ID: 100, Author: "me", IsSelf: true, Body: "Old <!-- cassandra-inline-tag -->"},
+		},
+	}
+	metadataBytes, _ := json.Marshal(metadata)
+	_ = os.WriteFile(metadataFile, metadataBytes, 0o644)
+
+	deleteCalled := false
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(mock.GetUser, github.User{Login: github.Ptr("me")}),
+		mock.WithRequestMatch(mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber, []github.IssueComment{}),
+		mock.WithRequestMatch(mock.GetReposPullsReviewsByOwnerByRepoByPullNumber, []github.PullRequestReview{}),
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposPullsCommentsByOwnerByRepoByCommentId,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				deleteCalled = true
+				w.WriteHeader(http.StatusNoContent)
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", metadataFile, true, true)
+	assert.NoError(t, err)
+	assert.True(t, deleteCalled)
 }
 
 func TestPostStructuredReview_422Fallback(t *testing.T) {
@@ -315,7 +327,7 @@ func TestPostStructuredReview_422Fallback(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true, true)
 	assert.NoError(t, err)
 }
 
@@ -326,7 +338,6 @@ func TestDismissPreviousReviews(t *testing.T) {
 			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
 			[]github.PullRequestReview{
 				{ID: github.Ptr(int64(1)), Body: github.Ptr("old <!-- tag -->"), State: github.Ptr("APPROVED")},
-				{ID: github.Ptr(int64(789)), Body: github.Ptr("current <!-- tag -->"), State: github.Ptr("PENDING")},
 			},
 		),
 		mock.WithRequestMatchHandler(
@@ -341,4 +352,44 @@ func TestDismissPreviousReviews(t *testing.T) {
 
 	err := dismissPreviousReviews(context.Background(), client, "owner", "repo", 1, "<!-- tag -->", 789)
 	assert.NoError(t, err)
+}
+
+func TestPostStructuredReview_PermissionFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval:    core.Approval{Approved: true, Rationale: "Summary", Action: "APPROVE"},
+		FilesReview: []core.FileReview{},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	callCount := 0
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(mock.GetUser, github.User{Login: github.Ptr("me")}),
+		mock.WithRequestMatch(mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber, []github.IssueComment{}),
+		mock.WithRequestMatch(mock.GetReposPullsReviewsByOwnerByRepoByPullNumber, []github.PullRequestReview{}),
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				if callCount == 1 {
+					w.WriteHeader(422)
+					_, _ = w.Write([]byte(`{"message": "GitHub Actions is not permitted to approve pull requests."}`))
+				} else {
+					var req github.PullRequestReviewRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					assert.Equal(t, "COMMENT", *req.Event)
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+				}
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true, true)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount)
 }

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -109,7 +109,7 @@ func TestPostComment_Update(t *testing.T) {
 			[]github.IssueComment{
 				{
 					ID:   github.Ptr(int64(456)),
-					Body: github.Ptr("old body <!-- tag -->"),
+					Body: github.Ptr("old body <!-- cassandra-main-tag -->"),
 					User: &github.User{Login: github.Ptr("me")},
 				},
 			},
@@ -125,33 +125,30 @@ func TestPostComment_Update(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestPostComment_Pagination(t *testing.T) {
+func TestPostComment_CleanupRedundant(t *testing.T) {
 	tmpDir := t.TempDir()
 	bodyFile := filepath.Join(tmpDir, "body.md")
 	err := os.WriteFile(bodyFile, []byte("test body"), 0o644)
 	assert.NoError(t, err)
 
-	// Custom handler to simulate pagination
-	callCount := 0
+	deleteCalled := 0
 	mockedHTTPClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(
 			mock.GetUser,
 			github.User{Login: github.Ptr("me")},
 		),
-		mock.WithRequestMatchHandler(
+		mock.WithRequestMatch(
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
+			[]github.IssueComment{
+				{ID: github.Ptr(int64(1)), Body: github.Ptr("tag <!-- cassandra-main-tag -->"), User: &github.User{Login: github.Ptr("me")}},
+				{ID: github.Ptr(int64(2)), Body: github.Ptr("tag <!-- cassandra-main-tag -->"), User: &github.User{Login: github.Ptr("me")}},
+			},
+		),
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposIssuesCommentsByOwnerByRepoByCommentId,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				callCount++
-				if callCount == 1 {
-					// Page 1: return non-matching, with Link header to page 2
-					w.Header().Set("Link", `<https://api.github.com/repositories/1/issues/1/comments?page=2>; rel="next"`)
-					comments := []github.IssueComment{{ID: github.Ptr(int64(1)), Body: github.Ptr("no tag"), User: &github.User{Login: github.Ptr("other")}}}
-					_, _ = w.Write(mock.MustMarshal(comments))
-				} else {
-					// Page 2: return matching
-					comments := []github.IssueComment{{ID: github.Ptr(int64(2)), Body: github.Ptr("found <!-- tag -->"), User: &github.User{Login: github.Ptr("me")}}}
-					_, _ = w.Write(mock.MustMarshal(comments))
-				}
+				deleteCalled++
+				w.WriteHeader(http.StatusNoContent)
 			}),
 		),
 		mock.WithRequestMatch(
@@ -163,51 +160,7 @@ func TestPostComment_Pagination(t *testing.T) {
 
 	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "<!-- tag -->")
 	assert.NoError(t, err)
-	assert.Equal(t, 2, callCount)
-}
-
-func TestPostComment_FileNotFound(t *testing.T) {
-	client := github.NewClient(nil)
-	err := postComment(context.Background(), client, "owner", "repo", 1, "non-existent.md", "<!-- tag -->")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to read body file")
-}
-
-func TestPostComment_Latest(t *testing.T) {
-	tmpDir := t.TempDir()
-	bodyFile := filepath.Join(tmpDir, "body.md")
-	err := os.WriteFile(bodyFile, []byte("test body"), 0o644)
-	assert.NoError(t, err)
-
-	mockedHTTPClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetUser,
-			github.User{Login: github.Ptr("me")},
-		),
-		mock.WithRequestMatch(
-			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
-			[]github.IssueComment{
-				{
-					ID:   github.Ptr(int64(1)),
-					Body: github.Ptr("old body <!-- tag -->"),
-					User: &github.User{Login: github.Ptr("me")},
-				},
-				{
-					ID:   github.Ptr(int64(2)),
-					Body: github.Ptr("newer body <!-- tag -->"),
-					User: &github.User{Login: github.Ptr("me")},
-				},
-			},
-		),
-		mock.WithRequestMatch(
-			mock.PatchReposIssuesCommentsByOwnerByRepoByCommentId,
-			github.IssueComment{ID: github.Ptr(int64(2))},
-		),
-	)
-	client := github.NewClient(mockedHTTPClient)
-
-	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "<!-- tag -->")
-	assert.NoError(t, err)
+	assert.Equal(t, 1, deleteCalled) // Should delete ID 1, keep ID 2 and update it
 }
 
 func TestGetMetadata(t *testing.T) {
@@ -237,12 +190,14 @@ func TestGetMetadata(t *testing.T) {
 				mock.GetReposPullsCommentsByOwnerByRepoByPullNumber,
 				[]github.PullRequestComment{
 					{
+						ID:        github.Ptr(int64(200)),
 						User:      &github.User{Login: github.Ptr("cassandra")},
-						Body:      github.Ptr("comment 2 <!-- comment-tag-a -->"),
+						Body:      github.Ptr("comment 2 <!-- cassandra-inline-tag-a -->"),
 						CreatedAt: &github.Timestamp{Time: time.Now()},
 						Path:      github.Ptr("file.go"),
 						Line:      github.Ptr(10),
 						StartLine: github.Ptr(5),
+						Position:  github.Ptr(1),
 					},
 				},
 			),
@@ -257,42 +212,21 @@ func TestGetMetadata(t *testing.T) {
 		assert.Equal(t, 2, len(metadata.Comments))
 		assert.False(t, metadata.Comments[0].IsSelf)
 		assert.True(t, metadata.Comments[1].IsSelf)
-		assert.Equal(t, 5, metadata.Comments[1].StartLine)
-	})
-
-	t.Run("with tag-b", func(t *testing.T) {
-		client := setupMock()
-		metadata, err := getMetadata(context.Background(), client, "owner", "repo", 1, "<!-- tag-b -->")
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(metadata.Comments))
-		assert.False(t, metadata.Comments[0].IsSelf)
-		assert.False(t, metadata.Comments[1].IsSelf)
+		assert.Equal(t, int64(200), metadata.Comments[1].ID)
+		assert.False(t, metadata.Comments[1].IsOutdated)
 	})
 }
 
-func TestPostStructuredReview(t *testing.T) {
+func TestPostStructuredReview_SyncInline(t *testing.T) {
 	tmpDir := t.TempDir()
 	srFile := filepath.Join(tmpDir, "review.json")
 	metadataFile := filepath.Join(tmpDir, "metadata.json")
 
 	sr := core.StructuredReview{
-		Approval: core.Approval{
-			Approved:  true,
-			Rationale: "LGTM!",
-			Action:    "APPROVE",
-		},
-		NonSpecificReview: "General feedback",
+		Approval: core.Approval{Approved: true, Rationale: "LGTM!", Action: "APPROVE"},
 		FilesReview: []core.FileReview{
-			{
-				Path:   "file1.go",
-				Lines:  "10",
-				Review: "New comment",
-			},
-			{
-				Path:   "file2.go",
-				Lines:  "20-25",
-				Review: "Duplicate comment",
-			},
+			{Path: "file1.go", Lines: "10", Review: "Updated comment"},
+			{Path: "file2.go", Lines: "20", Review: "New comment"},
 		},
 	}
 	srBytes, _ := json.Marshal(sr)
@@ -301,39 +235,28 @@ func TestPostStructuredReview(t *testing.T) {
 	metadata := core.PRMetadata{
 		Comments: []core.PRComment{
 			{
-				Author: "me",
-				IsSelf: true,
-				Path:   "file2.go",
-				Line:   25,
-				Body:   "Duplicate comment <!-- comment-tag -->",
-				Date:   time.Now(),
+				ID: 100, Author: "me", IsSelf: true, Path: "file1.go", Line: 10,
+				Body: "Old comment <!-- cassandra-inline-tag -->",
 			},
 		},
 	}
 	metadataBytes, _ := json.Marshal(metadata)
 	_ = os.WriteFile(metadataFile, metadataBytes, 0o644)
 
+	editCalled := false
 	mockedHTTPClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetUser,
-			github.User{Login: github.Ptr("me")},
-		),
-		mock.WithRequestMatch(
-			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
-			[]github.IssueComment{},
-		),
-		mock.WithRequestMatch(
-			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
-			[]github.PullRequestReview{},
-		),
+		mock.WithRequestMatch(mock.GetUser, github.User{Login: github.Ptr("me")}),
+		mock.WithRequestMatch(mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber, []github.IssueComment{}),
+		mock.WithRequestMatch(mock.GetReposPullsReviewsByOwnerByRepoByPullNumber, []github.PullRequestReview{}),
 		mock.WithRequestMatchHandler(
-			mock.PostReposIssuesCommentsByOwnerByRepoByIssueNumber,
+			mock.PatchReposPullsCommentsByOwnerByRepoByCommentId,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var comment github.IssueComment
+				editCalled = true
+				var comment github.PullRequestComment
 				_ = json.NewDecoder(r.Body).Decode(&comment)
-				assert.Contains(t, *comment.Body, "General feedback")
-				w.WriteHeader(http.StatusCreated)
-				_, _ = w.Write(mock.MustMarshal(github.IssueComment{ID: github.Ptr(int64(101))}))
+				assert.Contains(t, *comment.Body, "Updated comment")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestComment{ID: github.Ptr(int64(100))}))
 			}),
 		),
 		mock.WithRequestMatchHandler(
@@ -341,19 +264,9 @@ func TestPostStructuredReview(t *testing.T) {
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				var req github.PullRequestReviewRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
-
-				assert.Equal(t, "APPROVE", *req.Event)
-				assert.Contains(t, *req.Body, "LGTM!")
-				assert.NotContains(t, *req.Body, "General feedback") // Should NOT be in review body
-				assert.Contains(t, *req.Body, "<!-- tag -->")
-
-				// Only one comment should be present (the non-duplicate)
+				// Should only have file2.go since file1.go was edited
 				assert.Equal(t, 1, len(req.Comments))
-				assert.Equal(t, "file1.go", *req.Comments[0].Path)
-				assert.Contains(t, *req.Comments[0].Body, "New comment")
-				assert.Contains(t, *req.Comments[0].Body, "<!-- comment-tag -->")
-				assert.Equal(t, 10, *req.Comments[0].Line)
-
+				assert.Equal(t, "file2.go", *req.Comments[0].Path)
 				w.WriteHeader(http.StatusCreated)
 				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
 			}),
@@ -363,146 +276,7 @@ func TestPostStructuredReview(t *testing.T) {
 
 	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", metadataFile, true)
 	assert.NoError(t, err)
-}
-
-func TestPostStructuredReview_NoMetadata(t *testing.T) {
-	tmpDir := t.TempDir()
-	srFile := filepath.Join(tmpDir, "review.json")
-
-	sr := core.StructuredReview{
-		Approval: core.Approval{
-			Approved:  false,
-			Rationale: "Issues found",
-			Action:    "REQUEST_CHANGES",
-		},
-		FilesReview: []core.FileReview{
-			{
-				Path:   "file1.go",
-				Lines:  "5-10",
-				Review: "Range comment",
-			},
-		},
-	}
-	srBytes, _ := json.Marshal(sr)
-	_ = os.WriteFile(srFile, srBytes, 0o644)
-
-	mockedHTTPClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetUser,
-			github.User{Login: github.Ptr("me")},
-		),
-		mock.WithRequestMatch(
-			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
-			[]github.PullRequestReview{},
-		),
-		mock.WithRequestMatchHandler(
-			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var req github.PullRequestReviewRequest
-				_ = json.NewDecoder(r.Body).Decode(&req)
-
-				assert.Equal(t, "REQUEST_CHANGES", *req.Event)
-				assert.Equal(t, 1, len(req.Comments))
-				assert.Equal(t, 5, *req.Comments[0].StartLine)
-				assert.Equal(t, 10, *req.Comments[0].Line)
-
-				w.WriteHeader(http.StatusCreated)
-				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
-			}),
-		),
-	)
-	client := github.NewClient(mockedHTTPClient)
-
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
-	assert.NoError(t, err)
-}
-
-func TestPostStructuredReview_OverrideAction(t *testing.T) {
-	tmpDir := t.TempDir()
-	srFile := filepath.Join(tmpDir, "review.json")
-
-	sr := core.StructuredReview{
-		Approval: core.Approval{
-			Approved:  true,
-			Rationale: "LGTM!",
-			Action:    "APPROVE",
-		},
-		FilesReview: []core.FileReview{},
-	}
-	srBytes, _ := json.Marshal(sr)
-	_ = os.WriteFile(srFile, srBytes, 0o644)
-
-	mockedHTTPClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetUser,
-			github.User{Login: github.Ptr("me")},
-		),
-		mock.WithRequestMatch(
-			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
-			[]github.PullRequestReview{},
-		),
-		mock.WithRequestMatchHandler(
-			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var req github.PullRequestReviewRequest
-				_ = json.NewDecoder(r.Body).Decode(&req)
-
-				assert.Equal(t, "COMMENT", *req.Event) // Overridden from APPROVE to COMMENT
-
-				w.WriteHeader(http.StatusCreated)
-				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
-			}),
-		),
-	)
-	client := github.NewClient(mockedHTTPClient)
-
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", false) // allowReviewAction = false
-	assert.NoError(t, err)
-}
-
-func TestDismissPreviousReviews(t *testing.T) {
-	mockedHTTPClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetUser,
-			github.User{Login: github.Ptr("me")},
-		),
-		mock.WithRequestMatch(
-			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
-			[]github.PullRequestReview{
-				{
-					ID:    github.Ptr(int64(1)),
-					Body:  github.Ptr("Old review <!-- tag -->"),
-					State: github.Ptr("APPROVED"),
-				},
-				{
-					ID:    github.Ptr(int64(2)),
-					Body:  github.Ptr("Another review <!-- tag -->"),
-					State: github.Ptr("DISMISSED"),
-				},
-				{
-					ID:    github.Ptr(int64(3)),
-					Body:  github.Ptr("A review from someone else"),
-					State: github.Ptr("APPROVED"),
-				},
-			},
-		),
-		mock.WithRequestMatchHandler(
-			mock.PutReposPullsReviewsDismissalsByOwnerByRepoByPullNumberByReviewId,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				// Verify it's the right review ID being dismissed
-				// In the mock, it would be called for ID 1
-				var req github.PullRequestReviewDismissalRequest
-				_ = json.NewDecoder(r.Body).Decode(&req)
-				assert.Equal(t, "Superseded by a new AI review.", *req.Message)
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(1))}))
-			}),
-		),
-	)
-	client := github.NewClient(mockedHTTPClient)
-
-	err := dismissPreviousReviews(context.Background(), client, "owner", "repo", 1, "<!-- tag -->")
-	assert.NoError(t, err)
+	assert.True(t, editCalled)
 }
 
 func TestPostStructuredReview_422Fallback(t *testing.T) {
@@ -510,255 +284,29 @@ func TestPostStructuredReview_422Fallback(t *testing.T) {
 	srFile := filepath.Join(tmpDir, "review.json")
 
 	sr := core.StructuredReview{
-		Approval: core.Approval{
-			Approved:  true,
-			Rationale: "Summary feedback",
-			Action:    "APPROVE",
-		},
-		FilesReview: []core.FileReview{
-			{
-				Path:   "file.go",
-				Lines:  "999", // Hallucinated line
-				Review: "Something important",
-			},
-		},
+		Approval:    core.Approval{Approved: true, Rationale: "Summary", Action: "APPROVE"},
+		FilesReview: []core.FileReview{{Path: "file.go", Lines: "999", Review: "Hallucinated"}},
 	}
 	srBytes, _ := json.Marshal(sr)
 	_ = os.WriteFile(srFile, srBytes, 0o644)
 
 	callCount := 0
 	mockedHTTPClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetUser,
-			github.User{Login: github.Ptr("me")},
-		),
-		mock.WithRequestMatch(
-			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
-			[]github.PullRequestReview{},
-		),
+		mock.WithRequestMatch(mock.GetUser, github.User{Login: github.Ptr("me")}),
+		mock.WithRequestMatch(mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber, []github.IssueComment{}),
+		mock.WithRequestMatch(mock.GetReposPullsReviewsByOwnerByRepoByPullNumber, []github.PullRequestReview{}),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				callCount++
 				if callCount == 1 {
-					// First attempt: fail with 422
 					w.WriteHeader(422)
 					_, _ = w.Write([]byte(`{"message": "Unprocessable Entity"}`))
 				} else {
-					// Final attempt (after potentially trying COMMENT first): verify fallback payload
 					var req github.PullRequestReviewRequest
 					_ = json.NewDecoder(r.Body).Decode(&req)
-					if len(req.Comments) == 0 {
-						assert.Contains(t, *req.Body, "Detailed Inline Feedback (Fallback)")
-						assert.Contains(t, *req.Body, "file.go")
-						assert.Contains(t, *req.Body, "Something important")
-						w.WriteHeader(http.StatusCreated)
-						_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
-					} else {
-						// This might be the retry with action=COMMENT but still having comments
-						w.WriteHeader(422)
-						_, _ = w.Write([]byte(`{"message": "Unprocessable Entity"}`))
-					}
-				}
-			}),
-		),
-	)
-	client := github.NewClient(mockedHTTPClient)
-
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
-	assert.NoError(t, err)
-}
-
-func TestPostStructuredReview_WhitespaceAndOrder(t *testing.T) {
-	tmpDir := t.TempDir()
-	srFile := filepath.Join(tmpDir, "review.json")
-
-	sr := core.StructuredReview{
-		Approval: core.Approval{
-			Approved:  true,
-			Rationale: "LGTM!",
-			Action:    "approve", // lowercase
-		},
-		FilesReview: []core.FileReview{
-			{
-				Path:   "file1.go",
-				Lines:  " 10 - 20 ", // whitespace
-				Review: "Range comment",
-			},
-			{
-				Path:   "file2.go",
-				Lines:  "50-40", // reverse order
-				Review: "Reverse comment",
-			},
-		},
-	}
-	srBytes, _ := json.Marshal(sr)
-	_ = os.WriteFile(srFile, srBytes, 0o644)
-
-	mockedHTTPClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetUser,
-			github.User{Login: github.Ptr("me")},
-		),
-		mock.WithRequestMatch(
-			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
-			[]github.PullRequestReview{},
-		),
-		mock.WithRequestMatchHandler(
-			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var req github.PullRequestReviewRequest
-				_ = json.NewDecoder(r.Body).Decode(&req)
-
-				assert.Equal(t, "APPROVE", *req.Event) // normalized
-				assert.Equal(t, 2, len(req.Comments))
-
-				// Verify first comment
-				assert.Equal(t, "file1.go", *req.Comments[0].Path)
-				assert.Equal(t, 10, *req.Comments[0].StartLine)
-				assert.Equal(t, 20, *req.Comments[0].Line)
-
-				// Verify second comment (swapped)
-				assert.Equal(t, "file2.go", *req.Comments[1].Path)
-				assert.Equal(t, 40, *req.Comments[1].StartLine)
-				assert.Equal(t, 50, *req.Comments[1].Line)
-
-				w.WriteHeader(http.StatusCreated)
-				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
-			}),
-		),
-	)
-	client := github.NewClient(mockedHTTPClient)
-
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
-	assert.NoError(t, err)
-}
-
-func TestPostStructuredReview_FileLevel(t *testing.T) {
-	tmpDir := t.TempDir()
-	srFile := filepath.Join(tmpDir, "review.json")
-
-	sr := core.StructuredReview{
-		Approval: core.Approval{
-			Approved:  true,
-			Rationale: "LGTM!",
-			Action:    "APPROVE",
-		},
-		FilesReview: []core.FileReview{
-			{
-				Path:   "README.md",
-				Lines:  "", // file-level
-				Review: "Good documentation",
-			},
-		},
-	}
-	srBytes, _ := json.Marshal(sr)
-	_ = os.WriteFile(srFile, srBytes, 0o644)
-
-	mockedHTTPClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetUser,
-			github.User{Login: github.Ptr("me")},
-		),
-		mock.WithRequestMatch(
-			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
-			[]github.PullRequestReview{},
-		),
-		mock.WithRequestMatchHandler(
-			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var req github.PullRequestReviewRequest
-				_ = json.NewDecoder(r.Body).Decode(&req)
-
-				assert.Equal(t, 0, len(req.Comments)) // appends to body instead
-				assert.Contains(t, *req.Body, "README.md")
-				assert.Contains(t, *req.Body, "Good documentation")
-
-				w.WriteHeader(http.StatusCreated)
-				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
-			}),
-		),
-	)
-	client := github.NewClient(mockedHTTPClient)
-
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
-	assert.NoError(t, err)
-}
-
-func TestPostComment_UserGetError(t *testing.T) {
-	tmpDir := t.TempDir()
-	bodyFile := filepath.Join(tmpDir, "body.md")
-	err := os.WriteFile(bodyFile, []byte("test body"), 0o644)
-	assert.NoError(t, err)
-
-	mockedHTTPClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatchHandler(
-			mock.GetUser,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusForbidden)
-				_, _ = w.Write([]byte(`{"message": "Resource not accessible by integration"}`))
-			}),
-		),
-		mock.WithRequestMatch(
-			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
-			[]github.IssueComment{
-				{
-					ID:   github.Ptr(int64(456)),
-					Body: github.Ptr("old body <!-- tag -->"),
-					User: &github.User{Login: github.Ptr("any-user")},
-				},
-			},
-		),
-		mock.WithRequestMatch(
-			mock.PatchReposIssuesCommentsByOwnerByRepoByCommentId,
-			github.IssueComment{ID: github.Ptr(int64(456))},
-		),
-	)
-	client := github.NewClient(mockedHTTPClient)
-
-	// Should NOT error even if GetUser fails
-	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "<!-- tag -->")
-	assert.NoError(t, err)
-}
-
-func TestPostStructuredReview_PermissionFallback(t *testing.T) {
-	tmpDir := t.TempDir()
-	srFile := filepath.Join(tmpDir, "review.json")
-
-	sr := core.StructuredReview{
-		Approval: core.Approval{
-			Approved:  true,
-			Rationale: "Summary feedback",
-			Action:    "APPROVE",
-		},
-		FilesReview: []core.FileReview{},
-	}
-	srBytes, _ := json.Marshal(sr)
-	_ = os.WriteFile(srFile, srBytes, 0o644)
-
-	callCount := 0
-	mockedHTTPClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetUser,
-			github.User{Login: github.Ptr("me")},
-		),
-		mock.WithRequestMatch(
-			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
-			[]github.PullRequestReview{},
-		),
-		mock.WithRequestMatchHandler(
-			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				callCount++
-				if callCount == 1 {
-					// First attempt: fail with permission error
-					w.WriteHeader(422)
-					_, _ = w.Write([]byte(`{"message": "GitHub Actions is not permitted to approve pull requests."}`))
-				} else {
-					// Second attempt: verify action is now COMMENT
-					var req github.PullRequestReviewRequest
-					_ = json.NewDecoder(r.Body).Decode(&req)
-					assert.Equal(t, "COMMENT", *req.Event)
+					assert.Equal(t, 0, len(req.Comments))
+					assert.Contains(t, *req.Body, "Detailed Inline Feedback (Fallback)")
 					w.WriteHeader(http.StatusCreated)
 					_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
 				}
@@ -769,5 +317,28 @@ func TestPostStructuredReview_PermissionFallback(t *testing.T) {
 
 	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, callCount)
+}
+
+func TestDismissPreviousReviews(t *testing.T) {
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(mock.GetUser, github.User{Login: github.Ptr("me")}),
+		mock.WithRequestMatch(
+			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
+			[]github.PullRequestReview{
+				{ID: github.Ptr(int64(1)), Body: github.Ptr("old <!-- tag -->"), State: github.Ptr("APPROVED")},
+				{ID: github.Ptr(int64(789)), Body: github.Ptr("current <!-- tag -->"), State: github.Ptr("PENDING")},
+			},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PutReposPullsReviewsDismissalsByOwnerByRepoByPullNumberByReviewId,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(1))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := dismissPreviousReviews(context.Background(), client, "owner", "repo", 1, "<!-- tag -->", 789)
+	assert.NoError(t, err)
 }

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -502,3 +502,44 @@ func TestPostComment_UserGetError(t *testing.T) {
 	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "tag")
 	assert.NoError(t, err)
 }
+
+func TestPostComment_Pagination(t *testing.T) {
+	tmpDir := t.TempDir()
+	bodyFile := filepath.Join(tmpDir, "body.md")
+	err := os.WriteFile(bodyFile, []byte("test body"), 0o644)
+	assert.NoError(t, err)
+
+	// Custom handler to simulate pagination
+	callCount := 0
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
+		mock.WithRequestMatchHandler(
+			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				if callCount == 1 {
+					// Page 1: return non-matching, with Link header to page 2
+					w.Header().Set("Link", `<https://api.github.com/repositories/1/issues/1/comments?page=2>; rel="next"`)
+					comments := []github.IssueComment{{ID: github.Ptr(int64(1)), Body: github.Ptr("no tag"), User: &github.User{Login: github.Ptr("me")}}}
+					_, _ = w.Write(mock.MustMarshal(comments))
+				} else {
+					// Page 2: return matching
+					comments := []github.IssueComment{{ID: github.Ptr(int64(2)), Body: github.Ptr("found <!-- cassandra-main-tag -->"), User: &github.User{Login: github.Ptr("me")}}}
+					_, _ = w.Write(mock.MustMarshal(comments))
+				}
+			}),
+		),
+		mock.WithRequestMatch(
+			mock.PatchReposIssuesCommentsByOwnerByRepoByCommentId,
+			github.IssueComment{ID: github.Ptr(int64(2))},
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "tag")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+}

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -309,7 +309,8 @@ func TestPostStructuredReview(t *testing.T) {
 				// Only one comment should be present (the non-duplicate)
 				assert.Equal(t, 1, len(req.Comments))
 				assert.Equal(t, "file1.go", *req.Comments[0].Path)
-				assert.Equal(t, "New comment", *req.Comments[0].Body)
+				assert.Contains(t, *req.Comments[0].Body, "New comment")
+				assert.Contains(t, *req.Comments[0].Body, "<!-- tag -->")
 				assert.Equal(t, 10, *req.Comments[0].Line)
 
 				w.WriteHeader(http.StatusCreated)

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v69/github"
+	"github.com/menny/cassandra/core"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/stretchr/testify/assert"
 )
@@ -247,4 +249,120 @@ func TestGetMetadata(t *testing.T) {
 		assert.False(t, metadata.Comments[0].IsSelf)
 		assert.False(t, metadata.Comments[1].IsSelf)
 	})
+}
+
+func TestPostStructuredReview(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+	metadataFile := filepath.Join(tmpDir, "metadata.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  true,
+			Rationale: "LGTM!",
+			Action:    "APPROVE",
+		},
+		NonSpecificReview: "General feedback",
+		FilesReview: []core.FileReview{
+			{
+				Path:   "file1.go",
+				Lines:  "10",
+				Review: "New comment",
+			},
+			{
+				Path:   "file2.go",
+				Lines:  "20-25",
+				Review: "Duplicate comment",
+			},
+		},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	metadata := core.PRMetadata{
+		Comments: []core.PRComment{
+			{
+				Author: "cassandra",
+				IsSelf: true,
+				Path:   "file2.go",
+				Line:   25,
+				Body:   "Duplicate comment <!-- tag -->",
+				Date:   time.Now(),
+			},
+		},
+	}
+	metadataBytes, _ := json.Marshal(metadata)
+	_ = os.WriteFile(metadataFile, metadataBytes, 0o644)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				assert.Equal(t, "APPROVE", *req.Event)
+				assert.Contains(t, *req.Body, "LGTM!")
+				assert.Contains(t, *req.Body, "General feedback")
+				assert.Contains(t, *req.Body, "<!-- tag -->")
+
+				// Only one comment should be present (the non-duplicate)
+				assert.Equal(t, 1, len(req.Comments))
+				assert.Equal(t, "file1.go", *req.Comments[0].Path)
+				assert.Equal(t, "New comment", *req.Comments[0].Body)
+				assert.Equal(t, 10, *req.Comments[0].Line)
+
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", metadataFile)
+	assert.NoError(t, err)
+}
+
+func TestPostStructuredReview_NoMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  false,
+			Rationale: "Issues found",
+			Action:    "REQUEST_CHANGES",
+		},
+		FilesReview: []core.FileReview{
+			{
+				Path:   "file1.go",
+				Lines:  "5-10",
+				Review: "Range comment",
+			},
+		},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				assert.Equal(t, "REQUEST_CHANGES", *req.Event)
+				assert.Equal(t, 1, len(req.Comments))
+				assert.Equal(t, 5, *req.Comments[0].StartLine)
+				assert.Equal(t, 10, *req.Comments[0].Line)
+
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "")
+	assert.NoError(t, err)
 }

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -75,6 +75,10 @@ func TestPostComment_Create(t *testing.T) {
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
+		mock.WithRequestMatch(
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			[]github.IssueComment{}, // No existing comments
 		),
@@ -97,11 +101,16 @@ func TestPostComment_Update(t *testing.T) {
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
+		mock.WithRequestMatch(
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			[]github.IssueComment{
 				{
 					ID:   github.Ptr(int64(456)),
 					Body: github.Ptr("old body <!-- tag -->"),
+					User: &github.User{Login: github.Ptr("me")},
 				},
 			},
 		),
@@ -125,6 +134,10 @@ func TestPostComment_Pagination(t *testing.T) {
 	// Custom handler to simulate pagination
 	callCount := 0
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -132,11 +145,11 @@ func TestPostComment_Pagination(t *testing.T) {
 				if callCount == 1 {
 					// Page 1: return non-matching, with Link header to page 2
 					w.Header().Set("Link", `<https://api.github.com/repositories/1/issues/1/comments?page=2>; rel="next"`)
-					comments := []github.IssueComment{{ID: github.Ptr(int64(1)), Body: github.Ptr("no tag")}}
+					comments := []github.IssueComment{{ID: github.Ptr(int64(1)), Body: github.Ptr("no tag"), User: &github.User{Login: github.Ptr("other")}}}
 					_, _ = w.Write(mock.MustMarshal(comments))
 				} else {
 					// Page 2: return matching
-					comments := []github.IssueComment{{ID: github.Ptr(int64(2)), Body: github.Ptr("found <!-- tag -->")}}
+					comments := []github.IssueComment{{ID: github.Ptr(int64(2)), Body: github.Ptr("found <!-- tag -->"), User: &github.User{Login: github.Ptr("me")}}}
 					_, _ = w.Write(mock.MustMarshal(comments))
 				}
 			}),
@@ -168,15 +181,21 @@ func TestPostComment_Latest(t *testing.T) {
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
+		mock.WithRequestMatch(
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			[]github.IssueComment{
 				{
 					ID:   github.Ptr(int64(1)),
 					Body: github.Ptr("old body <!-- tag -->"),
+					User: &github.User{Login: github.Ptr("me")},
 				},
 				{
 					ID:   github.Ptr(int64(2)),
 					Body: github.Ptr("newer body <!-- tag -->"),
+					User: &github.User{Login: github.Ptr("me")},
 				},
 			},
 		),
@@ -219,7 +238,7 @@ func TestGetMetadata(t *testing.T) {
 				[]github.PullRequestComment{
 					{
 						User:      &github.User{Login: github.Ptr("cassandra")},
-						Body:      github.Ptr("comment 2 <!-- tag-a -->"),
+						Body:      github.Ptr("comment 2 <!-- comment-tag-a -->"),
 						CreatedAt: &github.Timestamp{Time: time.Now()},
 						Path:      github.Ptr("file.go"),
 						Line:      github.Ptr(10),
@@ -282,11 +301,11 @@ func TestPostStructuredReview(t *testing.T) {
 	metadata := core.PRMetadata{
 		Comments: []core.PRComment{
 			{
-				Author: "cassandra",
+				Author: "me",
 				IsSelf: true,
 				Path:   "file2.go",
 				Line:   25,
-				Body:   "Duplicate comment <!-- tag -->",
+				Body:   "Duplicate comment <!-- comment-tag -->",
 				Date:   time.Now(),
 			},
 		},
@@ -295,6 +314,10 @@ func TestPostStructuredReview(t *testing.T) {
 	_ = os.WriteFile(metadataFile, metadataBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatch(
 			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
 			[]github.IssueComment{},
@@ -324,7 +347,7 @@ func TestPostStructuredReview(t *testing.T) {
 				assert.Equal(t, 1, len(req.Comments))
 				assert.Equal(t, "file1.go", *req.Comments[0].Path)
 				assert.Contains(t, *req.Comments[0].Body, "New comment")
-				assert.Contains(t, *req.Comments[0].Body, "<!-- tag -->")
+				assert.Contains(t, *req.Comments[0].Body, "<!-- comment-tag -->")
 				assert.Equal(t, 10, *req.Comments[0].Line)
 
 				w.WriteHeader(http.StatusCreated)
@@ -360,6 +383,10 @@ func TestPostStructuredReview_NoMetadata(t *testing.T) {
 	_ = os.WriteFile(srFile, srBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -398,6 +425,10 @@ func TestPostStructuredReview_OverrideAction(t *testing.T) {
 	_ = os.WriteFile(srFile, srBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -419,6 +450,10 @@ func TestPostStructuredReview_OverrideAction(t *testing.T) {
 
 func TestDismissPreviousReviews(t *testing.T) {
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatch(
 			mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
 			[]github.PullRequestReview{
@@ -481,6 +516,10 @@ func TestPostStructuredReview_422Fallback(t *testing.T) {
 
 	callCount := 0
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -537,6 +576,10 @@ func TestPostStructuredReview_WhitespaceAndOrder(t *testing.T) {
 	_ = os.WriteFile(srFile, srBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -589,6 +632,10 @@ func TestPostStructuredReview_FileLevel(t *testing.T) {
 	_ = os.WriteFile(srFile, srBytes, 0o644)
 
 	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetUser,
+			github.User{Login: github.Ptr("me")},
+		),
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -320,7 +320,7 @@ func TestPostStructuredReview(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", metadataFile)
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", metadataFile, true)
 	assert.NoError(t, err)
 }
 
@@ -364,6 +364,41 @@ func TestPostStructuredReview_NoMetadata(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "")
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
+	assert.NoError(t, err)
+}
+
+func TestPostStructuredReview_OverrideAction(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval: core.Approval{
+			Approved:  true,
+			Rationale: "LGTM!",
+			Action:    "APPROVE",
+		},
+		FilesReview: []core.FileReview{},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				assert.Equal(t, "COMMENT", *req.Event) // Overridden from APPROVE to COMMENT
+
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", false) // allowReviewAction = false
 	assert.NoError(t, err)
 }

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -656,3 +656,39 @@ func TestPostStructuredReview_FileLevel(t *testing.T) {
 	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "<!-- tag -->", "", true)
 	assert.NoError(t, err)
 }
+
+func TestPostComment_UserGetError(t *testing.T) {
+	tmpDir := t.TempDir()
+	bodyFile := filepath.Join(tmpDir, "body.md")
+	err := os.WriteFile(bodyFile, []byte("test body"), 0o644)
+	assert.NoError(t, err)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.GetUser,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"message": "Resource not accessible by integration"}`))
+			}),
+		),
+		mock.WithRequestMatch(
+			mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber,
+			[]github.IssueComment{
+				{
+					ID:   github.Ptr(int64(456)),
+					Body: github.Ptr("old body <!-- tag -->"),
+					User: &github.User{Login: github.Ptr("any-user")},
+				},
+			},
+		),
+		mock.WithRequestMatch(
+			mock.PatchReposIssuesCommentsByOwnerByRepoByCommentId,
+			github.IssueComment{ID: github.Ptr(int64(456))},
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	// Should NOT error even if GetUser fails
+	err = postComment(context.Background(), client, "owner", "repo", 1, bodyFile, "<!-- tag -->")
+	assert.NoError(t, err)
+}

--- a/cmd/github/main_test.go
+++ b/cmd/github/main_test.go
@@ -252,9 +252,6 @@ func TestPostStructuredReview(t *testing.T) {
 		mock.WithRequestMatchHandler(
 			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var req github.PullRequestReviewRequest
-				_ = json.NewDecoder(r.Body).Decode(&req)
-				assert.Contains(t, *req.Body, "<!-- tag -->")
 				w.WriteHeader(http.StatusCreated)
 				_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
 			}),
@@ -334,9 +331,11 @@ func TestPostStructuredReview_422Fallback(t *testing.T) {
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				callCount++
 				if callCount == 1 {
+					// First attempt: fail with 422
 					w.WriteHeader(422)
 					_, _ = w.Write([]byte(`{"message": "Unprocessable Entity"}`))
 				} else {
+					// Second attempt: verify fallback payload (comments stripped)
 					var req github.PullRequestReviewRequest
 					_ = json.NewDecoder(r.Body).Decode(&req)
 					assert.Equal(t, 0, len(req.Comments))
@@ -372,7 +371,7 @@ func TestDismissPreviousReviews(t *testing.T) {
 	)
 	client := github.NewClient(mockedHTTPClient)
 
-	err := dismissPreviousReviews(context.Background(), client, "owner", "repo", 1, "<!-- tag -->", 789)
+	err := dismissPreviousReviews(context.Background(), client, "owner", "repo", 1, "tag", 789)
 	assert.NoError(t, err)
 }
 
@@ -382,7 +381,7 @@ func TestPostStructuredReview_PermissionFallback(t *testing.T) {
 
 	sr := core.StructuredReview{
 		Approval:    core.Approval{Approved: true, Rationale: "Summary", Action: "APPROVE"},
-		FilesReview: []core.FileReview{},
+		FilesReview: []core.FileReview{{Path: "file1.go", Lines: "10", Review: "Valid"}},
 	}
 	srBytes, _ := json.Marshal(sr)
 	_ = os.WriteFile(srFile, srBytes, 0o644)
@@ -397,12 +396,15 @@ func TestPostStructuredReview_PermissionFallback(t *testing.T) {
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				callCount++
 				if callCount == 1 {
+					// First attempt: fail with permission error
 					w.WriteHeader(422)
 					_, _ = w.Write([]byte(`{"message": "GitHub Actions is not permitted to approve pull requests."}`))
 				} else {
+					// Second attempt: verify action is now COMMENT but comments are STILL PRESENT
 					var req github.PullRequestReviewRequest
 					_ = json.NewDecoder(r.Body).Decode(&req)
 					assert.Equal(t, "COMMENT", *req.Event)
+					assert.Equal(t, 1, len(req.Comments)) // Comments preserved!
 					w.WriteHeader(http.StatusCreated)
 					_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
 				}
@@ -414,6 +416,56 @@ func TestPostStructuredReview_PermissionFallback(t *testing.T) {
 	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "tag", "", true, true)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, callCount)
+}
+
+func TestPostStructuredReview_PermissionAndHallucinationFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	srFile := filepath.Join(tmpDir, "review.json")
+
+	sr := core.StructuredReview{
+		Approval:    core.Approval{Approved: true, Rationale: "Summary", Action: "APPROVE"},
+		FilesReview: []core.FileReview{{Path: "file.go", Lines: "999", Review: "Hallucinated"}},
+	}
+	srBytes, _ := json.Marshal(sr)
+	_ = os.WriteFile(srFile, srBytes, 0o644)
+
+	callCount := 0
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(mock.GetUser, github.User{Login: github.Ptr("me")}),
+		mock.WithRequestMatch(mock.GetReposIssuesCommentsByOwnerByRepoByIssueNumber, []github.IssueComment{}),
+		mock.WithRequestMatch(mock.GetReposPullsReviewsByOwnerByRepoByPullNumber, []github.PullRequestReview{}),
+		mock.WithRequestMatchHandler(
+			mock.PostReposPullsReviewsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				var req github.PullRequestReviewRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				if callCount == 1 {
+					// First attempt: permission fail
+					w.WriteHeader(422)
+					_, _ = w.Write([]byte(`{"message": "GitHub Actions is not permitted to approve pull requests."}`))
+				} else if callCount == 2 {
+					// Second attempt: retry with COMMENT, but still has bad line, so 422 again
+					assert.Equal(t, "COMMENT", *req.Event)
+					assert.Equal(t, 1, len(req.Comments))
+					w.WriteHeader(422)
+					_, _ = w.Write([]byte(`{"message": "Unprocessable Entity"}`))
+				} else {
+					// Final attempt: comments stripped
+					assert.Equal(t, 0, len(req.Comments))
+					assert.Contains(t, *req.Body, "Detailed Inline Feedback (Fallback)")
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write(mock.MustMarshal(github.PullRequestReview{ID: github.Ptr(int64(789))}))
+				}
+			}),
+		),
+	)
+	client := github.NewClient(mockedHTTPClient)
+
+	err := postStructuredReview(context.Background(), client, "owner", "repo", 1, srFile, "tag", "", true, true)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, callCount)
 }
 
 func TestPostComment_UserGetError(t *testing.T) {

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -20,9 +20,11 @@ go_test(
     srcs = [
         "agent_test.go",
         "io_util_test.go",
+        "review_types_test.go",
     ],
     embed = [":core"],
     deps = [
         "//llm",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/core/github.go
+++ b/core/github.go
@@ -16,11 +16,13 @@ type PRMetadata struct {
 
 // PRComment represents a single comment on a pull request.
 type PRComment struct {
-	Author    string    `json:"author"`
-	Body      string    `json:"body"`
-	IsSelf    bool      `json:"is_self"`
-	Date      time.Time `json:"date"`
-	Path      string    `json:"path,omitempty"`
-	Line      int       `json:"line,omitempty"`
-	StartLine int       `json:"start_line,omitempty"`
+	ID         int64     `json:"id"`
+	Author     string    `json:"author"`
+	Body       string    `json:"body"`
+	IsSelf     bool      `json:"is_self"`
+	Date       time.Time `json:"date"`
+	Path       string    `json:"path,omitempty"`
+	Line       int       `json:"line,omitempty"`
+	StartLine  int       `json:"start_line,omitempty"`
+	IsOutdated bool      `json:"is_outdated"`
 }

--- a/core/prompts/extraction_prompt.md
+++ b/core/prompts/extraction_prompt.md
@@ -7,6 +7,10 @@ You are an expert code review parser. Your task is to take a raw markdown code r
 1. **Approval**:
    - `approved`: This must be a strict boolean (true/false). If the review contains a clear approval (e.g., "LGTM", "Looks good"), set to `true`. If there are blocking issues or a clear rejection, set to `false`.
    - `rationale`: Provide a brief, high-level summary of the reasoning behind the approval or rejection.
+   - `action`: Map the review sentiment to one of:
+     - `APPROVE`: If `approved` is true and there are no major issues.
+     - `REQUEST_CHANGES`: If `approved` is false and there are blocking issues.
+     - `COMMENT`: If the review is neutral or contains only suggestions without a clear approval/rejection.
 2. **Non-Specific Review**: If the review contains general comments that aren't tied to a specific file or line range (e.g., architecture, consistency, high-level logic), include them in the `non_specific_review` field.
 3. **Files Review**:
    - `path`: The relative path to the file.

--- a/core/review_types.go
+++ b/core/review_types.go
@@ -37,7 +37,7 @@ func (fr *FileReview) ParseLines() (int, int, error) {
 
 	parts := strings.Split(fr.Lines, "-")
 	if len(parts) == 1 {
-		line, err := strconv.Atoi(parts[0])
+		line, err := strconv.Atoi(strings.TrimSpace(parts[0]))
 		if err != nil {
 			return 0, 0, fmt.Errorf("invalid line format: %v", err)
 		}
@@ -45,13 +45,17 @@ func (fr *FileReview) ParseLines() (int, int, error) {
 	}
 
 	if len(parts) == 2 {
-		startLine, err := strconv.Atoi(parts[0])
+		startLine, err := strconv.Atoi(strings.TrimSpace(parts[0]))
 		if err != nil {
 			return 0, 0, fmt.Errorf("invalid start line format: %v", err)
 		}
-		endLine, err := strconv.Atoi(parts[1])
+		endLine, err := strconv.Atoi(strings.TrimSpace(parts[1]))
 		if err != nil {
 			return 0, 0, fmt.Errorf("invalid end line format: %v", err)
+		}
+
+		if startLine > endLine {
+			return endLine, startLine, nil
 		}
 		return startLine, endLine, nil
 	}

--- a/core/review_types.go
+++ b/core/review_types.go
@@ -1,5 +1,11 @@
 package core
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // StructuredReview represents the final extracted code review in a machine-readable format.
 type StructuredReview struct {
 	RawFreeText       string       `json:"raw_free_text"`
@@ -12,6 +18,7 @@ type StructuredReview struct {
 type Approval struct {
 	Approved  bool   `json:"approved"`
 	Rationale string `json:"rationale"`
+	Action    string `json:"action,omitempty"` // The GitHub review action: "APPROVE", "REQUEST_CHANGES", "COMMENT".
 }
 
 // FileReview represents feedback for a specific part of a file.
@@ -19,6 +26,37 @@ type FileReview struct {
 	Path   string `json:"path"`
 	Lines  string `json:"lines,omitempty"` // A single line ("42") or a single range ("10-25").
 	Review string `json:"review"`
+}
+
+// ParseLines parses the 'lines' string into individual line numbers.
+// Returns startLine and endLine. For single lines, startLine == endLine.
+func (fr *FileReview) ParseLines() (int, int, error) {
+	if fr.Lines == "" {
+		return 0, 0, nil
+	}
+
+	parts := strings.Split(fr.Lines, "-")
+	if len(parts) == 1 {
+		line, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid line format: %v", err)
+		}
+		return line, line, nil
+	}
+
+	if len(parts) == 2 {
+		startLine, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid start line format: %v", err)
+		}
+		endLine, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid end line format: %v", err)
+		}
+		return startLine, endLine, nil
+	}
+
+	return 0, 0, fmt.Errorf("invalid lines format: %s", fr.Lines)
 }
 
 // StructuredReviewSchema is the JSON Schema representation of StructuredReview.
@@ -39,8 +77,13 @@ var StructuredReviewSchema = map[string]any{
 					"type":        "string",
 					"description": "The high-level reasoning for the approval or rejection.",
 				},
+				"action": map[string]any{
+					"type":        "string",
+					"description": "The GitHub review action: 'APPROVE' if approved, 'REQUEST_CHANGES' if there are issues, or 'COMMENT' for neutral feedback.",
+					"enum":        []string{"APPROVE", "REQUEST_CHANGES", "COMMENT"},
+				},
 			},
-			"required": []string{"approved", "rationale"},
+			"required": []string{"approved", "rationale", "action"},
 		},
 		"non_specific_review": map[string]any{
 			"type":        "string",

--- a/core/review_types_test.go
+++ b/core/review_types_test.go
@@ -1,0 +1,94 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileReview_ParseLines(t *testing.T) {
+	tests := []struct {
+		name      string
+		lines     string
+		wantStart int
+		wantEnd   int
+		wantErr   bool
+	}{
+		{
+			name:      "empty string",
+			lines:     "",
+			wantStart: 0,
+			wantEnd:   0,
+			wantErr:   false,
+		},
+		{
+			name:      "single line",
+			lines:     "42",
+			wantStart: 42,
+			wantEnd:   42,
+			wantErr:   false,
+		},
+		{
+			name:      "single line with whitespace",
+			lines:     " 42 ",
+			wantStart: 42,
+			wantEnd:   42,
+			wantErr:   false,
+		},
+		{
+			name:      "valid range",
+			lines:     "10-20",
+			wantStart: 10,
+			wantEnd:   20,
+			wantErr:   false,
+		},
+		{
+			name:      "valid range with whitespace",
+			lines:     " 10 - 20 ",
+			wantStart: 10,
+			wantEnd:   20,
+			wantErr:   false,
+		},
+		{
+			name:      "inverted range",
+			lines:     "20-10",
+			wantStart: 10,
+			wantEnd:   20,
+			wantErr:   false,
+		},
+		{
+			name:    "invalid single line",
+			lines:   "abc",
+			wantErr: true,
+		},
+		{
+			name:    "invalid range start",
+			lines:   "abc-20",
+			wantErr: true,
+		},
+		{
+			name:    "invalid range end",
+			lines:   "10-abc",
+			wantErr: true,
+		},
+		{
+			name:    "too many hyphens",
+			lines:   "10-20-30",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fr := &FileReview{Lines: tt.lines}
+			gotStart, gotEnd, err := fr.ParseLines()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantStart, gotStart)
+				assert.Equal(t, tt.wantEnd, gotEnd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implement support for posting inline comments to GitHub PRs based on structured AI review output.

This PR provides a hardened implementation of inline reviews:
- **Separated Feedback**: Distinguishes between 'main' architectural comments and 'atomic' inline line-level feedback.
- **Robust Tagging**: Uses unique tags for different comment types to ensure accurate deduplication and identification.
- **Resilience**: Includes a 422 error fallback to prevent lost reviews due to LLM line hallucinations.
- **Safety**: Validates review actions and author identity before performing updates.
- **Configurable**: Controllable via `use_inline_comments` and `submit_review_action` flags in `action.yml`.

Fixes #26