### PR TITLE
refactor(tools): error idioms and helper extraction

### DIFF
--- a/tools/diff.go
+++ b/tools/diff.go
@@ -36,7 +36,7 @@ func FetchGitDiff(workingDir, base, head string) (string, []string, error) {
 	cmd.Dir = workingDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", nil, fmt.Errorf("git diff %s failed in %s: %v\nOutput: %s", diffRange, workingDir, err, string(out))
+		return "", nil, fmt.Errorf("git diff %s failed in %s: %w\nOutput: %s", diffRange, workingDir, err, string(out))
 	}
 
 	diffText := string(out)
@@ -83,7 +83,7 @@ func FetchGitCommits(workingDir, base, head string) (string, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		// If git log fails (e.g., shallow clone), we return an error to be handled by the caller.
-		return "", fmt.Errorf("git log %s failed: %v. Output: %s", commitRange, err, string(out))
+		return "", fmt.Errorf("git log %s failed: %w. Output: %s", commitRange, err, string(out))
 	}
 
 	return string(out), nil

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -16,6 +16,16 @@ var LockFiles = []string{
 	"Gemfile.lock",
 }
 
+// appendLockFileExcludes appends a git pathspec ":(exclude)*<name>" for each
+// entry in LockFiles to args, returning the grown slice. Used to suppress
+// noisy lockfile churn in diff and grep output.
+func appendLockFileExcludes(args []string) []string {
+	for _, lf := range LockFiles {
+		args = append(args, fmt.Sprintf(":(exclude)*%s", lf))
+	}
+	return args
+}
+
 func FetchGitDiff(workingDir, base, head string) (string, []string, error) {
 	var diffRange string
 	if head == "HEAD" {
@@ -28,9 +38,7 @@ func FetchGitDiff(workingDir, base, head string) (string, []string, error) {
 	cmdArgs := []string{"diff", diffRange}
 
 	cmdArgs = append(cmdArgs, "--", ".")
-	for _, lf := range LockFiles {
-		cmdArgs = append(cmdArgs, fmt.Sprintf(":(exclude)*%s", lf))
-	}
+	cmdArgs = appendLockFileExcludes(cmdArgs)
 
 	cmd := exec.Command("git", cmdArgs...)
 	cmd.Dir = workingDir
@@ -45,10 +53,7 @@ func FetchGitDiff(workingDir, base, head string) (string, []string, error) {
 	}
 
 	// Get file list
-	nameOnlyArgs := []string{"diff", "--name-only", diffRange, "--", "."}
-	for _, lf := range LockFiles {
-		nameOnlyArgs = append(nameOnlyArgs, fmt.Sprintf(":(exclude)*%s", lf))
-	}
+	nameOnlyArgs := appendLockFileExcludes([]string{"diff", "--name-only", diffRange, "--", "."})
 	nameOnlyCmd := exec.Command("git", nameOnlyArgs...)
 	nameOnlyCmd.Dir = workingDir
 	nameOnlyOut, err := nameOnlyCmd.CombinedOutput()

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -26,6 +26,19 @@ func appendLockFileExcludes(args []string) []string {
 	return args
 }
 
+// runGit invokes `git <args>` in the given working directory (or the current
+// directory when dir is empty) and returns combined stdout+stderr. Callers
+// wrap the returned error with their own context; runGit itself does not
+// format the error so callers can inspect the exit code via errors.As
+// (*exec.ExitError) where relevant.
+func runGit(dir string, args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	return cmd.CombinedOutput()
+}
+
 func FetchGitDiff(workingDir, base, head string) (string, []string, error) {
 	var diffRange string
 	if head == "HEAD" {
@@ -40,9 +53,7 @@ func FetchGitDiff(workingDir, base, head string) (string, []string, error) {
 	cmdArgs = append(cmdArgs, "--", ".")
 	cmdArgs = appendLockFileExcludes(cmdArgs)
 
-	cmd := exec.Command("git", cmdArgs...)
-	cmd.Dir = workingDir
-	out, err := cmd.CombinedOutput()
+	out, err := runGit(workingDir, cmdArgs...)
 	if err != nil {
 		return "", nil, fmt.Errorf("git diff %s failed in %s: %w\nOutput: %s", diffRange, workingDir, err, string(out))
 	}
@@ -54,9 +65,7 @@ func FetchGitDiff(workingDir, base, head string) (string, []string, error) {
 
 	// Get file list
 	nameOnlyArgs := appendLockFileExcludes([]string{"diff", "--name-only", diffRange, "--", "."})
-	nameOnlyCmd := exec.Command("git", nameOnlyArgs...)
-	nameOnlyCmd.Dir = workingDir
-	nameOnlyOut, err := nameOnlyCmd.CombinedOutput()
+	nameOnlyOut, err := runGit(workingDir, nameOnlyArgs...)
 	if err != nil {
 		return diffText, nil, nil // Fallback if name-only fails
 	}
@@ -81,11 +90,7 @@ func FetchGitCommits(workingDir, base, head string) (string, error) {
 	}
 
 	// Use a clean format for commit messages
-	cmdArgs := []string{"log", "--pretty=format:- %s", "--no-merges", commitRange}
-	cmd := exec.Command("git", cmdArgs...)
-	cmd.Dir = workingDir
-
-	out, err := cmd.CombinedOutput()
+	out, err := runGit(workingDir, "log", "--pretty=format:- %s", "--no-merges", commitRange)
 	if err != nil {
 		// If git log fails (e.g., shallow clone), we return an error to be handled by the caller.
 		return "", fmt.Errorf("git log %s failed: %w. Output: %s", commitRange, err, string(out))

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -160,8 +160,7 @@ func registerLocalGrepFiles(r *Registry) {
 		// Note: git grep already searches the working tree (unstaged changes) by default.
 		// We've also added --untracked to include newly created files.
 
-		cmd := exec.Command("git", cmdArgs...)
-		out, err := cmd.CombinedOutput()
+		out, err := runGit("", cmdArgs...)
 		if err != nil {
 			// git grep returns exit code 1 if no matches are found.
 			var exitErr *exec.ExitError

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -164,8 +165,9 @@ func registerLocalGrepFiles(r *Registry) {
 		cmd := exec.Command("git", cmdArgs...)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			// git grep returns exit code 1 if no matches are found
-			if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == 1 && len(out) == 0 {
+			// git grep returns exit code 1 if no matches are found.
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && len(out) == 0 {
 				return "No matches found.", nil
 			}
 			return "", fmt.Errorf("grep_files failed: %w\nOutput: %s", err, string(out))

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -155,9 +155,7 @@ func registerLocalGrepFiles(r *Registry) {
 		}
 
 		// Filter out lock files as they are usually not relevant and can be huge.
-		for _, lf := range LockFiles {
-			cmdArgs = append(cmdArgs, fmt.Sprintf(":(exclude)*%s", lf))
-		}
+		cmdArgs = appendLockFileExcludes(cmdArgs)
 
 		// Note: git grep already searches the working tree (unstaged changes) by default.
 		// We've also added --untracked to include newly created files.

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -168,7 +168,7 @@ func registerLocalGrepFiles(r *Registry) {
 			if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == 1 && len(out) == 0 {
 				return "No matches found.", nil
 			}
-			return "", fmt.Errorf("grep_files failed: %v\nOutput: %s", err, string(out))
+			return "", fmt.Errorf("grep_files failed: %w\nOutput: %s", err, string(out))
 		}
 
 		output := string(out)


### PR DESCRIPTION
## Summary

Same four-phase pattern as the prior cleanups (#54 llm/, #55 core/), scoped to `tools/`.

- **P0 — idiom fixes (2 commits):** `%v` → `%w` at three git-command error-wrap sites so callers can `errors.Is/As` the underlying `*exec.ExitError`; switch `grep_files`' no-match detection from `cmd.ProcessState.ExitCode() == 1` to `errors.As(err, *exec.ExitError)` — more robust (ProcessState can be nil on spawn failures) and idiomatic.
- **P2 — reuse (2 commits):** extract `appendLockFileExcludes` (3 call sites across diff, name-only diff, grep) and `runGit(dir, args...)` (4 call sites). The runGit helper deliberately returns the raw error without wrapping so callers retain `errors.As` access to the underlying ExitError.

## Out of scope (deliberate)

- **ctx plumbing into `ToolHandler`**: adding `context.Context` to the handler signature would ripple through `Registry`, `ToolDispatcher`, `core.Agent.executeToolCalls`, and the mock dispatcher. Worth doing but not in a cleanup PR.
- **Schema-builder helper for tool definitions**: each tool's JSON Schema is distinct and reads cleanly as a literal; a generalizing helper would obscure more than it saves.
- **No new `tools/AGENTS.md` or `tools/REVIEWERS.md`**: no cross-cutting invariants surfaced that aren't already covered by root AGENTS.md.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` — all packages green including `tools/` which now tests the new helpers transparently via existing behavioral tests
- [x] `bazel run //:format` is a no-op
- [x] Existing `FetchGitDiff`, `FetchGitCommits`, and `grep_files` tests unchanged — helpers are behaviorally equivalent
- [ ] CI green