### PR TITLE
feat: extend review approval for 'comment' when uncertain

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,6 +12,9 @@ The system is designed as a CLI-driven, autonomous AI worker. It acts essentiall
 - **Main Guidelines**: Defaults to `general`. This can be:
   - A path to a local Markdown file (absolute or relative to the current directory).
   - The name of a pre-defined prompt from the internal library (e.g., `asana-do-try-consider`, `google`, `palantir`).
+- **Approval Evaluation Guidelines**: Defines the criteria for `APPROVE`, `REJECT`, and `COMMENT` verdicts.
+  - Defaults to an internal "velocity-first" prompt.
+  - Can be overridden via `--approval-evaluation-prompt-file`.
 - Coordinates the flow from git diff extraction to system prompt building, and finally running the review agent.
 
 ### 2. GitHub Utility (`cmd/github/main.go`)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ To review changes between a base and a head commit/branch:
 | `--model` | LLM provider's specific model ID | | **Yes** |
 | `--provider-api-key` | API key for the selected provider | | **Yes** |
 | `--main-guidelines` | Path to a file or a named prompt from the library (`general`, `asana-do-try-consider`, `google`, `conventional-comments`, `palantir`, `minimalist`, `security-first`) | `general` | No |
+| `--approval-evaluation-prompt-file` | Path to a file containing custom approval evaluation guidelines | | No |
 | `--review-output-file` | Path to a file where the final review will be written | | No |
 | `--output-json` | Path to a file where the structured JSON review will be written | | No |
 | `--extraction-model` | Optional model override for the structured JSON extraction pass | | No |
@@ -69,6 +70,7 @@ To review changes between a base and a head commit/branch:
 | `head` | Head commit/branch for diff | `HEAD` | No |
 | `working_directory` | Working directory to review | `.` | No |
 | `main_guidelines` | Path to a file or a named prompt from the library (`general`, `asana-do-try-consider`, `google`, `conventional-comments`, `palantir`, `minimalist`, `security-first`) | `general` | No |
+| `approval_evaluation_prompt_file` | Path to a file containing custom approval evaluation guidelines | | No |
 | `metadata_tag` | Tag to identify Cassandra comments (inner text only, will be wrapped in `<!-- ... -->`) | `cassandra-ai-review-${{ github.workflow }}` | No |
 | `reaction_icon` | The reaction icon to add to the PR description while the review is in progress (e.g., `eyes`, `rocket`, `heart`) | `eyes` | No |
 | `reviewer_github_token` | GitHub token for posting comments and reactions | `${{ github.token }}` | No |

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Path to a file or a named prompt from the library (general, asana-do-try-consider, google, conventional-comments, palantir, minimalist, security-first)'
     required: false
     default: 'general'
+  approval_evaluation_prompt_file:
+    description: 'Optional path to a file containing custom approval evaluation guidelines'
+    required: false
+    default: ''
   metadata_tag:
     description: 'Tag to identify Cassandra comments (inner text only, will be wrapped in <!-- ... -->)'
     required: false
@@ -119,6 +123,7 @@ runs:
         HEAD: ${{ inputs.head }}
         WORKING_DIRECTORY: ${{ inputs.working_directory }}
         MAIN_GUIDELINES: ${{ inputs.main_guidelines }}
+        APPROVAL_EVALUATION_PROMPT_FILE: ${{ inputs.approval_evaluation_prompt_file }}
       run: |
         # Use temporary files for the review outputs
         REVIEW_FILE="${{ runner.temp }}/cassandra_review.md"
@@ -137,6 +142,16 @@ runs:
 
         if [[ -f "$METADATA_FILE" ]]; then
           ARGS+=(--metadata-json "$METADATA_FILE")
+        fi
+
+        if [[ -n "$APPROVAL_EVALUATION_PROMPT_FILE" ]]; then
+          EVAL_PROMPT="${{ github.workspace }}/$WORKING_DIRECTORY/$APPROVAL_EVALUATION_PROMPT_FILE"
+          if [[ -f "$EVAL_PROMPT" ]]; then
+            ARGS+=(--approval-evaluation-prompt-file "$EVAL_PROMPT")
+          else
+            # Try it as a relative path or literal if not found in the workspace
+            ARGS+=(--approval-evaluation-prompt-file "$APPROVAL_EVALUATION_PROMPT_FILE")
+          fi
         fi
 
         # Try to resolve main guidelines:

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -34,9 +34,11 @@ func main() {
 	var outputJSONFile string
 	var extractionModel string
 	var metadataJSONFile string
+	var approvalEvaluationPromptFile string
 
 	flag.StringVar(&workingDir, "cwd", "", "Working directory (defaults to BUILD_WORKSPACE_DIRECTORY or current directory)")
 	flag.StringVar(&mainGuidelines, "main-guidelines", "general", "Path to a file or a named prompt from the library")
+	flag.StringVar(&approvalEvaluationPromptFile, "approval-evaluation-prompt-file", "", "Optional path to a file containing custom approval evaluation guidelines")
 	flag.IntVar(&maxTokens, "max-tokens", 8192, "Max tokens for the LLM response")
 	flag.StringVar(&base, "base", "main", "Base commit/branch for diff")
 	flag.StringVar(&head, "head", "HEAD", "Head commit/branch for diff")
@@ -91,6 +93,15 @@ func main() {
 		log.Fatalf("Failed to resolve main guidelines: %v", err)
 	}
 
+	var approvalEvaluationContent string
+	if approvalEvaluationPromptFile != "" {
+		content, err := os.ReadFile(approvalEvaluationPromptFile)
+		if err != nil {
+			log.Fatalf("Failed to read approval evaluation prompt file: %v", err)
+		}
+		approvalEvaluationContent = string(content)
+	}
+
 	stderr.Println("=== Cassandra Configuration ===")
 	stderr.Printf("  Working Directory: %s\n", targetDir)
 	stderr.Printf("  Base: %s\n", base)
@@ -108,6 +119,9 @@ func main() {
 	}
 	if metadataJSONFile != "" {
 		stderr.Printf("  Metadata JSON: %s\n", metadataJSONFile)
+	}
+	if approvalEvaluationPromptFile != "" {
+		stderr.Printf("  Approval Evaluation Prompt File: %s\n", approvalEvaluationPromptFile)
 	}
 	stderr.Println("  API Key: [PROVIDED]")
 	stderr.Println("===============================")
@@ -158,7 +172,7 @@ func main() {
 	// Compute max ReAct iterations based on changed files.
 	maxIterations := core.CalculateMaxIterations(len(changedFiles))
 
-	systemPrompt, err := prompts.BuildSystemPrompt(targetDir, changedFiles, mainGuidelinesContent)
+	systemPrompt, err := prompts.BuildSystemPrompt(targetDir, changedFiles, mainGuidelinesContent, approvalEvaluationContent)
 	if err != nil {
 		log.Fatalf("Failed to build system prompt: %v", err)
 	}

--- a/core/prompts/approval_evaluation_prompt.md
+++ b/core/prompts/approval_evaluation_prompt.md
@@ -1,0 +1,9 @@
+# Approval Evaluation Guidelines
+
+You must decide whether to Approve, Reject, or Comment on this Pull Request based on the following criteria:
+
+- **Approve**: If you are certain that the changes are safe, mostly follow the project's guidelines, and have no blocking issues.
+- **Reject**: If you are certain that there are one or more blocking issues (bugs, security vulnerabilities, major architectural violations) that MUST be fixed before merging.
+- **Comment**: If you are uncertain whether the issues you found are blocking, or if the PR contains only non-blocking suggestions and you are not ready to provide a definitive Approve/Reject verdict.
+
+If you are unsure (which should be rare), default to **Comment**.

--- a/core/prompts/extraction_prompt.md
+++ b/core/prompts/extraction_prompt.md
@@ -5,12 +5,12 @@ You are an expert code review parser. Your task is to take a raw markdown code r
 ## Guidelines:
 
 1. **Approval**:
-   - `approved`: This must be a strict boolean (true/false). If the review contains a clear approval (e.g., "LGTM", "Looks good"), set to `true`. If there are blocking issues or a clear rejection, set to `false`.
-   - `rationale`: Provide a brief, high-level summary of the reasoning behind the approval or rejection.
+   - `approved`: This must be a strict boolean (true/false). If the review contains a clear approval (e.g., "LGTM", "Looks good", "✅ Approved"), set to `true`. If there are blocking issues, a clear rejection ("❌ Rejected"), or uncertainty ("💬 Comment"), set to `false`.
+   - `rationale`: Provide a brief, high-level summary of the reasoning behind the approval, rejection, or comment.
    - `action`: Map the review sentiment to one of:
-     - `APPROVE`: If `approved` is true and there are no major issues.
-     - `REQUEST_CHANGES`: If `approved` is false and there are blocking issues.
-     - `COMMENT`: If the review is neutral or contains only suggestions without a clear approval/rejection.
+     - `APPROVE`: If the review explicitly ends with `✅ Approved`.
+     - `REQUEST_CHANGES`: If the review explicitly ends with `❌ Rejected`.
+     - `COMMENT`: If the review ends with `💬 Comment` or is otherwise neutral/uncertain.
 2. **Non-Specific Review**: If the review contains general comments that aren't tied to a specific file or line range (e.g., architecture, consistency, high-level logic), include them in the `non_specific_review` field.
 3. **Files Review**:
    - `path`: The relative path to the file.

--- a/core/prompts/prompts.go
+++ b/core/prompts/prompts.go
@@ -14,6 +14,9 @@ var reviewerPrompt string
 //go:embed extraction_prompt.md
 var extractionPrompt string
 
+//go:embed approval_evaluation_prompt.md
+var approvalEvaluationPrompt string
+
 //go:embed library/*.md
 var libraryFS embed.FS
 
@@ -35,9 +38,13 @@ func GetLibraryPrompt(name string) (string, error) {
 // the selected general guidelines (mainGuidelinesContent), any repository-specific rules found
 // in REVIEWERS.md or AGENTS.md files, and optional personal preferences from
 // personal.ai_code_review_guidelines.md located in the workspace root.
-func BuildSystemPrompt(workspaceRoot string, changedFiles []string, mainGuidelinesContent string) (string, error) {
+func BuildSystemPrompt(workspaceRoot string, changedFiles []string, mainGuidelinesContent, approvalEvaluationContent string) (string, error) {
 	if mainGuidelinesContent == "" {
 		return "", fmt.Errorf("main guidelines content is required")
+	}
+
+	if approvalEvaluationContent == "" {
+		approvalEvaluationContent = approvalEvaluationPrompt
 	}
 
 	prompt := reviewerPrompt + "\n<code_review_guidelines>\n" + mainGuidelinesContent
@@ -50,6 +57,8 @@ func BuildSystemPrompt(workspaceRoot string, changedFiles []string, mainGuidelin
 		}
 	}
 	prompt += "\n</code_review_guidelines>\n"
+
+	prompt += "\n<approval_evaluation_guidelines>\n" + approvalEvaluationContent + "\n</approval_evaluation_guidelines>\n"
 
 	personalPath := filepath.Join(workspaceRoot, "personal.ai_code_review_guidelines.md")
 	if personalBytes, err := os.ReadFile(personalPath); err == nil {

--- a/core/prompts/prompts_test.go
+++ b/core/prompts/prompts_test.go
@@ -53,13 +53,17 @@ func TestBuildSystemPrompt(t *testing.T) {
 
 	changedFiles := []string{"foo.go"}
 
-	prompt, err := BuildSystemPrompt(tmpDir, changedFiles, "Is this code maintainable, easy to work with, and safe?")
+	prompt, err := BuildSystemPrompt(tmpDir, changedFiles, "Is this code maintainable, easy to work with, and safe?", "")
 	require.NoError(t, err)
 
 	require.True(t, strings.Contains(prompt, "You are a code review bot - named Cassandra - for the provided codebase."))
 	require.True(t, strings.Contains(prompt, "<code_review_guidelines>"))
 	require.True(t, strings.Contains(prompt, "Is this code maintainable, easy to work with, and safe?"))
 	require.True(t, strings.Contains(prompt, "Skepticism of Internal Knowledge"))
+	require.True(t, strings.Contains(prompt, "<approval_evaluation_guidelines>"))
+	require.True(t, strings.Contains(prompt, "Approve"))
+	require.True(t, strings.Contains(prompt, "Reject"))
+	require.True(t, strings.Contains(prompt, "Comment"))
 
 	// Check that reviewers is inside code_review_guidelines:
 	guidelinesIndex := strings.Index(prompt, "<code_review_guidelines>")
@@ -79,10 +83,12 @@ func TestBuildSystemPrompt_Override(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 
-	prompt, err := BuildSystemPrompt(tmpDir, nil, "CUSTOM GUIDELINES HERE")
+	prompt, err := BuildSystemPrompt(tmpDir, nil, "CUSTOM GUIDELINES HERE", "CUSTOM APPROVAL HERE")
 	require.NoError(t, err)
 
 	require.True(t, strings.Contains(prompt, "You are a code review bot - named Cassandra - for the provided codebase."))
 	require.True(t, strings.Contains(prompt, "<code_review_guidelines>"))
 	require.True(t, strings.Contains(prompt, "CUSTOM GUIDELINES HERE"))
+	require.True(t, strings.Contains(prompt, "<approval_evaluation_guidelines>"))
+	require.True(t, strings.Contains(prompt, "CUSTOM APPROVAL HERE"))
 }

--- a/core/prompts/reviewer_prompt.md
+++ b/core/prompts/reviewer_prompt.md
@@ -4,6 +4,8 @@ If the input includes <agents_guidelines>, use them as area-specific correctness
 
 If the input includes <code_review_guidelines>, use them as the primary code review rules and grading system for the files being reviewed. You MUST strictly adhere to the labels, severity levels, and reviewer behavior defined in these guidelines.
 
+If the input includes <approval_evaluation_guidelines>, use them to decide whether to Approve, Reject, or Comment on the pull request. These guidelines define the threshold for each action.
+
 If the input includes <reviewer_context>, treat it as additional focus or intent provided by the person requesting the review — use it to prioritize or narrow your feedback accordingly.
 
 If the input includes <personal_review_guidelines>, treat them as the reviewer's personal preferences and style. Prioritize them over the general <code_review_guidelines> when they conflict.
@@ -42,3 +44,4 @@ Each finding MUST follow this format:
 Close with a brief positive note, then one of:
 - `✅ Approved` — no blocking items (as defined by the guidelines' grading system)
 - `❌ Rejected` — one or more blocking items must be resolved first
+- `💬 Comment` — you are uncertain or have only non-blocking suggestions (see <approval_evaluation_guidelines>)


### PR DESCRIPTION
This PR implements #32, introducing a third state to the review verdict: `💬 Comment`.

### Key Changes:
- **Default Evaluation Prompt**: Added `core/prompts/approval_evaluation_prompt.md` which defines the criteria for Approve, Reject, and Comment. It prioritizes approval velocity while allowing for a neutral Comment when the reviewer is uncertain.
- **Embedded Guidelines**: The evaluation guidelines are now embedded and injected into the main ReAct system prompt.
- **Extraction Logic**: Updated `core/prompts/extraction_prompt.md` to correctly map the `💬 Comment` verdict to a structured `COMMENT` action with `approved: false`.
- **Customizable Prompt**: Added `--approval-evaluation-prompt-file` CLI flag and a corresponding GitHub Action input to allow overriding the default guidelines.
- **Documentation**: Updated `README.md` and `DESIGN.md` to reflect the new configuration options.

Tested locally with Bazel; all tests passed.