### PR TITLE
refactor(llm): cleanup + scoped AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Progress reporting is abstracted via the `core.Reporter` interface.
 - **Mock Isolation**: When using `mockLLM` or similar history-tracking doubles, you MUST perform a deep copy of the message slice and its internal slices (`ToolCalls`, `ToolResults`). Shallow copies will lead to state contamination across iterations.
 - **Safer JSON Construction**: Avoid manual string concatenation for JSON arguments in tests. Use `json.Marshal` or existing helpers to ensure paths (especially in `t.TempDir()`) containing special characters do not break the test payload.
 - **Negative Testing**: Every new tool or core logic change SHOULD include error-handling test cases (e.g., malformed JSON, missing files, individual tool failures).
+- **Test Doubles Must Forward `ctx` and Arguments**: A stub or mock implementing a `context.Context`-accepting interface MUST forward the received `ctx` and arguments to any internal delegate. Substituting `context.Background()` silently breaks cancellation tests. Every context-accepting method on a test double needs at least one cancellation-propagation test.
+- **Parallel Method Coverage**: When an interface has parallel methods that share a wrapper (e.g. `GenerateContent` / `GenerateStructuredContent` behind `RetryingModel`), behavioral tests (retries, cancellation, error propagation) MUST cover both methods. Generics or composition that unify them in production do not remove the need for independent test coverage.
 
 ### 4. Performance Mindfulness
 - **Redundant I/O**: When walking the directory tree for configuration or guidelines (like `REVIEWERS.md`), use directory-based caching to avoid redundant disk lookups. If a directory subtree has already been searched for a specific filename, terminate the walk-up early.
@@ -76,6 +78,9 @@ Progress reporting is abstracted via the `core.Reporter` interface.
 - **Zone ordering**: The system prompt is divided into three zones ordered from most- to least-stable (see `core/prompts/library/README.md` for the full Prompt Developer Guide). When editing `BuildSystemPrompt` or any prompt file, **never inject dynamic or per-request data (file paths, PR metadata, commit SHAs) into Zone 1 or Zone 2**. All such content belongs in Zone 3 (the dynamic suffix).
 - **Byte-for-byte stability**: Any change to `reviewer_prompt.md`, a library guideline file, or the `approval_evaluation_prompt.md` will invalidate the prefix cache for every subsequent review using that configuration. Review such changes carefully and keep them minimal.
 - **New sections**: If you add a new semi-static section to `BuildSystemPrompt`, insert it between the existing Zone 2 entries and before the Zone 3 block (AGENTS.md / REVIEWERS.md), maintaining the stable-prefix ordering described in the design.
+
+### 7. Lint Exceptions
+- **Centralize `//nolint` pragmas**: If a construct legitimately needs a lint exception (e.g. `int32` narrowing after a bounds check, an intentionally-unused receiver), wrap it in a named helper so the pragma lives in one place with a comment explaining the invariant. Do not sprinkle `//nolint:gosec` or similar pragmas at multiple call sites — the invariant becomes invisible and copy-paste drift accumulates. See `clampInt32` in `llm/google/provider.go` as the canonical example.
 
 ## Security Standards
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -64,7 +64,31 @@ The system is designed as a CLI-driven, autonomous AI worker. It acts essentiall
 - **Provider Implementations**:
   - `llm/anthropic`: Uses `github.com/anthropics/anthropic-sdk-go`.
   - `llm/google`: Uses `google.golang.org/genai`.
-- **Factory**: `llm/factory/factory.go` provides a single `New` function to construct the appropriate `Model` implementation.
+- **Factory**: `llm/factory/factory.go` provides a single `New` function to construct the appropriate `Model` implementation. Providers are registered via the package-level `providers` map; adding a provider is a one-line map entry.
+
+#### Shared Contracts
+
+The following symbols in `llm/llm.go` are the load-bearing contracts that every
+provider implementation depends on. See [`llm/AGENTS.md`](llm/AGENTS.md) for
+the companion implementation rules.
+
+- **`llm.UnknownUsage()`** — sentinel `Usage` (`PromptTokens: -1`,
+  `OutputTokens: -1`) meaning "provider reported no token data". Providers
+  seed `Response.Usage` with this and overwrite on success. When a provider
+  exposes multiple counters (e.g. cache vs. non-cache), every counter path
+  must be covered by the usage-presence guard.
+- **`llm.StructuredConfig.Resolve(defaultModel)`** — returns
+  `(model, maxTokens)` with `ModelOverride` and `DefaultStructuredMaxTokens`
+  applied. `GenerateStructuredContent` implementations call this to
+  eliminate per-provider defaulting boilerplate.
+- **`llm.DefaultStructuredMaxTokens = 8192`** — fallback budget for
+  structured-output calls. Kept in lockstep with the CLI `--max-tokens`
+  default in `cmd/ai_reviewer`.
+- **`llm.retry[T]`** (package-private) — the canonical exponential-back-off
+  + ctx-cancellation loop. `RetryingModel` wraps the interface via this
+  helper; any new cross-cutting `llm.Model` wrapper (caching, telemetry,
+  rate-limiting) should follow the same composition rather than
+  re-implementing the loop.
 
 ## Technical Decisions
 
@@ -81,7 +105,7 @@ The system is designed as a CLI-driven, autonomous AI worker. It acts essentiall
    - The system separates reasoning from formatting. The primary review pass is free-form markdown to optimize for reasoning quality.
    - **Secondary Extraction**: A second, optional LLM call converts the markdown review into a structured JSON representation.
    - **Implementation strategy**:
-     - **Anthropic**: Instructs the model to use a `submit_review` tool with the target schema.
+     - **Anthropic**: Forces the model to call a synthetic tool whose name is pinned by the package-level const `llm/anthropic.submitReviewToolName` (`"submit_review"`). This name is a stable contract — downstream consumers may match on it, so changes must be coordinated with any code that introspects the structured response.
      - **Google**: Uses `ResponseMIMEType = "application/json"` and `ResponseSchema`.
 
 ## Output Contract

--- a/REVIEWERS.md
+++ b/REVIEWERS.md
@@ -1,0 +1,19 @@
+# Review Guidelines
+
+Reviewer lens for the whole repo. Assumes [AGENTS.md](AGENTS.md) and [DESIGN.md](DESIGN.md) have been read; does not restate them. Per-directory `REVIEWERS.md` files (e.g. [llm/REVIEWERS.md](llm/REVIEWERS.md)) scope further.
+
+## Severity mapping
+
+Map findings to Do / Try / Consider:
+
+- **Do (blocking)**: output-contract violations (stdout/stderr split), broken contracts named in `DESIGN.md`, security findings (AGENTS.md §Security), Zone 1/2 prompt edits that inject dynamic data.
+- **Try (recommended)**: AGENTS.md deviations that are rules but not contracts.
+- **Consider (optional)**: code shape, naming, comment clarity.
+
+Not every AGENTS.md deviation is blocking. Over-blocking drowns real defects.
+
+## Paired edits (block if one is missing)
+
+- New `os.Stdout` write ↔ justification that it is final review output.
+- `BuildSystemPrompt` addition ↔ placement between Zone 2 and Zone 3 (AGENTS.md §6).
+- GitHub Action input added ↔ `env:` mapping per AGENTS.md §Security 1.

--- a/REVIEWERS.md
+++ b/REVIEWERS.md
@@ -2,16 +2,6 @@
 
 Reviewer lens for the whole repo. Assumes [AGENTS.md](AGENTS.md) and [DESIGN.md](DESIGN.md) have been read; does not restate them. Per-directory `REVIEWERS.md` files (e.g. [llm/REVIEWERS.md](llm/REVIEWERS.md)) scope further.
 
-## Severity mapping
-
-Map findings to Do / Try / Consider:
-
-- **Do (blocking)**: output-contract violations (stdout/stderr split), broken contracts named in `DESIGN.md`, security findings (AGENTS.md §Security), Zone 1/2 prompt edits that inject dynamic data.
-- **Try (recommended)**: AGENTS.md deviations that are rules but not contracts.
-- **Consider (optional)**: code shape, naming, comment clarity.
-
-Not every AGENTS.md deviation is blocking. Over-blocking drowns real defects.
-
 ## Paired edits (block if one is missing)
 
 - New `os.Stdout` write ↔ justification that it is final review output.

--- a/llm/AGENTS.md
+++ b/llm/AGENTS.md
@@ -1,0 +1,73 @@
+# LLM Package Guidelines
+
+Scoped guidance for code under `llm/`. These rules complement the repo-level
+[AGENTS.md](../AGENTS.md); follow both. See also the architectural contract
+in [DESIGN.md §4 LLM Abstraction](../DESIGN.md#4-llm-abstraction-llm).
+
+## Provider Implementation Pattern
+
+When adding or modifying an `llm.Model` implementation, follow these
+conventions so the provider stays consistent with the shared abstraction.
+
+### 1. Registration
+Register new providers by adding one entry to the `providers` map in
+`llm/factory/factory.go`. Do **not** extend `factory.New` with a new
+`switch` branch. The "unsupported provider" error message is derived from
+the map, so a single map entry wires both construction and error reporting.
+
+### 2. Structured Output Defaults
+Every `GenerateStructuredContent` implementation MUST open with:
+```go
+modelName, maxTokens := config.Resolve(p.modelName)
+```
+Do not inline model-override or max-tokens defaulting.
+`llm.DefaultStructuredMaxTokens` is the single source of truth and is kept
+in lockstep with the CLI `--max-tokens` default.
+
+### 3. Usage Sentinel
+Seed `llm.Response.Usage` with `llm.UnknownUsage()` and overwrite on
+success. Do not hand-roll `Usage{PromptTokens: -1, ...}` literals.
+
+When a provider reports token usage across multiple counter fields (e.g.
+Anthropic's `InputTokens`, `CacheReadInputTokens`,
+`CacheCreationInputTokens`), the guard that decides "do we have real usage
+data?" MUST cover **every** counter path. A guard that only checks the
+non-cache counters will silently leave `CachedTokens` at its sentinel for
+cache-only responses — the exact bug fixed in `da5f0f3`.
+
+### 4. Tool-Name Contracts
+Tool names referenced by downstream consumers or documented in
+`DESIGN.md` (e.g. `submitReviewToolName`) MUST be package-level `const`s
+with a doc comment pointing at the DESIGN.md contract. Never inline the
+literal at use sites — both the tool definition and the tool-choice must
+reference the same symbol so they cannot silently desync.
+
+### 5. ProviderMetadata Access
+Provider-specific keys in `llm.Message.ProviderMetadata` are typed-unsafe
+map indexes. For every key:
+- Define a package-level `const` for the key string.
+- Define a typed accessor (e.g. `func thoughtSignature(m llm.Message) []byte`)
+  that performs the type assertion once.
+
+Both the write site and every read site MUST reference the const and go
+through the accessor. Hardcoding the key string in multiple places (as was
+done for `google_thought_signature` before `899d74d`) makes typos
+undetectable until runtime.
+
+### 6. JSON Schema → Native Schema Conversion
+When translating a JSON Schema type string to a provider-native enum, use
+a `map[string]T` lookup, not a `switch`. Unknown types MUST emit a stderr
+diagnostic naming the offending type (per the repo-level Output Contract).
+Silent fallthroughs are banned — they surface as opaque provider errors
+well after the malformed schema has left our process. See
+`jsonSchemaTypes` in `llm/google/provider.go` as the canonical example.
+
+### 7. Cross-Cutting Model Wrappers
+`llm.retry[T]` (in `llm/retry.go`) encapsulates the attempt loop,
+exponential back-off, and ctx-cancellation policy used by `RetryingModel`.
+Any new cross-cutting `llm.Model` wrapper (caching, telemetry,
+rate-limiting) SHOULD compose via the `llm.Model` interface and reuse
+this helper where applicable rather than re-implementing the loop.
+Parallel methods on the interface (`GenerateContent` and
+`GenerateStructuredContent`) share one helper; do not duplicate the
+control flow per method.

--- a/llm/CLAUDE.md
+++ b/llm/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/llm/REVIEWERS.md
+++ b/llm/REVIEWERS.md
@@ -1,76 +1,25 @@
-# LLM Package Review Guidelines
+# llm/ Review Guidelines
 
-Reviewer lens for code under `llm/`. Assumes [`AGENTS.md`](AGENTS.md) and
-[`DESIGN.md`](../DESIGN.md) have been read — this file does not restate
-their rules.
+Reviewer lens. Complements [AGENTS.md](AGENTS.md) and [DESIGN.md](../DESIGN.md); does not restate them.
 
-## Cross-Provider Feature Parity
+## Feature parity across providers
 
-The `llm.Model` interface is provider-agnostic by design; behavioral
-divergence between concrete implementations is a defect, not a stylistic
-choice. For every change to one provider, the review MUST verify the
-other.
+Behavioral divergence between `llm/anthropic` and `llm/google` is a defect unless documented.
 
-- If a feature, field, counter, or code path is added to
-  `llm/google/provider.go`, the reviewer MUST verify that
-  `llm/anthropic/provider.go` either implements it or explicitly ignores
-  it with a documented rationale (and vice versa).
-- "Explicitly ignores" means a code comment at the relevant site naming
-  the divergence and why — not silent absence. Silent divergence between
-  providers is the single most common way callers leak provider-specific
-  assumptions into provider-agnostic code.
-- When reviewing a PR that touches only one provider, the expected
-  reviewer question is **"why does the other provider not need this
-  change?"** — and the PR description (or a code comment) must answer
-  it. Absence of the question is a review defect.
-- The `llm.Message.CacheBreakpoint` field is the canonical precedent for
-  documented graceful degradation: one provider acts on it, the other
-  ignores it, and the field's doc comment names both behaviors. New
-  provider-specific fields or metadata keys must follow the same pattern.
+- A change to one provider requires the same change in the other, or a code comment naming the divergence and its rationale. `llm.Message.CacheBreakpoint` is the canonical graceful-degradation precedent.
+- For a single-provider PR, the description must answer "why does the other provider not need this?". Absence is a review defect.
 
-## Noise Filter — Do Not Flag
+## Do not flag
 
-Patterns that look like issues but are settled decisions. Raising them
-costs tokens and trains the model toward re-suggesting them.
+- `RetryingModel` retries on all errors, including 4xx. Error-class filtering was rejected.
+- `llm.UnknownUsage()` is value-typed with `-1/-1` sentinels. Callers depend on this; do not suggest pointers or an `Ok` field.
+- `clampInt32` carries the package `//nolint:gosec`; it is the centralization point (root AGENTS.md §7).
+- `llm/internal/util` is the intentional shared conversion layer.
+- `llm.retry[T]` is tested via both `RetryingModel` methods; do not request direct unit tests.
 
-- **`RetryingModel` retries on every error**, including 4xx and context
-  deadlines other than cancellation. Provider SDKs sometimes map
-  transient upstream conditions to 4xx, and filtering by error class has
-  been rejected. Do not suggest error-class filtering or retry-budget
-  refinements unless the PR itself is about retry policy.
-- **`llm.UnknownUsage()` returns a value, not a pointer, and uses
-  `-1/-1` sentinels.** Callers depend on value semantics and the
-  sentinel convention. Do not suggest `*Usage`, `Optional[Usage]`, or an
-  `Ok bool` companion field.
-- **`clampInt32` in `llm/google/provider.go` carries
-  `//nolint:gosec`.** It is the centralization point for the pragma
-  (root AGENTS.md §7). Do not suggest moving, duplicating, or removing
-  the pragma.
-- **Provider packages import `llm/internal/util`.** That is the
-  intentional shared conversion layer; do not suggest inlining
-  `ParseRequired` into each provider.
-- **`llm.retry[T]` is package-private and untested directly.** It is
-  exercised through both `RetryingModel` methods (per root AGENTS.md §3
-  "Parallel Method Coverage"). Do not request direct unit tests for the
-  generic helper.
+## Paired edits (block if one is missing)
 
-## Cross-File Invariants
-
-Paired edits that must land together. If the reviewer sees one without
-the other, that is a blocking finding.
-
-- A change to `llm/anthropic.submitReviewToolName` (value or symbol)
-  MUST be accompanied by a corresponding update in
-  [`DESIGN.md §Technical Decisions 4`](../DESIGN.md#technical-decisions).
-  The name is a documented contract.
-- A change to `llm.DefaultStructuredMaxTokens` MUST be accompanied by
-  the matching change to the CLI `--max-tokens` default in
-  `cmd/ai_reviewer`. The two are paired by `DESIGN.md §4 Shared
-  Contracts`.
-- A new provider added under `llm/<name>/` MUST register in
-  `llm/factory/factory.go`'s `providers` map *and* be listed in
-  `README.md` §Supported Models in the same PR.
-- A change to any `llm.Model` interface method signature MUST update
-  both provider implementations, `RetryingModel`, and any test doubles
-  under `llm/` — the compiler enforces the first three; test doubles
-  are the common miss.
+- `submitReviewToolName` ↔ `DESIGN.md §Technical Decisions 4`.
+- `DefaultStructuredMaxTokens` ↔ CLI `--max-tokens` default in `cmd/ai_reviewer`.
+- New provider ↔ `factory.providers` map + `README.md` §Supported Models.
+- `llm.Model` signature change ↔ test doubles under `llm/`.

--- a/llm/REVIEWERS.md
+++ b/llm/REVIEWERS.md
@@ -1,0 +1,76 @@
+# LLM Package Review Guidelines
+
+Reviewer lens for code under `llm/`. Assumes [`AGENTS.md`](AGENTS.md) and
+[`DESIGN.md`](../DESIGN.md) have been read — this file does not restate
+their rules.
+
+## Cross-Provider Feature Parity
+
+The `llm.Model` interface is provider-agnostic by design; behavioral
+divergence between concrete implementations is a defect, not a stylistic
+choice. For every change to one provider, the review MUST verify the
+other.
+
+- If a feature, field, counter, or code path is added to
+  `llm/google/provider.go`, the reviewer MUST verify that
+  `llm/anthropic/provider.go` either implements it or explicitly ignores
+  it with a documented rationale (and vice versa).
+- "Explicitly ignores" means a code comment at the relevant site naming
+  the divergence and why — not silent absence. Silent divergence between
+  providers is the single most common way callers leak provider-specific
+  assumptions into provider-agnostic code.
+- When reviewing a PR that touches only one provider, the expected
+  reviewer question is **"why does the other provider not need this
+  change?"** — and the PR description (or a code comment) must answer
+  it. Absence of the question is a review defect.
+- The `llm.Message.CacheBreakpoint` field is the canonical precedent for
+  documented graceful degradation: one provider acts on it, the other
+  ignores it, and the field's doc comment names both behaviors. New
+  provider-specific fields or metadata keys must follow the same pattern.
+
+## Noise Filter — Do Not Flag
+
+Patterns that look like issues but are settled decisions. Raising them
+costs tokens and trains the model toward re-suggesting them.
+
+- **`RetryingModel` retries on every error**, including 4xx and context
+  deadlines other than cancellation. Provider SDKs sometimes map
+  transient upstream conditions to 4xx, and filtering by error class has
+  been rejected. Do not suggest error-class filtering or retry-budget
+  refinements unless the PR itself is about retry policy.
+- **`llm.UnknownUsage()` returns a value, not a pointer, and uses
+  `-1/-1` sentinels.** Callers depend on value semantics and the
+  sentinel convention. Do not suggest `*Usage`, `Optional[Usage]`, or an
+  `Ok bool` companion field.
+- **`clampInt32` in `llm/google/provider.go` carries
+  `//nolint:gosec`.** It is the centralization point for the pragma
+  (root AGENTS.md §7). Do not suggest moving, duplicating, or removing
+  the pragma.
+- **Provider packages import `llm/internal/util`.** That is the
+  intentional shared conversion layer; do not suggest inlining
+  `ParseRequired` into each provider.
+- **`llm.retry[T]` is package-private and untested directly.** It is
+  exercised through both `RetryingModel` methods (per root AGENTS.md §3
+  "Parallel Method Coverage"). Do not request direct unit tests for the
+  generic helper.
+
+## Cross-File Invariants
+
+Paired edits that must land together. If the reviewer sees one without
+the other, that is a blocking finding.
+
+- A change to `llm/anthropic.submitReviewToolName` (value or symbol)
+  MUST be accompanied by a corresponding update in
+  [`DESIGN.md §Technical Decisions 4`](../DESIGN.md#technical-decisions).
+  The name is a documented contract.
+- A change to `llm.DefaultStructuredMaxTokens` MUST be accompanied by
+  the matching change to the CLI `--max-tokens` default in
+  `cmd/ai_reviewer`. The two are paired by `DESIGN.md §4 Shared
+  Contracts`.
+- A new provider added under `llm/<name>/` MUST register in
+  `llm/factory/factory.go`'s `providers` map *and* be listed in
+  `README.md` §Supported Models in the same PR.
+- A change to any `llm.Model` interface method signature MUST update
+  both provider implementations, `RetryingModel`, and any test doubles
+  under `llm/` — the compiler enforces the first three; test doubles
+  are the common miss.

--- a/llm/anthropic/provider.go
+++ b/llm/anthropic/provider.go
@@ -14,6 +14,12 @@ import (
 	"github.com/menny/cassandra/llm/internal/util"
 )
 
+// submitReviewToolName is the synthetic tool the Anthropic provider forces
+// the model to call to deliver structured output. The name is a documented
+// contract — see DESIGN.md §Technical Decisions 4 ("Structured Feedback
+// Extraction"). Keep it stable; downstream consumers may match on it.
+const submitReviewToolName = "submit_review"
+
 // Provider implements llm.Model backed by the Anthropic Messages API.
 type Provider struct {
 	client    anthropicsdk.Client
@@ -65,9 +71,8 @@ func (p *Provider) GenerateStructuredContent(ctx context.Context, messages []llm
 	modelName, maxTokens := config.Resolve(p.modelName)
 
 	// Define a synthetic tool to enforce the structured response.
-	toolName := "submit_review"
 	tool := anthropicsdk.ToolParam{
-		Name:        toolName,
+		Name:        submitReviewToolName,
 		Description: param.NewOpt("Returns the structured code review."),
 		InputSchema: schemaParamFromJSONSchema(schema),
 	}
@@ -81,7 +86,7 @@ func (p *Provider) GenerateStructuredContent(ctx context.Context, messages []llm
 		ToolChoice: anthropicsdk.ToolChoiceUnionParam{
 			OfTool: &anthropicsdk.ToolChoiceToolParam{
 				Type: "tool",
-				Name: toolName,
+				Name: submitReviewToolName,
 			},
 		},
 	}

--- a/llm/anthropic/provider.go
+++ b/llm/anthropic/provider.go
@@ -197,14 +197,7 @@ func toAnthropicTools(tools []llm.ToolDef) []anthropicsdk.ToolUnionParam {
 // parseAnthropicResponse converts an Anthropic *Message to a normalised
 // *llm.Response.
 func parseAnthropicResponse(msg *anthropicsdk.Message) (*llm.Response, error) {
-	resp := &llm.Response{
-		Usage: llm.Usage{
-			PromptTokens:   -1,
-			OutputTokens:   -1,
-			ThinkingTokens: 0,
-			CachedTokens:   0,
-		},
-	}
+	resp := &llm.Response{Usage: llm.UnknownUsage()}
 
 	// The SDK usage struct is not a pointer, but we check if we have values.
 	// Cache-only responses report tokens exclusively through the cache counters,

--- a/llm/anthropic/provider.go
+++ b/llm/anthropic/provider.go
@@ -62,15 +62,7 @@ func (p *Provider) GenerateStructuredContent(ctx context.Context, messages []llm
 		return nil, fmt.Errorf("anthropic: building messages: %w", err)
 	}
 
-	modelName := p.modelName
-	if config.ModelOverride != "" {
-		modelName = config.ModelOverride
-	}
-
-	maxTokens := config.MaxTokens
-	if maxTokens <= 0 {
-		maxTokens = 8192
-	}
+	modelName, maxTokens := config.Resolve(p.modelName)
 
 	// Define a synthetic tool to enforce the structured response.
 	toolName := "submit_review"

--- a/llm/anthropic/provider.go
+++ b/llm/anthropic/provider.go
@@ -23,9 +23,7 @@ type Provider struct {
 // New creates a Provider for the given model. Extra SDK options (e.g.
 // option.WithBaseURL) can be passed for testing or proxying.
 func New(apiKey, modelName string, opts ...option.RequestOption) *Provider {
-	allOpts := make([]option.RequestOption, 0, 1+len(opts))
-	allOpts = append(allOpts, option.WithAPIKey(apiKey))
-	allOpts = append(allOpts, opts...)
+	allOpts := append([]option.RequestOption{option.WithAPIKey(apiKey)}, opts...)
 	return &Provider{client: anthropicsdk.NewClient(allOpts...), modelName: modelName}
 }
 

--- a/llm/anthropic/provider.go
+++ b/llm/anthropic/provider.go
@@ -69,11 +69,7 @@ func (p *Provider) GenerateStructuredContent(ctx context.Context, messages []llm
 	tool := anthropicsdk.ToolParam{
 		Name:        toolName,
 		Description: param.NewOpt("Returns the structured code review."),
-		InputSchema: anthropicsdk.ToolInputSchemaParam{
-			Type:       "object",
-			Properties: schema["properties"],
-			Required:   util.ParseRequired(schema["required"]),
-		},
+		InputSchema: schemaParamFromJSONSchema(schema),
 	}
 
 	sdkParams := anthropicsdk.MessageNewParams{
@@ -174,24 +170,27 @@ func toAnthropicMessages(messages []llm.Message) ([]anthropicsdk.TextBlockParam,
 func toAnthropicTools(tools []llm.ToolDef) []anthropicsdk.ToolUnionParam {
 	out := make([]anthropicsdk.ToolUnionParam, 0, len(tools))
 	for _, t := range tools {
-		// The Anthropic API requires the top-level tool schema to be an
-		// "object". If a tool defines a different top-level type (e.g.
-		// "array"), this conversion will produce a malformed schema.
-		schema := anthropicsdk.ToolInputSchemaParam{
-			Type:       "object",
-			Properties: t.Parameters["properties"],
-		}
-		// Forward required field so the model knows which parameters are mandatory.
-		schema.Required = util.ParseRequired(t.Parameters["required"])
-
 		tp := anthropicsdk.ToolParam{
 			Name:        t.Name,
 			Description: param.NewOpt(t.Description),
-			InputSchema: schema,
+			InputSchema: schemaParamFromJSONSchema(t.Parameters),
 		}
 		out = append(out, anthropicsdk.ToolUnionParam{OfTool: &tp})
 	}
 	return out
+}
+
+// schemaParamFromJSONSchema converts a JSON Schema object (as stored in
+// llm.ToolDef.Parameters) into an Anthropic ToolInputSchemaParam. The
+// Anthropic API requires the top-level schema to be an "object"; if a tool
+// defines a different top-level type (e.g. "array") the resulting schema
+// will be malformed.
+func schemaParamFromJSONSchema(schema map[string]any) anthropicsdk.ToolInputSchemaParam {
+	return anthropicsdk.ToolInputSchemaParam{
+		Type:       "object",
+		Properties: schema["properties"],
+		Required:   util.ParseRequired(schema["required"]),
+	}
 }
 
 // parseAnthropicResponse converts an Anthropic *Message to a normalised

--- a/llm/anthropic/provider.go
+++ b/llm/anthropic/provider.go
@@ -217,7 +217,10 @@ func parseAnthropicResponse(msg *anthropicsdk.Message) (*llm.Response, error) {
 	}
 
 	// The SDK usage struct is not a pointer, but we check if we have values.
-	if msg.Usage.InputTokens > 0 || msg.Usage.OutputTokens > 0 {
+	// Cache-only responses report tokens exclusively through the cache counters,
+	// so the gate must include those or CachedTokens would stay at its -1 sentinel.
+	if msg.Usage.InputTokens > 0 || msg.Usage.OutputTokens > 0 ||
+		msg.Usage.CacheReadInputTokens > 0 || msg.Usage.CacheCreationInputTokens > 0 {
 		resp.Usage.PromptTokens = int(msg.Usage.InputTokens + msg.Usage.CacheCreationInputTokens)
 		resp.Usage.OutputTokens = int(msg.Usage.OutputTokens)
 		resp.Usage.CachedTokens = int(msg.Usage.CacheReadInputTokens)

--- a/llm/factory/factory.go
+++ b/llm/factory/factory.go
@@ -5,6 +5,8 @@ package factory
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/menny/cassandra/llm"
 	"github.com/menny/cassandra/llm/anthropic"
@@ -19,25 +21,47 @@ const (
 	ProviderGoogle    Provider = "google"
 )
 
+// providerFactory constructs a provider-specific llm.Model. Implementations
+// may use ctx (e.g. to dial eagerly) or ignore it.
+type providerFactory func(ctx context.Context, apiKey, modelName string) (llm.Model, error)
+
+// providers is the registry of supported Providers. Adding a new provider
+// is a single entry here; factory.New and the "unsupported provider" error
+// message derive from this map automatically.
+var providers = map[Provider]providerFactory{
+	ProviderAnthropic: func(_ context.Context, apiKey, modelName string) (llm.Model, error) {
+		// Anthropic client is constructed synchronously; ctx is unused at
+		// construction time (the SDK dials lazily per request).
+		return anthropic.New(apiKey, modelName), nil
+	},
+	ProviderGoogle: func(ctx context.Context, apiKey, modelName string) (llm.Model, error) {
+		return google.New(ctx, apiKey, modelName)
+	},
+}
+
 // New constructs a Model for the given provider, model name, and API key.
 // The returned model automatically retries transient errors with exponential
 // back-off using llm.DefaultRetryAttempts and llm.DefaultRetryBaseDelay.
 func New(ctx context.Context, provider, modelName, apiKey string) (llm.Model, error) {
-	var inner llm.Model
-	switch Provider(provider) {
-	case ProviderAnthropic:
-		// Anthropic client is constructed synchronously; ctx is unused at
-		// construction time (the SDK dials lazily per request).
-		inner = anthropic.New(apiKey, modelName)
-	case ProviderGoogle:
-		var err error
-		inner, err = google.New(ctx, apiKey, modelName)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("unsupported provider %q: supported providers are %q and %q",
-			provider, ProviderAnthropic, ProviderGoogle)
+	f, ok := providers[Provider(provider)]
+	if !ok {
+		return nil, fmt.Errorf("unsupported provider %q: supported providers are %s",
+			provider, supportedProviders())
+	}
+	inner, err := f(ctx, apiKey, modelName)
+	if err != nil {
+		return nil, err
 	}
 	return llm.NewRetryingModel(inner, llm.DefaultRetryAttempts, llm.DefaultRetryBaseDelay), nil
+}
+
+// supportedProviders returns a sorted, comma-separated list of known
+// provider identifiers for use in error messages.
+func supportedProviders() string {
+	names := make([]string, 0, len(providers))
+	for p := range providers {
+		names = append(names, fmt.Sprintf("%q", string(p)))
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
 }

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -123,12 +123,9 @@ func toContents(messages []llm.Message) ([]*genai.Content, *genai.Content, error
 		switch m.Role {
 		case llm.RoleSystem:
 			if system == nil {
-				system = &genai.Content{
-					Parts: []*genai.Part{{Text: m.Text}},
-				}
-			} else {
-				system.Parts = append(system.Parts, &genai.Part{Text: m.Text})
+				system = &genai.Content{}
 			}
+			system.Parts = append(system.Parts, &genai.Part{Text: m.Text})
 
 		case llm.RoleUser:
 			contents = append(contents, &genai.Content{

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -14,6 +14,18 @@ import (
 	"github.com/menny/cassandra/llm/internal/util"
 )
 
+// thoughtSignatureKey is the ProviderMetadata key under which the Gemini
+// thought signature (opaque []byte) is stored on llm.Message.
+const thoughtSignatureKey = "google_thought_signature"
+
+// thoughtSignature extracts the Gemini thought signature from a Message's
+// ProviderMetadata. Returns nil if the key is absent or the stored value is
+// not a []byte — both of which are valid states for non-thinking models.
+func thoughtSignature(m llm.Message) []byte {
+	sig, _ := m.ProviderMetadata[thoughtSignatureKey].([]byte)
+	return sig
+}
+
 // clampInt32 saturates n into the int32 range. The Gemini SDK's
 // MaxOutputTokens is an int32 while our llm.Model API uses int, so every
 // call site needs this conversion; centralizing it removes duplicated
@@ -127,10 +139,7 @@ func toContents(messages []llm.Message) ([]*genai.Content, *genai.Content, error
 
 		case llm.RoleAssistant:
 			var parts []*genai.Part
-			var sig []byte
-			if s, ok := m.ProviderMetadata["google_thought_signature"].([]byte); ok {
-				sig = s
-			}
+			sig := thoughtSignature(m)
 
 			if m.Reasoning != "" {
 				parts = append(parts, &genai.Part{
@@ -265,7 +274,7 @@ func parseGenaiResponse(resp *genai.GenerateContentResponse) (*llm.Response, err
 			if result.ProviderMetadata == nil {
 				result.ProviderMetadata = make(map[string]any)
 			}
-			result.ProviderMetadata["google_thought_signature"] = part.ThoughtSignature
+			result.ProviderMetadata[thoughtSignatureKey] = part.ThoughtSignature
 		}
 
 		// Both fields are checked independently: the Gemini API can return a

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -14,6 +14,17 @@ import (
 	"github.com/menny/cassandra/llm/internal/util"
 )
 
+// jsonSchemaTypes maps JSON Schema type names (lowercase) to their
+// genai.Type counterparts (uppercase enum). Used by convertSchema.
+var jsonSchemaTypes = map[string]genai.Type{
+	"object":  genai.TypeObject,
+	"string":  genai.TypeString,
+	"number":  genai.TypeNumber,
+	"integer": genai.TypeInteger,
+	"boolean": genai.TypeBoolean,
+	"array":   genai.TypeArray,
+}
+
 // Provider implements llm.Model backed by the Google Generative AI API.
 type Provider struct {
 	client    *genai.Client
@@ -194,20 +205,9 @@ func convertSchema(m map[string]any) *genai.Schema {
 	s := &genai.Schema{}
 
 	if t, ok := m["type"].(string); ok {
-		switch t {
-		case "object":
-			s.Type = genai.TypeObject
-		case "string":
-			s.Type = genai.TypeString
-		case "number":
-			s.Type = genai.TypeNumber
-		case "integer":
-			s.Type = genai.TypeInteger
-		case "boolean":
-			s.Type = genai.TypeBoolean
-		case "array":
-			s.Type = genai.TypeArray
-		default:
+		if mapped, known := jsonSchemaTypes[t]; known {
+			s.Type = mapped
+		} else {
 			log.Printf("google: convertSchema: unknown JSON Schema type %q; resulting schema will be malformed", t)
 		}
 	}

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -14,6 +14,20 @@ import (
 	"github.com/menny/cassandra/llm/internal/util"
 )
 
+// clampInt32 saturates n into the int32 range. The Gemini SDK's
+// MaxOutputTokens is an int32 while our llm.Model API uses int, so every
+// call site needs this conversion; centralizing it removes duplicated
+// //nolint:gosec pragmas.
+func clampInt32(n int) int32 {
+	if n > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if n < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(n) //nolint:gosec // bounds-checked above
+}
+
 // jsonSchemaTypes maps JSON Schema type names (lowercase) to their
 // genai.Type counterparts (uppercase enum). Used by convertSchema.
 var jsonSchemaTypes = map[string]genai.Type{
@@ -49,7 +63,7 @@ func (p *Provider) GenerateContent(ctx context.Context, messages []llm.Message, 
 	}
 
 	config := &genai.GenerateContentConfig{
-		MaxOutputTokens: int32(min(maxTokens, math.MaxInt32)), //nolint:gosec // clamped above
+		MaxOutputTokens: clampInt32(maxTokens),
 	}
 	if systemInstruction != nil {
 		config.SystemInstruction = systemInstruction
@@ -84,7 +98,7 @@ func (p *Provider) GenerateStructuredContent(ctx context.Context, messages []llm
 	}
 
 	genaiConfig := &genai.GenerateContentConfig{
-		MaxOutputTokens:  int32(min(maxTokens, math.MaxInt32)), //nolint:gosec // clamped above
+		MaxOutputTokens:  clampInt32(maxTokens),
 		ResponseMIMEType: "application/json",
 		ResponseSchema:   convertSchema(schema),
 	}

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -87,15 +87,7 @@ func (p *Provider) GenerateStructuredContent(ctx context.Context, messages []llm
 		return nil, fmt.Errorf("google: building contents: %w", err)
 	}
 
-	modelName := p.modelName
-	if config.ModelOverride != "" {
-		modelName = config.ModelOverride
-	}
-
-	maxTokens := config.MaxTokens
-	if maxTokens <= 0 {
-		maxTokens = 8192
-	}
+	modelName, maxTokens := config.Resolve(p.modelName)
 
 	genaiConfig := &genai.GenerateContentConfig{
 		MaxOutputTokens:  clampInt32(maxTokens),

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math"
+	"os"
 
 	"google.golang.org/genai"
 
@@ -220,7 +220,7 @@ func convertSchema(m map[string]any) *genai.Schema {
 		if mapped, known := jsonSchemaTypes[t]; known {
 			s.Type = mapped
 		} else {
-			log.Printf("google: convertSchema: unknown JSON Schema type %q; resulting schema will be malformed", t)
+			fmt.Fprintf(os.Stderr, "google: convertSchema: unknown JSON Schema type %q; resulting schema will be malformed\n", t)
 		}
 	}
 	if desc, ok := m["description"].(string); ok {

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math"
 
 	"google.golang.org/genai"
@@ -206,6 +207,8 @@ func convertSchema(m map[string]any) *genai.Schema {
 			s.Type = genai.TypeBoolean
 		case "array":
 			s.Type = genai.TypeArray
+		default:
+			log.Printf("google: convertSchema: unknown JSON Schema type %q; resulting schema will be malformed", t)
 		}
 	}
 	if desc, ok := m["description"].(string); ok {

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -246,12 +246,7 @@ func parseGenaiResponse(resp *genai.GenerateContentResponse) (*llm.Response, err
 		return nil, fmt.Errorf("google: candidate has no content")
 	}
 
-	result := &llm.Response{
-		Usage: llm.Usage{
-			PromptTokens: -1,
-			OutputTokens: -1,
-		},
-	}
+	result := &llm.Response{Usage: llm.UnknownUsage()}
 
 	if resp.UsageMetadata != nil {
 		result.Usage.PromptTokens = int(resp.UsageMetadata.PromptTokenCount - resp.UsageMetadata.CachedContentTokenCount)

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -82,6 +82,14 @@ type Usage struct {
 	CachedTokens   int // tokens served from a cache
 }
 
+// UnknownUsage returns a Usage with PromptTokens and OutputTokens set to -1,
+// indicating the provider did not report any token counts. ThinkingTokens
+// and CachedTokens remain 0 (the zero value) which providers overwrite when
+// they do have data.
+func UnknownUsage() Usage {
+	return Usage{PromptTokens: -1, OutputTokens: -1}
+}
+
 // TotalInput returns the total number of input-side tokens (prompt + cached).
 func (u Usage) TotalInput() int {
 	if u.PromptTokens < 0 {

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -109,12 +109,33 @@ type Response struct {
 	Usage            Usage          // token usage for this interaction
 }
 
+// DefaultStructuredMaxTokens is the fallback max-tokens budget used by
+// providers when StructuredConfig.MaxTokens is unset. Kept in sync with the
+// CLI's --max-tokens default (see cmd/ai_reviewer) so the structured
+// extraction pass has a consistent headroom across provider implementations.
+const DefaultStructuredMaxTokens = 8192
+
 // StructuredConfig provides options for structured output generation.
 type StructuredConfig struct {
 	// ModelOverride allows using a different model for the structured pass.
 	ModelOverride string
 	// MaxTokens limits the length of the LLM response.
 	MaxTokens int
+}
+
+// Resolve returns the effective model and max-tokens values, applying the
+// provider's default model when no override is set and
+// DefaultStructuredMaxTokens when MaxTokens is non-positive.
+func (c StructuredConfig) Resolve(defaultModel string) (string, int) {
+	model := defaultModel
+	if c.ModelOverride != "" {
+		model = c.ModelOverride
+	}
+	maxTokens := c.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = DefaultStructuredMaxTokens
+	}
+	return model, maxTokens
 }
 
 // Model is the only interface core.Agent depends on.

--- a/llm/retry.go
+++ b/llm/retry.go
@@ -37,56 +37,45 @@ func NewRetryingModel(inner Model, maxAttempts int, baseDelay time.Duration) *Re
 	return &RetryingModel{inner: inner, maxAttempts: maxAttempts, baseDelay: baseDelay}
 }
 
-// GenerateContent calls the underlying model, retrying on any error.
-func (r *RetryingModel) GenerateContent(ctx context.Context, messages []Message, tools []ToolDef, maxTokens int) (*Response, error) {
+// retry invokes fn up to maxAttempts times, doubling the delay between
+// attempts starting from baseDelay. It returns early if ctx is cancelled.
+func retry[T any](ctx context.Context, maxAttempts int, baseDelay time.Duration, fn func(context.Context) (T, error)) (T, error) {
+	var zero T
 	var lastErr error
-	delay := r.baseDelay
-	for attempt := range r.maxAttempts {
+	delay := baseDelay
+	for attempt := range maxAttempts {
 		if attempt > 0 {
 			timer := time.NewTimer(delay)
 			select {
 			case <-ctx.Done():
 				timer.Stop()
-				return nil, ctx.Err()
+				return zero, ctx.Err()
 			case <-timer.C:
 			}
 			delay *= 2
 		}
-		resp, err := r.inner.GenerateContent(ctx, messages, tools, maxTokens)
+		resp, err := fn(ctx)
 		if err == nil {
 			return resp, nil
 		}
 		lastErr = err
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return zero, ctx.Err()
 		}
 	}
-	return nil, lastErr
+	return zero, lastErr
+}
+
+// GenerateContent calls the underlying model, retrying on any error.
+func (r *RetryingModel) GenerateContent(ctx context.Context, messages []Message, tools []ToolDef, maxTokens int) (*Response, error) {
+	return retry(ctx, r.maxAttempts, r.baseDelay, func(ctx context.Context) (*Response, error) {
+		return r.inner.GenerateContent(ctx, messages, tools, maxTokens)
+	})
 }
 
 // GenerateStructuredContent calls the underlying model, retrying on any error.
 func (r *RetryingModel) GenerateStructuredContent(ctx context.Context, messages []Message, schema map[string]any, config StructuredConfig) (*Response, error) {
-	var lastErr error
-	delay := r.baseDelay
-	for attempt := range r.maxAttempts {
-		if attempt > 0 {
-			timer := time.NewTimer(delay)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return nil, ctx.Err()
-			case <-timer.C:
-			}
-			delay *= 2
-		}
-		resp, err := r.inner.GenerateStructuredContent(ctx, messages, schema, config)
-		if err == nil {
-			return resp, nil
-		}
-		lastErr = err
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-	}
-	return nil, lastErr
+	return retry(ctx, r.maxAttempts, r.baseDelay, func(ctx context.Context) (*Response, error) {
+		return r.inner.GenerateStructuredContent(ctx, messages, schema, config)
+	})
 }

--- a/llm/retry.go
+++ b/llm/retry.go
@@ -49,8 +49,8 @@ func (r *RetryingModel) GenerateContent(ctx context.Context, messages []Message,
 				timer.Stop()
 				return nil, ctx.Err()
 			case <-timer.C:
-				delay *= 2
 			}
+			delay *= 2
 		}
 		resp, err := r.inner.GenerateContent(ctx, messages, tools, maxTokens)
 		if err == nil {
@@ -76,8 +76,8 @@ func (r *RetryingModel) GenerateStructuredContent(ctx context.Context, messages 
 				timer.Stop()
 				return nil, ctx.Err()
 			case <-timer.C:
-				delay *= 2
 			}
+			delay *= 2
 		}
 		resp, err := r.inner.GenerateStructuredContent(ctx, messages, schema, config)
 		if err == nil {

--- a/llm/retry_test.go
+++ b/llm/retry_test.go
@@ -29,8 +29,8 @@ func (s *stubModel) GenerateContent(_ context.Context, _ []Message, _ []ToolDef,
 	return nil, errors.New("stubModel: no response configured")
 }
 
-func (s *stubModel) GenerateStructuredContent(_ context.Context, _ []Message, _ map[string]any, _ StructuredConfig) (*Response, error) {
-	return s.GenerateContent(context.Background(), nil, nil, 0)
+func (s *stubModel) GenerateStructuredContent(ctx context.Context, messages []Message, _ map[string]any, _ StructuredConfig) (*Response, error) {
+	return s.GenerateContent(ctx, messages, nil, 0)
 }
 
 // immediateRetryModel makes retries instant by using a zero base delay.
@@ -89,6 +89,21 @@ func TestRetryingModel_RespectsContextCancellation(t *testing.T) {
 	_, err := m.GenerateContent(ctx, nil, nil, 0)
 	require.Error(t, err)
 	// After the first failure the wrapper should detect ctx.Err() and stop.
+	assert.Equal(t, 1, stub.callCount)
+}
+
+func TestRetryingModel_GenerateStructuredContent_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	stub := &stubModel{
+		errs: []error{errors.New("transient")},
+	}
+	// Real delay so the cancelled context is detected before sleeping.
+	m := NewRetryingModel(stub, 3, 10*time.Second)
+
+	_, err := m.GenerateStructuredContent(ctx, nil, nil, StructuredConfig{})
+	require.Error(t, err)
 	assert.Equal(t, 1, stub.callCount)
 }
 

--- a/llm/retry_test.go
+++ b/llm/retry_test.go
@@ -107,6 +107,19 @@ func TestRetryingModel_GenerateStructuredContent_RespectsContextCancellation(t *
 	assert.Equal(t, 1, stub.callCount)
 }
 
+func TestRetryingModel_GenerateStructuredContent_ExhaustsAllAttempts(t *testing.T) {
+	sentinel := errors.New("permanent failure")
+	stub := &stubModel{
+		errs: []error{sentinel, sentinel, sentinel},
+	}
+	m := newInstantRetryModel(stub, 3)
+
+	_, err := m.GenerateStructuredContent(context.Background(), nil, nil, StructuredConfig{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 3, stub.callCount)
+}
+
 func TestRetryingModel_GenerateStructuredContent_Retries(t *testing.T) {
 	want := &Response{Text: `{"ok":true}`}
 	stub := &stubModel{


### PR DESCRIPTION
## Summary

Three-phase cleanup of `llm/` surfaced by a targeted review: bugs/correctness first, then Go idioms, then code-reuse consolidation, then doc updates to lock the patterns in.

- **P0 — bugs & correctness (4 commits):** cache-only Anthropic usage gate was leaving `CachedTokens` at `-1`; `stubModel.GenerateStructuredContent` dropped ctx/args and silently neutered the structured-path cancellation test; retry back-off multiplication was coupled to the timer-fired branch of a `select`; `convertSchema` silently dropped unknown JSON Schema types.
- **P1 — Go idioms (4 commits):** schema type switch → map lookup; `clampInt32` helper replaces two `//nolint:gosec` pragmas; `anthropic.New` option-list collapsed; `toContents` system branch unified.
- **P2 — code reuse (5 commits):** `retry[T]` generic helper collapses the two identical `RetryingModel` loops; `StructuredConfig.Resolve` + `DefaultStructuredMaxTokens` share the provider defaulting boilerplate; `llm.UnknownUsage()` centralizes the `-1/-1` sentinel; `schemaParamFromJSONSchema` dedupes Anthropic tool-schema builders; `submitReviewToolName` const replaces the inline string that `DESIGN.md` already treats as a contract.
- **P3 — verbosity (2 commits):** `factory.New` is now driven by a `providers` map — adding a provider is a one-line entry; `thoughtSignature` + `thoughtSignatureKey` const replace untyped `ProviderMetadata` map indexing.
- **Docs (3 commits):** cross-cutting test/lint rules added to root `AGENTS.md`; new `llm/AGENTS.md` captures the seven provider-implementation conventions with a symlinked `llm/CLAUDE.md` so Claude Code picks up the same scoped content; `DESIGN.md` §4 gains a "Shared Contracts" subsection naming the load-bearing symbols.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `golangci-lint run ./llm/...` (via hermetic Bazel Go toolchain)
- [x] `bazel run //:format` is a no-op
- [x] New cancellation test exercises `GenerateStructuredContent`
- [ ] CI green