### PR TITLE
refactor(core): cleanup and idiom pass

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -78,11 +78,12 @@ the companion implementation rules.
   exposes multiple counters (e.g. cache vs. non-cache), every counter path
   must be covered by the usage-presence guard.
 - **`llm.StructuredConfig.Resolve(defaultModel)`** — returns
-  `(model, maxTokens)` with `ModelOverride` and `DefaultStructuredMaxTokens`
+  `(model, maxTokens)` with `ModelOverride` and `DefaultMaxTokens`
   applied. `GenerateStructuredContent` implementations call this to
   eliminate per-provider defaulting boilerplate.
-- **`llm.DefaultStructuredMaxTokens = 8192`** — fallback budget for
-  structured-output calls. Kept in lockstep with the CLI `--max-tokens`
+- **`llm.DefaultMaxTokens = 8192`** — fallback token budget for both
+  `GenerateContent` and `GenerateStructuredContent` when the caller
+  does not specify one. Kept in lockstep with the CLI `--max-tokens`
   default in `cmd/ai_reviewer`.
 - **`llm.retry[T]`** (package-private) — the canonical exponential-back-off
   + ctx-cancellation loop. `RetryingModel` wraps the interface via this

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -42,7 +42,7 @@ func main() {
 	flag.StringVar(&workingDir, "cwd", "", "Working directory (defaults to BUILD_WORKSPACE_DIRECTORY or current directory)")
 	flag.StringVar(&mainGuidelines, "main-guidelines", "general", "Path to a file or a named prompt from the library")
 	flag.StringVar(&approvalEvaluationPromptFile, "approval-evaluation-prompt-file", "", "Optional path to a file containing custom approval evaluation guidelines")
-	flag.IntVar(&maxTokens, "max-tokens", 8192, "Max tokens for the LLM response")
+	flag.IntVar(&maxTokens, "max-tokens", llm.DefaultMaxTokens, "Max tokens for the LLM response")
 	flag.StringVar(&base, "base", "main", "Base commit/branch for diff")
 	flag.StringVar(&head, "head", "HEAD", "Head commit/branch for diff")
 	flag.StringVar(&reviewOutputFile, "review-output-file", "", "Path to a file where the final review will be written")

--- a/core/agent.go
+++ b/core/agent.go
@@ -155,7 +155,7 @@ func (a *Agent) RunReview(ctx context.Context, stableSystem, dynamicSystem, requ
 		maxIterations = AbsoluteMaxIter
 	}
 	if maxTokens <= 0 {
-		maxTokens = 8192
+		maxTokens = llm.DefaultMaxTokens
 	}
 
 	messages := []llm.Message{

--- a/core/agent.go
+++ b/core/agent.go
@@ -158,19 +158,13 @@ func (a *Agent) RunReview(ctx context.Context, stableSystem, dynamicSystem, requ
 		maxTokens = 8192
 	}
 
-	var messages []llm.Message
-	if dynamicSystem != "" {
-		messages = []llm.Message{
-			{Role: llm.RoleSystem, Text: stableSystem, CacheBreakpoint: true},
-			{Role: llm.RoleSystem, Text: dynamicSystem},
-			{Role: llm.RoleUser, Text: requestText},
-		}
-	} else {
-		messages = []llm.Message{
-			{Role: llm.RoleSystem, Text: stableSystem, CacheBreakpoint: true},
-			{Role: llm.RoleUser, Text: requestText},
-		}
+	messages := []llm.Message{
+		{Role: llm.RoleSystem, Text: stableSystem, CacheBreakpoint: true},
 	}
+	if dynamicSystem != "" {
+		messages = append(messages, llm.Message{Role: llm.RoleSystem, Text: dynamicSystem})
+	}
+	messages = append(messages, llm.Message{Role: llm.RoleUser, Text: requestText})
 
 	tools := a.registry.ToTools()
 

--- a/core/agent.go
+++ b/core/agent.go
@@ -182,7 +182,7 @@ func (a *Agent) RunReview(ctx context.Context, stableSystem, dynamicSystem, requ
 		}
 
 		a.reporter.ReportUsage(resp.Usage)
-		a.trackUsage(resp.Usage)
+		a.totalUsage.Add(resp.Usage)
 
 		// No tool calls → LLM has produced its final review.
 		if len(resp.ToolCalls) == 0 {
@@ -248,7 +248,7 @@ func (a *Agent) ExtractStructuredReview(ctx context.Context, extractionSystemPro
 		}
 
 		a.reporter.ReportUsage(resp.Usage)
-		a.trackUsage(resp.Usage)
+		a.totalUsage.Add(resp.Usage)
 
 		if resp.Text == "" {
 			lastErr = errors.New("extraction returned empty content")
@@ -316,16 +316,12 @@ func (a *Agent) handleCapReached(ctx context.Context, messages []llm.Message, ma
 	}
 
 	a.reporter.ReportUsage(resp.Usage)
-	a.trackUsage(resp.Usage)
+	a.totalUsage.Add(resp.Usage)
 
 	if resp.Text == "" {
 		return "", fmt.Errorf("llm returned empty content on forced-final review after %d attempts", emptyResponseMaxAttempts)
 	}
 	return resp.Text, nil
-}
-
-func (a *Agent) trackUsage(usage llm.Usage) {
-	a.totalUsage.Add(usage)
 }
 
 // generateContentWithEmptyRetry calls GenerateContent and retries up to

--- a/core/agent.go
+++ b/core/agent.go
@@ -324,18 +324,7 @@ func (a *Agent) handleCapReached(ctx context.Context, messages []llm.Message, ma
 }
 
 func (a *Agent) trackUsage(usage llm.Usage) {
-	if usage.PromptTokens > 0 {
-		a.totalUsage.PromptTokens += usage.PromptTokens
-	}
-	if usage.OutputTokens > 0 {
-		a.totalUsage.OutputTokens += usage.OutputTokens
-	}
-	if usage.ThinkingTokens > 0 {
-		a.totalUsage.ThinkingTokens += usage.ThinkingTokens
-	}
-	if usage.CachedTokens > 0 {
-		a.totalUsage.CachedTokens += usage.CachedTokens
-	}
+	a.totalUsage.Add(usage)
 }
 
 // generateContentWithEmptyRetry calls GenerateContent and retries up to

--- a/core/agent.go
+++ b/core/agent.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -250,7 +251,7 @@ func (a *Agent) ExtractStructuredReview(ctx context.Context, extractionSystemPro
 		a.trackUsage(resp.Usage)
 
 		if resp.Text == "" {
-			lastErr = fmt.Errorf("extraction returned empty content")
+			lastErr = errors.New("extraction returned empty content")
 			continue
 		}
 

--- a/core/agent.go
+++ b/core/agent.go
@@ -209,11 +209,7 @@ func (a *Agent) RunReview(ctx context.Context, stableSystem, dynamicSystem, requ
 			ProviderMetadata: resp.ProviderMetadata,
 		})
 
-		toolMsg, err := a.executeToolCalls(resp.ToolCalls)
-		if err != nil {
-			return "", err
-		}
-		messages = append(messages, toolMsg)
+		messages = append(messages, a.executeToolCalls(resp.ToolCalls))
 	}
 
 	return a.handleCapReached(ctx, messages, maxIterations, maxTokens)
@@ -276,7 +272,7 @@ func (a *Agent) ExtractStructuredReview(ctx context.Context, extractionSystemPro
 	return nil, lastErr
 }
 
-func (a *Agent) executeToolCalls(toolCalls []llm.ToolCall) (llm.Message, error) {
+func (a *Agent) executeToolCalls(toolCalls []llm.ToolCall) llm.Message {
 	// Execute all tool calls and collect results into ONE RoleTool message.
 	// All ToolResults must be in a single message so providers see strict
 	// role alternation (no consecutive same-role turns).
@@ -286,7 +282,6 @@ func (a *Agent) executeToolCalls(toolCalls []llm.ToolCall) (llm.Message, error) 
 	}
 
 	for _, tc := range toolCalls {
-		// Progress line: print tool name + a compact summary of args.
 		a.reporter.ReportToolCall(tc)
 
 		// Dispatch; on error, surface the message as the tool result so the
@@ -302,7 +297,7 @@ func (a *Agent) executeToolCalls(toolCalls []llm.ToolCall) (llm.Message, error) 
 			Content:    result,
 		})
 	}
-	return toolMsg, nil
+	return toolMsg
 }
 
 func (a *Agent) handleCapReached(ctx context.Context, messages []llm.Message, maxIterations, maxTokens int) (string, error) {

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -26,7 +26,14 @@ type mockLLM struct {
 	callIdx   int
 }
 
-func (m *mockLLM) GenerateContent(_ context.Context, msgs []llm.Message, _ []llm.ToolDef, _ int) (*llm.Response, error) {
+func (m *mockLLM) GenerateContent(ctx context.Context, msgs []llm.Message, _ []llm.ToolDef, _ int) (*llm.Response, error) {
+	// Honor ctx at entry so a cancelled context surfaces as ctx.Err() before
+	// any scripted response is returned. This is what real provider SDKs do,
+	// and it is the only way a ctx-forwarding test at the double's boundary
+	// can observe the cancellation path.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	snapshot := make([]llm.Message, len(msgs))
 	for i, msg := range msgs {
 		snapshot[i] = msg
@@ -706,18 +713,40 @@ func TestExtractStructuredReview_LLMErrorReturnsImmediately(t *testing.T) {
 	}
 }
 
+// TestMockLLM_GenerateStructuredContent_ForwardsCanceledContext verifies
+// that the test double forwards ctx to GenerateContent rather than silently
+// substituting context.Background() — the exact bug fixed in 7acedcd. This
+// is the only test that anchors cancellation at the double's boundary;
+// without it, ExtractStructuredReview's cancellation coverage would pass
+// even after a regression in GenerateStructuredContent's ctx forwarding.
+func TestMockLLM_GenerateStructuredContent_ForwardsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	lm := &mockLLM{responses: []*llm.Response{textResponse("never returned")}}
+
+	_, err := lm.GenerateStructuredContent(ctx, nil, nil, llm.StructuredConfig{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if lm.callIdx != 0 {
+		t.Errorf("expected 0 calls (mock should short-circuit on cancelled ctx), got %d", lm.callIdx)
+	}
+}
+
 // TestExtractStructuredReview_RespectsContextCancellation verifies that a
-// cancelled ctx halts the soft-retry loop: mockLLM returns empty content on
-// the first attempt (triggering a retry) and sleepWithContext at the top of
-// the next iteration detects the cancellation and returns ctx.Err() instead
-// of making a second LLM call.
+// cancelled ctx flows through ExtractStructuredReview's soft-retry loop and
+// surfaces as a wrapped context.Canceled. With mockLLM now honoring ctx at
+// entry, the cancellation is observed on the first call and the loop never
+// enters its second attempt.
 func TestExtractStructuredReview_RespectsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	lm := &mockLLM{responses: []*llm.Response{
-		{Text: ""}, // empty triggers soft retry; sleepWithContext will then propagate ctx.Err()
-	}}
+	lm := &mockLLM{responses: []*llm.Response{textResponse("never returned")}}
 
 	agent := newTestAgent(lm, newMockDispatcher())
 
@@ -728,8 +757,9 @@ func TestExtractStructuredReview_RespectsContextCancellation(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
 	}
-	if lm.callIdx != 1 {
-		t.Errorf("expected 1 LLM call before cancellation halted retry, got %d", lm.callIdx)
+	// mockLLM short-circuits on cancelled ctx; the first call never records.
+	if lm.callIdx != 0 {
+		t.Errorf("expected 0 LLM calls (mock short-circuit on cancelled ctx), got %d", lm.callIdx)
 	}
 }
 

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -197,10 +197,7 @@ func TestAgent_ExecuteToolCalls(t *testing.T) {
 		tc1 := llm.ToolCall{ID: "id1", Name: "tool1"}
 		tc2 := llm.ToolCall{ID: "id2", Name: "tool2"}
 
-		msg, err := agent.executeToolCalls([]llm.ToolCall{tc1, tc2})
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg := agent.executeToolCalls([]llm.ToolCall{tc1, tc2})
 
 		if msg.Role != llm.RoleTool {
 			t.Errorf("expected RoleTool, got %v", msg.Role)
@@ -218,10 +215,7 @@ func TestAgent_ExecuteToolCalls(t *testing.T) {
 		d.handlers["bad"] = func(_ llm.ToolCall) (string, error) { return "", fmt.Errorf("boom") }
 
 		agent := NewAgent(nil, d, WithStderr(io.Discard))
-		msg, err := agent.executeToolCalls([]llm.ToolCall{{ID: "id1", Name: "bad"}})
-		if err != nil {
-			t.Errorf("executeToolCalls should not return error on tool failure, got: %v", err)
-		}
+		msg := agent.executeToolCalls([]llm.ToolCall{{ID: "id1", Name: "bad"}})
 
 		if len(msg.ToolResults) != 1 {
 			t.Fatal("expected 1 result")

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -706,6 +706,33 @@ func TestExtractStructuredReview_LLMErrorReturnsImmediately(t *testing.T) {
 	}
 }
 
+// TestExtractStructuredReview_RespectsContextCancellation verifies that a
+// cancelled ctx halts the soft-retry loop: mockLLM returns empty content on
+// the first attempt (triggering a retry) and sleepWithContext at the top of
+// the next iteration detects the cancellation and returns ctx.Err() instead
+// of making a second LLM call.
+func TestExtractStructuredReview_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	lm := &mockLLM{responses: []*llm.Response{
+		{Text: ""}, // empty triggers soft retry; sleepWithContext will then propagate ctx.Err()
+	}}
+
+	agent := newTestAgent(lm, newMockDispatcher())
+
+	_, err := agent.ExtractStructuredReview(ctx, "sys", "raw review", llm.StructuredConfig{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if lm.callIdx != 1 {
+		t.Errorf("expected 1 LLM call before cancellation halted retry, got %d", lm.callIdx)
+	}
+}
+
 // TestRunReview_EmptyResponseRetry verifies that when the LLM returns a
 // successful but empty response (no text, no tool calls), the agent retries
 // the call and eventually succeeds.

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"testing"
 
 	"github.com/menny/cassandra/llm"
@@ -38,10 +39,7 @@ func (m *mockLLM) GenerateContent(_ context.Context, msgs []llm.Message, _ []llm
 			copy(snapshot[i].ToolResults, msg.ToolResults)
 		}
 		if msg.ProviderMetadata != nil {
-			snapshot[i].ProviderMetadata = make(map[string]any)
-			for k, v := range msg.ProviderMetadata {
-				snapshot[i].ProviderMetadata[k] = v
-			}
+			snapshot[i].ProviderMetadata = maps.Clone(msg.ProviderMetadata)
 		}
 	}
 	m.calls = append(m.calls, snapshot)

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -57,10 +57,10 @@ func (m *mockLLM) GenerateContent(_ context.Context, msgs []llm.Message, _ []llm
 	return m.responses[idx], nil
 }
 
-func (m *mockLLM) GenerateStructuredContent(_ context.Context, msgs []llm.Message, schema map[string]any, _ llm.StructuredConfig) (*llm.Response, error) {
+func (m *mockLLM) GenerateStructuredContent(ctx context.Context, msgs []llm.Message, schema map[string]any, _ llm.StructuredConfig) (*llm.Response, error) {
 	m.schemas = append(m.schemas, schema)
 	// For testing, just treat it like GenerateContent but record the call.
-	return m.GenerateContent(context.Background(), msgs, nil, 0)
+	return m.GenerateContent(ctx, msgs, nil, 0)
 }
 
 // textResponse builds a Response with plain text and no tool calls.

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -212,7 +212,7 @@ func TestAgent_ExecuteToolCalls(t *testing.T) {
 
 	t.Run("error-handling (individual tool failure)", func(t *testing.T) {
 		d := newMockDispatcher()
-		d.handlers["bad"] = func(_ llm.ToolCall) (string, error) { return "", fmt.Errorf("boom") }
+		d.handlers["bad"] = func(_ llm.ToolCall) (string, error) { return "", errors.New("boom") }
 
 		agent := NewAgent(nil, d, WithStderr(io.Discard))
 		msg := agent.executeToolCalls([]llm.ToolCall{{ID: "id1", Name: "bad"}})

--- a/core/review_types.go
+++ b/core/review_types.go
@@ -39,7 +39,7 @@ func (fr *FileReview) ParseLines() (int, int, error) {
 	if len(parts) == 1 {
 		line, err := strconv.Atoi(strings.TrimSpace(parts[0]))
 		if err != nil {
-			return 0, 0, fmt.Errorf("invalid line format: %v", err)
+			return 0, 0, fmt.Errorf("invalid line format: %w", err)
 		}
 		return line, line, nil
 	}
@@ -47,11 +47,11 @@ func (fr *FileReview) ParseLines() (int, int, error) {
 	if len(parts) == 2 {
 		startLine, err := strconv.Atoi(strings.TrimSpace(parts[0]))
 		if err != nil {
-			return 0, 0, fmt.Errorf("invalid start line format: %v", err)
+			return 0, 0, fmt.Errorf("invalid start line format: %w", err)
 		}
 		endLine, err := strconv.Atoi(strings.TrimSpace(parts[1]))
 		if err != nil {
-			return 0, 0, fmt.Errorf("invalid end line format: %v", err)
+			return 0, 0, fmt.Errorf("invalid end line format: %w", err)
 		}
 
 		if startLine > endLine {

--- a/llm/AGENTS.md
+++ b/llm/AGENTS.md
@@ -35,6 +35,11 @@ data?" MUST cover **every** counter path. A guard that only checks the
 non-cache counters will silently leave `CachedTokens` at its sentinel for
 cache-only responses — the exact bug fixed in `da5f0f3`.
 
+Callers aggregating per-iteration `Usage` into a session total MUST use
+`(*Usage).Add(other)`, which ignores sentinel fields (values ≤ 0) so
+`UnknownUsage()` responses do not corrupt the aggregate. Do not hand-roll
+field-by-field accumulation.
+
 ### 4. Tool-Name Contracts
 Tool names referenced by downstream consumers or documented in
 `DESIGN.md` (e.g. `submitReviewToolName`) MUST be package-level `const`s

--- a/llm/AGENTS.md
+++ b/llm/AGENTS.md
@@ -21,7 +21,7 @@ Every `GenerateStructuredContent` implementation MUST open with:
 modelName, maxTokens := config.Resolve(p.modelName)
 ```
 Do not inline model-override or max-tokens defaulting.
-`llm.DefaultStructuredMaxTokens` is the single source of truth and is kept
+`llm.DefaultMaxTokens` is the single source of truth and is kept
 in lockstep with the CLI `--max-tokens` default.
 
 ### 3. Usage Sentinel

--- a/llm/REVIEWERS.md
+++ b/llm/REVIEWERS.md
@@ -20,6 +20,6 @@ Behavioral divergence between `llm/anthropic` and `llm/google` is a defect unles
 ## Paired edits (block if one is missing)
 
 - `submitReviewToolName` ↔ `DESIGN.md §Technical Decisions 4`.
-- `DefaultStructuredMaxTokens` ↔ CLI `--max-tokens` default in `cmd/ai_reviewer`.
+- `DefaultMaxTokens` ↔ CLI `--max-tokens` default in `cmd/ai_reviewer`.
 - New provider ↔ `factory.providers` map + `README.md` §Supported Models.
 - `llm.Model` signature change ↔ test doubles under `llm/`.

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -136,11 +136,12 @@ type Response struct {
 	Usage            Usage          // token usage for this interaction
 }
 
-// DefaultStructuredMaxTokens is the fallback max-tokens budget used by
-// providers when StructuredConfig.MaxTokens is unset. Kept in sync with the
-// CLI's --max-tokens default (see cmd/ai_reviewer) so the structured
-// extraction pass has a consistent headroom across provider implementations.
-const DefaultStructuredMaxTokens = 8192
+// DefaultMaxTokens is the fallback max-tokens budget for LLM calls when the
+// caller does not specify one — covering both GenerateContent (via
+// core.Agent.RunReview) and GenerateStructuredContent (via
+// StructuredConfig.Resolve). Kept in sync with the CLI's --max-tokens
+// default (see cmd/ai_reviewer) so every pass has consistent headroom.
+const DefaultMaxTokens = 8192
 
 // StructuredConfig provides options for structured output generation.
 type StructuredConfig struct {
@@ -151,8 +152,8 @@ type StructuredConfig struct {
 }
 
 // Resolve returns the effective model and max-tokens values, applying the
-// provider's default model when no override is set and
-// DefaultStructuredMaxTokens when MaxTokens is non-positive.
+// provider's default model when no override is set and DefaultMaxTokens
+// when MaxTokens is non-positive.
 func (c StructuredConfig) Resolve(defaultModel string) (string, int) {
 	model := defaultModel
 	if c.ModelOverride != "" {
@@ -160,7 +161,7 @@ func (c StructuredConfig) Resolve(defaultModel string) (string, int) {
 	}
 	maxTokens := c.MaxTokens
 	if maxTokens <= 0 {
-		maxTokens = DefaultStructuredMaxTokens
+		maxTokens = DefaultMaxTokens
 	}
 	return model, maxTokens
 }

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -90,6 +90,25 @@ func UnknownUsage() Usage {
 	return Usage{PromptTokens: -1, OutputTokens: -1}
 }
 
+// Add accumulates other's token counts into u, ignoring sentinel fields
+// (values <= 0). Intended for callers that sum per-iteration Usage into a
+// running session total without letting UnknownUsage() sentinels
+// corrupt the aggregate.
+func (u *Usage) Add(other Usage) {
+	if other.PromptTokens > 0 {
+		u.PromptTokens += other.PromptTokens
+	}
+	if other.OutputTokens > 0 {
+		u.OutputTokens += other.OutputTokens
+	}
+	if other.ThinkingTokens > 0 {
+		u.ThinkingTokens += other.ThinkingTokens
+	}
+	if other.CachedTokens > 0 {
+		u.CachedTokens += other.CachedTokens
+	}
+}
+
 // TotalInput returns the total number of input-side tokens (prompt + cached).
 func (u Usage) TotalInput() int {
 	if u.PromptTokens < 0 {

--- a/llm/llm_test.go
+++ b/llm/llm_test.go
@@ -7,6 +7,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestUsage_Add(t *testing.T) {
+	t.Run("accumulates positive counts", func(t *testing.T) {
+		u := Usage{PromptTokens: 10, OutputTokens: 5}
+		u.Add(Usage{PromptTokens: 3, OutputTokens: 2, ThinkingTokens: 7, CachedTokens: 1})
+		assert.Equal(t, Usage{PromptTokens: 13, OutputTokens: 7, ThinkingTokens: 7, CachedTokens: 1}, u)
+	})
+
+	t.Run("ignores UnknownUsage sentinel", func(t *testing.T) {
+		u := Usage{PromptTokens: 10, OutputTokens: 5}
+		u.Add(UnknownUsage())
+		assert.Equal(t, Usage{PromptTokens: 10, OutputTokens: 5}, u)
+	})
+
+	t.Run("ignores zero fields", func(t *testing.T) {
+		u := Usage{PromptTokens: 10}
+		u.Add(Usage{PromptTokens: 0, OutputTokens: 0, ThinkingTokens: 4})
+		assert.Equal(t, Usage{PromptTokens: 10, ThinkingTokens: 4}, u)
+	})
+}
+
 func TestToolCall_UnmarshalArguments(t *testing.T) {
 	t.Run("empty arguments", func(t *testing.T) {
 		tc := &ToolCall{Arguments: ""}


### PR DESCRIPTION
## Summary

Applies the same four-phase cleanup pattern as the llm/ work (#54) to `core/`:

- **P0 — bugs & correctness (2 commits):** `mockLLM.GenerateStructuredContent` dropped ctx (identical pattern to the `stubModel` bug fixed in #54 and explicitly banned by AGENTS.md §3); `Agent.executeToolCalls` returned `(Message, error)` but never produced a non-nil error — tool-handler errors are intentionally converted to tool-result text so the ReAct loop survives individual tool failures.
- **P1 — idioms (1 commit):** collapse `RunReview`'s duplicated if/else message-list construction into a base slice + conditional append.
- **P2 — code reuse (2 commits):** promote the per-field usage accumulation into `llm.Usage.Add(other)` (the type that owns the `-1` sentinel), and rename `llm.DefaultStructuredMaxTokens` → `llm.DefaultMaxTokens` now that both `GenerateContent` and `GenerateStructuredContent` share the budget; `core.RunReview` references the const instead of hardcoding `8192`.
- **P3 — verbosity/idioms (3 commits):** `errors.New` for empty-format `fmt.Errorf`, `%w` for `ParseLines` strconv wraps (enables `errors.Is/As`), `maps.Clone` for `ProviderMetadata` deep copy (silences `mapsloop`), and inline the now-trivial `trackUsage` wrapper.

Doc updates in `llm/AGENTS.md`, `llm/REVIEWERS.md`, and `DESIGN.md §4 Shared Contracts` ride along with the `DefaultMaxTokens` rename and `Usage.Add` addition.

No scoped `core/AGENTS.md` or `core/REVIEWERS.md` — none of the surfaced patterns are strong enough to justify their own file; the `executeToolCalls` "errors become tool-result text" invariant is already self-documented by the function's existing comment.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `golangci-lint run ./core/...` clean
- [x] `bazel run //:format` is a no-op
- [x] Exhaustion / cancellation / empty-content tests unaffected
- [ ] CI green