### PR TITLE
chore: update release workflow to use gh-release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,11 +48,9 @@ jobs:
           done
           ls -lh dist/
       - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ github.ref_name }}
-        run: |
-          gh release create "$RELEASE_VERSION" \
-            --generate-notes \
-            --title "Cassandra $RELEASE_VERSION" \
-            dist/cassandra-*
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          name: "Cassandra ${{ github.ref_name }}"
+          make_latest: true
+          files: dist/cassandra-*


### PR DESCRIPTION
This PR updates the .github/workflows/release.yml workflow to use the softprops/action-gh-release@v2 action instead of manual gh release create commands.

Key improvements:
- **Idempotency**: The workflow can now be re-run safely. If a release already exists for the tag, it will be updated instead of causing the job to fail.
- **Mark as Latest**: Explicitly sets `make_latest: true` to ensure the release is always marked as the latest version.
- **Permission Check**: Confirmed that `contents: write` is sufficient for this action to manage releases and assets.