### PR TITLE
feat: fetch diff and commits via GitHub API

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,24 @@ runs:
         cd "${{ github.action_path }}"
         bazel run //cmd/github:github -- get-metadata --repo-full-name "${{ github.repository }}" --pr "${{ github.event.pull_request.number }}" --tag "$METADATA_TAG" --output "$METADATA_FILE"
         echo "METADATA_FILE=$METADATA_FILE" >> $GITHUB_ENV
+    - name: Fetch PR Context
+      if: github.event.pull_request.number != ''
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ steps.prepare_token.outputs.token }}
+      run: |
+        DIFF_FILE="${{ runner.temp }}/cassandra_diff.diff"
+        FILES_LIST_FILE="${{ runner.temp }}/cassandra_files.txt"
+        COMMITS_FILE="${{ runner.temp }}/cassandra_commits.txt"
+
+        cd "${{ github.action_path }}"
+        bazel run //cmd/github:github -- get-diff --repo-full-name "${{ github.repository }}" --pr "${{ github.event.pull_request.number }}" --output "$DIFF_FILE"
+        bazel run //cmd/github:github -- get-files --repo-full-name "${{ github.repository }}" --pr "${{ github.event.pull_request.number }}" --output "$FILES_LIST_FILE"
+        bazel run //cmd/github:github -- get-commits --repo-full-name "${{ github.repository }}" --pr "${{ github.event.pull_request.number }}" --output "$COMMITS_FILE"
+
+        echo "DIFF_FILE=$DIFF_FILE" >> $GITHUB_ENV
+        echo "FILES_LIST_FILE=$FILES_LIST_FILE" >> $GITHUB_ENV
+        echo "COMMITS_FILE=$COMMITS_FILE" >> $GITHUB_ENV
     - name: Run AI Review
       shell: bash
       env:
@@ -142,6 +160,18 @@ runs:
 
         if [[ -f "$METADATA_FILE" ]]; then
           ARGS+=(--metadata-json "$METADATA_FILE")
+        fi
+
+        if [[ -f "$DIFF_FILE" ]]; then
+          ARGS+=(--diff-file "$DIFF_FILE")
+        fi
+
+        if [[ -f "$FILES_LIST_FILE" ]]; then
+          ARGS+=(--files-list-file "$FILES_LIST_FILE")
+        fi
+
+        if [[ -f "$COMMITS_FILE" ]]; then
+          ARGS+=(--commits-file "$COMMITS_FILE")
         fi
 
         if [[ -n "$APPROVAL_EVALUATION_PROMPT_FILE" ]]; then

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -35,6 +35,9 @@ func main() {
 	var extractionModel string
 	var metadataJSONFile string
 	var approvalEvaluationPromptFile string
+	var diffFile string
+	var filesListFile string
+	var commitsFile string
 
 	flag.StringVar(&workingDir, "cwd", "", "Working directory (defaults to BUILD_WORKSPACE_DIRECTORY or current directory)")
 	flag.StringVar(&mainGuidelines, "main-guidelines", "general", "Path to a file or a named prompt from the library")
@@ -46,6 +49,9 @@ func main() {
 	flag.StringVar(&outputJSONFile, "output-json", "", "Path to a file where the structured JSON review will be written")
 	flag.StringVar(&extractionModel, "extraction-model", "", "Optional model override for the structured JSON extraction pass (requires --output-json)")
 	flag.StringVar(&metadataJSONFile, "metadata-json", "", "Path to a JSON file containing PR metadata")
+	flag.StringVar(&diffFile, "diff-file", "", "Path to a file containing the git diff")
+	flag.StringVar(&filesListFile, "files-list-file", "", "Path to a file containing the list of changed files (one per line)")
+	flag.StringVar(&commitsFile, "commits-file", "", "Path to a file containing the commit messages")
 
 	flag.StringVar(&modelName, "model", "", "LLM provider's model id (e.g. gemini-3-flash-preview, claude-3-7-sonnet-20250219)")
 	flag.StringVar(&provider, "provider", "", "LLM provider to use (google, anthropic)")
@@ -140,20 +146,68 @@ func main() {
 
 	agent := core.NewAgent(client, registry)
 
-	var requestText string
+	var diffOutput string
 	var changedFiles []string
-	diffOutput, files, err := tools.FetchGitDiff(targetDir, base, head)
-	if err != nil {
-		log.Fatalf("Failed to extract git diff: %v", err)
+	var commitsOutput string
+
+	if diffFile != "" && filesListFile != "" {
+		diffBytes, err := os.ReadFile(diffFile)
+		if err != nil {
+			log.Fatalf("Failed to read diff file %s: %v", diffFile, err)
+		}
+		diffOutput = string(diffBytes)
+
+		filesBytes, err := os.ReadFile(filesListFile)
+		if err != nil {
+			log.Fatalf("Failed to read files list file %s: %v", filesListFile, err)
+		}
+		lines := strings.Split(strings.TrimSpace(string(filesBytes)), "\n")
+		for _, line := range lines {
+			if f := strings.TrimSpace(line); f != "" {
+				changedFiles = append(changedFiles, f)
+			}
+		}
+	} else {
+		stderr.Println("Fetching git diff locally...")
+		var err error
+		diffOutput, changedFiles, err = tools.FetchGitDiff(targetDir, base, head)
+		if err != nil {
+			log.Fatalf("Failed to extract git diff: %v", err)
+		}
 	}
 
-	if len(files) == 0 {
+	if commitsFile != "" {
+		commitsBytes, err := os.ReadFile(commitsFile)
+		if err != nil {
+			log.Fatalf("Failed to read commits file %s: %v", commitsFile, err)
+		}
+		commitsOutput = string(commitsBytes)
+	} else {
+		stderr.Println("Fetching git commits locally...")
+		commits, err := tools.FetchGitCommits(targetDir, base, head)
+		if err != nil {
+			// Don't fail if commits fetching fails (e.g. shallow clone), just log it
+			stderr.Printf("Warning: failed to fetch git commits: %v\n", err)
+		} else {
+			commitsOutput = commits
+		}
+	}
+
+	if len(changedFiles) == 0 {
 		stderr.Println("No changes found to review.")
 		os.Exit(0)
 	}
 
-	requestText = fmt.Sprintf("Review the following git diff for issues:\n\n%s", diffOutput)
-	changedFiles = files
+	var requestTextBuilder strings.Builder
+	if commitsOutput != "" {
+		requestTextBuilder.WriteString("### Commit Messages\n")
+		requestTextBuilder.WriteString(commitsOutput)
+		requestTextBuilder.WriteString("\n\n")
+	}
+	requestTextBuilder.WriteString("Review the following git diff for issues:\n\n")
+	requestTextBuilder.WriteString(diffOutput)
+
+	requestText := requestTextBuilder.String()
 
 	if metadataJSONFile != "" {
 		metadataBytes, err := os.ReadFile(metadataJSONFile)

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -150,7 +150,11 @@ func main() {
 	var changedFiles []string
 	var commitsOutput string
 
-	if diffFile != "" && filesListFile != "" {
+	if diffFile != "" || filesListFile != "" {
+		if diffFile == "" || filesListFile == "" {
+			log.Fatal("Both --diff-file and --files-list-file must be provided together.")
+		}
+
 		diffBytes, err := os.ReadFile(diffFile)
 		if err != nil {
 			log.Fatalf("Failed to read diff file %s: %v", diffFile, err)

--- a/cmd/github/BUILD.bazel
+++ b/cmd/github/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//core",
+        "//tools",
         "@com_github_google_go_github_v69//github",
         "@com_github_spf13_pflag//:pflag",
     ],

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	if len(flag.Args()) < 1 {
-		log.Fatal("Action required (add-reaction, remove-reaction, post-comment, get-metadata)")
+		log.Fatal("Action required (add-reaction, remove-reaction, post-comment, post-structured-review, get-metadata, get-diff, get-files, get-commits)")
 	}
 
 	// Process tag: only the inner text is provided.
@@ -125,6 +125,47 @@ func main() {
 			}
 		} else {
 			fmt.Println(string(bytes))
+		}
+
+	case "get-diff":
+		diff, err := getDiff(ctx, client, owner, repo, prNumber)
+		if err != nil {
+			log.Fatalf("Failed to get diff: %v", err)
+		}
+		if outputFile != "" {
+			if err := os.WriteFile(outputFile, []byte(diff), 0o644); err != nil {
+				log.Fatalf("Failed to write diff to %s: %v", outputFile, err)
+			}
+		} else {
+			fmt.Println(diff)
+		}
+
+	case "get-files":
+		files, err := getFiles(ctx, client, owner, repo, prNumber)
+		if err != nil {
+			log.Fatalf("Failed to get files: %v", err)
+		}
+		content := strings.Join(files, "\n")
+		if outputFile != "" {
+			if err := os.WriteFile(outputFile, []byte(content), 0o644); err != nil {
+				log.Fatalf("Failed to write files to %s: %v", outputFile, err)
+			}
+		} else {
+			fmt.Println(content)
+		}
+
+	case "get-commits":
+		commits, err := getCommits(ctx, client, owner, repo, prNumber)
+		if err != nil {
+			log.Fatalf("Failed to get commits: %v", err)
+		}
+		content := strings.Join(commits, "\n")
+		if outputFile != "" {
+			if err := os.WriteFile(outputFile, []byte(content), 0o644); err != nil {
+				log.Fatalf("Failed to write commits to %s: %v", outputFile, err)
+			}
+		} else {
+			fmt.Println(content)
 		}
 
 	default:
@@ -517,4 +558,63 @@ func dismissPreviousReviews(ctx context.Context, client *github.Client, owner, r
 		opts.Page = resp.NextPage
 	}
 	return nil
+}
+
+func getDiff(ctx context.Context, client *github.Client, owner, repo string, prNumber int) (string, error) {
+	diff, _, err := client.PullRequests.GetRaw(ctx, owner, repo, prNumber, github.RawOptions{Type: github.Diff})
+	return diff, err
+}
+
+func getFiles(ctx context.Context, client *github.Client, owner, repo string, prNumber int) ([]string, error) {
+	opts := &github.ListOptions{
+		PerPage: 100,
+	}
+	var allFiles []string
+	lockFiles := []string{"go.sum", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "Cargo.lock", "poetry.lock", "Gemfile.lock"}
+
+	for {
+		files, resp, err := client.PullRequests.ListFiles(ctx, owner, repo, prNumber, opts)
+		if err != nil {
+			return nil, err
+		}
+		for _, f := range files {
+			path := f.GetFilename()
+			isLockFile := false
+			for _, lf := range lockFiles {
+				if strings.Contains(path, lf) {
+					isLockFile = true
+					break
+				}
+			}
+			if !isLockFile {
+				allFiles = append(allFiles, path)
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return allFiles, nil
+}
+
+func getCommits(ctx context.Context, client *github.Client, owner, repo string, prNumber int) ([]string, error) {
+	opts := &github.ListOptions{
+		PerPage: 100,
+	}
+	var allCommits []string
+	for {
+		commits, resp, err := client.PullRequests.ListCommits(ctx, owner, repo, prNumber, opts)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range commits {
+			allCommits = append(allCommits, "- "+c.GetCommit().GetMessage())
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return allCommits, nil
 }

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-github/v69/github"
 	"github.com/menny/cassandra/core"
+	"github.com/menny/cassandra/tools"
 	flag "github.com/spf13/pflag"
 )
 
@@ -562,7 +563,40 @@ func dismissPreviousReviews(ctx context.Context, client *github.Client, owner, r
 
 func getDiff(ctx context.Context, client *github.Client, owner, repo string, prNumber int) (string, error) {
 	diff, _, err := client.PullRequests.GetRaw(ctx, owner, repo, prNumber, github.RawOptions{Type: github.Diff})
-	return diff, err
+	if err != nil {
+		return "", err
+	}
+
+	// Filter out lockfiles from the raw diff text.
+	// Unified diff format separates file chunks with "diff --git a/... b/..."
+	lines := strings.Split(diff, "\n")
+	var filteredLines []string
+	skipping := false
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "diff --git ") {
+			// Extract file paths from "diff --git a/path/to/file b/path/to/file"
+			parts := strings.Fields(line)
+			isLockFile := false
+			if len(parts) >= 4 {
+				// parts[2] is a/file, parts[3] is b/file
+				pathB := strings.TrimPrefix(parts[3], "b/")
+				for _, lf := range tools.LockFiles {
+					if pathB == lf || strings.HasSuffix(pathB, "/"+lf) {
+						isLockFile = true
+						break
+					}
+				}
+			}
+			skipping = isLockFile
+		}
+
+		if !skipping {
+			filteredLines = append(filteredLines, line)
+		}
+	}
+
+	return strings.Join(filteredLines, "\n"), nil
 }
 
 func getFiles(ctx context.Context, client *github.Client, owner, repo string, prNumber int) ([]string, error) {
@@ -570,7 +604,6 @@ func getFiles(ctx context.Context, client *github.Client, owner, repo string, pr
 		PerPage: 100,
 	}
 	var allFiles []string
-	lockFiles := []string{"go.sum", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "Cargo.lock", "poetry.lock", "Gemfile.lock"}
 
 	for {
 		files, resp, err := client.PullRequests.ListFiles(ctx, owner, repo, prNumber, opts)
@@ -580,8 +613,8 @@ func getFiles(ctx context.Context, client *github.Client, owner, repo string, pr
 		for _, f := range files {
 			path := f.GetFilename()
 			isLockFile := false
-			for _, lf := range lockFiles {
-				if strings.Contains(path, lf) {
+			for _, lf := range tools.LockFiles {
+				if path == lf || strings.HasSuffix(path, "/"+lf) {
 					isLockFile = true
 					break
 				}
@@ -609,7 +642,10 @@ func getCommits(ctx context.Context, client *github.Client, owner, repo string, 
 			return nil, err
 		}
 		for _, c := range commits {
-			allCommits = append(allCommits, "- "+c.GetCommit().GetMessage())
+			msg := c.GetCommit().GetMessage()
+			// Extract only the first line (subject)
+			subject := strings.SplitN(msg, "\n", 2)[0]
+			allCommits = append(allCommits, "- "+subject)
 		}
 		if resp.NextPage == 0 {
 			break

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -642,9 +642,15 @@ func getCommits(ctx context.Context, client *github.Client, owner, repo string, 
 			return nil, err
 		}
 		for _, c := range commits {
+			// Skip merge commits to maintain consistency with --no-merges
+			if len(c.Parents) > 1 {
+				continue
+			}
+
 			msg := c.GetCommit().GetMessage()
-			// Extract only the first line (subject)
-			subject := strings.SplitN(msg, "\n", 2)[0]
+			// Normalize newlines and extract only the first line (subject)
+			normalized := strings.ReplaceAll(msg, "\r\n", "\n")
+			subject := strings.SplitN(normalized, "\n", 2)[0]
 			allCommits = append(allCommits, "- "+subject)
 		}
 		if resp.NextPage == 0 {

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -65,3 +65,26 @@ func FetchGitDiff(workingDir, base, head string) (string, []string, error) {
 
 	return diffText, filteredFiles, nil
 }
+
+// FetchGitCommits retrieves a list of commit messages between base and head.
+func FetchGitCommits(workingDir, base, head string) (string, error) {
+	var commitRange string
+	if head == "HEAD" {
+		commitRange = base + "..HEAD"
+	} else {
+		commitRange = fmt.Sprintf("%s..%s", base, head)
+	}
+
+	// Use a clean format for commit messages
+	cmdArgs := []string{"log", "--pretty=format:- %s", "--no-merges", commitRange}
+	cmd := exec.Command("git", cmdArgs...)
+	cmd.Dir = workingDir
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// If git log fails (e.g., shallow clone), we return an error to be handled by the caller.
+		return "", fmt.Errorf("git log %s failed: %v. Output: %s", commitRange, err, string(out))
+	}
+
+	return string(out), nil
+}

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var lockFiles = []string{
+var LockFiles = []string{
 	"go.sum",
 	"package-lock.json",
 	"yarn.lock",
@@ -28,7 +28,7 @@ func FetchGitDiff(workingDir, base, head string) (string, []string, error) {
 	cmdArgs := []string{"diff", diffRange}
 
 	cmdArgs = append(cmdArgs, "--", ".")
-	for _, lf := range lockFiles {
+	for _, lf := range LockFiles {
 		cmdArgs = append(cmdArgs, fmt.Sprintf(":(exclude)*%s", lf))
 	}
 
@@ -46,7 +46,7 @@ func FetchGitDiff(workingDir, base, head string) (string, []string, error) {
 
 	// Get file list
 	nameOnlyArgs := []string{"diff", "--name-only", diffRange, "--", "."}
-	for _, lf := range lockFiles {
+	for _, lf := range LockFiles {
 		nameOnlyArgs = append(nameOnlyArgs, fmt.Sprintf(":(exclude)*%s", lf))
 	}
 	nameOnlyCmd := exec.Command("git", nameOnlyArgs...)

--- a/tools/diff_test.go
+++ b/tools/diff_test.go
@@ -146,3 +146,45 @@ func TestFetchGitDiff(t *testing.T) {
 		}
 	})
 }
+
+func TestFetchGitCommits(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupGitRepo(t, tmpDir)
+
+	t.Run("Commits between main and feature", func(t *testing.T) {
+		commits, err := FetchGitCommits(tmpDir, "main", "feature")
+		if err != nil {
+			t.Fatalf("FetchGitCommits failed: %v", err)
+		}
+
+		if !strings.Contains(commits, "- feature commit") {
+			t.Errorf("expected commit message 'feature commit', got:\n%s", commits)
+		}
+		if strings.Contains(commits, "main new commit") {
+			t.Errorf("did NOT expect commit message 'main new commit', got:\n%s", commits)
+		}
+	})
+
+	t.Run("Commits with HEAD", func(t *testing.T) {
+		// Add an uncommitted change and commit it
+		runGitCmd(t, tmpDir, "checkout", "feature")
+		err := os.WriteFile(filepath.Join(tmpDir, "extra.txt"), []byte("extra"), 0o644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		runGitCmd(t, tmpDir, "add", "extra.txt")
+		runGitCmd(t, tmpDir, "commit", "-m", "extra commit")
+
+		commits, err := FetchGitCommits(tmpDir, "main", "HEAD")
+		if err != nil {
+			t.Fatalf("FetchGitCommits failed: %v", err)
+		}
+
+		if !strings.Contains(commits, "- feature commit") {
+			t.Errorf("expected commit message 'feature commit', got:\n%s", commits)
+		}
+		if !strings.Contains(commits, "- extra commit") {
+			t.Errorf("expected commit message 'extra commit', got:\n%s", commits)
+		}
+	})
+}

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -154,7 +154,7 @@ func registerLocalGrepFiles(r *Registry) {
 		}
 
 		// Filter out lock files as they are usually not relevant and can be huge.
-		for _, lf := range lockFiles {
+		for _, lf := range LockFiles {
 			cmdArgs = append(cmdArgs, fmt.Sprintf(":(exclude)*%s", lf))
 		}
 


### PR DESCRIPTION
This PR allows Cassandra to fetch the git diff, file list, and commit messages directly from the GitHub API. This is particularly useful for CI environments using shallow clones, as it avoids the need for a full repository history to perform a review.

Key changes:
- Added 'get-diff', 'get-files', and 'get-commits' actions to the 'github' tool.
- Updated 'ai_reviewer' to accept pre-fetched data via new flags.
- Commit messages are now unconditionally included in the review context.
- Updated 'action.yml' to fetch PR context using the new tool actions.

Fixes #40