### PR TITLE
refactor(cmd): cleanup and shared helpers

### DIFF
--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -302,13 +302,13 @@ func formatMetadata(metadata core.PRMetadata) string {
 	var sb strings.Builder
 	sb.WriteString("### PR Metadata\n")
 	if metadata.RepoFullName != "" {
-		sb.WriteString(fmt.Sprintf("- **Repository**: %s\n", metadata.RepoFullName))
+		fmt.Fprintf(&sb, "- **Repository**: %s\n", metadata.RepoFullName)
 	}
-	sb.WriteString(fmt.Sprintf("- **Author**: %s\n", metadata.Author))
-	sb.WriteString(fmt.Sprintf("- **Date**: %s\n", metadata.CreatedAt.Format("2006-01-02")))
-	sb.WriteString(fmt.Sprintf("- **Title**: %s\n", metadata.Title))
+	fmt.Fprintf(&sb, "- **Author**: %s\n", metadata.Author)
+	fmt.Fprintf(&sb, "- **Date**: %s\n", metadata.CreatedAt.Format("2006-01-02"))
+	fmt.Fprintf(&sb, "- **Title**: %s\n", metadata.Title)
 	if metadata.Description != "" {
-		sb.WriteString(fmt.Sprintf("- **Description**: %s\n", metadata.Description))
+		fmt.Fprintf(&sb, "- **Description**: %s\n", metadata.Description)
 	}
 
 	if len(metadata.Comments) > 0 {
@@ -330,11 +330,11 @@ func formatMetadata(metadata core.PRMetadata) string {
 					location = fmt.Sprintf(" on %s (file-level)", c.Path)
 				}
 			}
-			sb.WriteString(fmt.Sprintf("- **%s** (%s)%s:\n", author, c.Date.Format("2006-01-02 15:04"), location))
+			fmt.Fprintf(&sb, "- **%s** (%s)%s:\n", author, c.Date.Format("2006-01-02 15:04"), location)
 			// Indent body and wrap in blockquote to maintain Markdown structure
 			lines := strings.Split(c.Body, "\n")
 			for _, line := range lines {
-				sb.WriteString(fmt.Sprintf("  > %s\n", line))
+				fmt.Fprintf(&sb, "  > %s\n", line)
 			}
 		}
 	}

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -126,57 +126,45 @@ func main() {
 			log.Fatalf("Failed to marshal metadata: %v", err)
 		}
 
-		if outputFile != "" {
-			if err := os.WriteFile(outputFile, bytes, 0o644); err != nil {
-				log.Fatalf("Failed to write metadata to %s: %v", outputFile, err)
-			}
-		} else {
-			fmt.Println(string(bytes))
-		}
+		writeOutputOrStdout(outputFile, "metadata", bytes)
 
 	case "get-diff":
 		diff, err := getDiff(ctx, client, owner, repo, prNumber)
 		if err != nil {
 			log.Fatalf("Failed to get diff: %v", err)
 		}
-		if outputFile != "" {
-			if err := os.WriteFile(outputFile, []byte(diff), 0o644); err != nil {
-				log.Fatalf("Failed to write diff to %s: %v", outputFile, err)
-			}
-		} else {
-			fmt.Println(diff)
-		}
+		writeOutputOrStdout(outputFile, "diff", []byte(diff))
 
 	case "get-files":
 		files, err := getFiles(ctx, client, owner, repo, prNumber)
 		if err != nil {
 			log.Fatalf("Failed to get files: %v", err)
 		}
-		content := strings.Join(files, "\n")
-		if outputFile != "" {
-			if err := os.WriteFile(outputFile, []byte(content), 0o644); err != nil {
-				log.Fatalf("Failed to write files to %s: %v", outputFile, err)
-			}
-		} else {
-			fmt.Println(content)
-		}
+		writeOutputOrStdout(outputFile, "files", []byte(strings.Join(files, "\n")))
 
 	case "get-commits":
 		commits, err := getCommits(ctx, client, owner, repo, prNumber)
 		if err != nil {
 			log.Fatalf("Failed to get commits: %v", err)
 		}
-		content := strings.Join(commits, "\n")
-		if outputFile != "" {
-			if err := os.WriteFile(outputFile, []byte(content), 0o644); err != nil {
-				log.Fatalf("Failed to write commits to %s: %v", outputFile, err)
-			}
-		} else {
-			fmt.Println(content)
-		}
+		writeOutputOrStdout(outputFile, "commits", []byte(strings.Join(commits, "\n")))
 
 	default:
 		log.Fatalf("Unknown action: %s", action)
+	}
+}
+
+// writeOutputOrStdout writes data to outputFile when set, otherwise prints
+// it to stdout. label is used only in the fatal-error message to identify
+// which action produced the data. Fatals on I/O failure — callers are in
+// the main dispatch and have no meaningful recovery path.
+func writeOutputOrStdout(outputFile, label string, data []byte) {
+	if outputFile == "" {
+		fmt.Println(string(data))
+		return
+	}
+	if err := os.WriteFile(outputFile, data, 0o644); err != nil {
+		log.Fatalf("Failed to write %s to %s: %v", label, outputFile, err)
 	}
 }
 

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -188,6 +188,17 @@ func parseRepo(fullName string) (owner, repo string, err error) {
 	return parts[0], parts[1], nil
 }
 
+// Tag prefixes used to namespace bot-authored PR content. DESIGN.md
+// describes the separation: main-tag comments carry the persistent
+// architectural review, inline-tag comments carry per-line feedback, and
+// the empty-prefix form identifies formal PR-level review bodies. Changes
+// to these prefixes must be coordinated with README.md's troubleshooting
+// section since they appear verbatim in user-visible documentation.
+const (
+	tagPrefixMain   = "cassandra-main-"
+	tagPrefixInline = "cassandra-inline-"
+)
+
 // retryableStatusCodes are HTTP status codes that indicate a transient failure
 // on the GitHub API side and are safe to retry.
 var retryableStatusCodes = map[int]bool{
@@ -270,7 +281,7 @@ func postComment(ctx context.Context, client *github.Client, owner, repo string,
 		return fmt.Errorf("failed to read body file: %w", err)
 	}
 
-	mainTag := wrapTag(tag, "cassandra-main-")
+	mainTag := wrapTag(tag, tagPrefixMain)
 	return postCommentText(ctx, client, owner, repo, prNumber, string(body), mainTag)
 }
 
@@ -353,8 +364,8 @@ func getMetadata(ctx context.Context, client *github.Client, owner, repo string,
 		return nil, fmt.Errorf("failed to get PR: %w", err)
 	}
 
-	mainTag := wrapTag(tag, "cassandra-main-")
-	inlineTag := wrapTag(tag, "cassandra-inline-")
+	mainTag := wrapTag(tag, tagPrefixMain)
+	inlineTag := wrapTag(tag, tagPrefixInline)
 	reviewTag := wrapTag(tag, "")
 
 	metadata := &core.PRMetadata{
@@ -465,8 +476,8 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 	}
 
 	reviewTag := wrapTag(tag, "")
-	inlineTag := wrapTag(tag, "cassandra-inline-")
-	mainTag := wrapTag(tag, "cassandra-main-")
+	inlineTag := wrapTag(tag, tagPrefixInline)
+	mainTag := wrapTag(tag, tagPrefixMain)
 
 	// 1. Dismiss previous reviews BEFORE providing new review
 	if tag != "" {

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -220,8 +220,8 @@ func retryGitHubWrite(ctx context.Context, fn func() (*github.Response, error), 
 				timer.Stop()
 				return lastResp, ctx.Err()
 			case <-timer.C:
-				baseDelay *= 2
 			}
+			baseDelay *= 2
 		}
 		resp, err := fn()
 		if err == nil {

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -16,6 +16,12 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
+// stderr is used for all non-fatal diagnostic / warning output so that any
+// future stdout contract (matching cmd/ai_reviewer) isn't polluted by
+// log-package timestamp prefixes. log.Fatalf still uses the default logger
+// for fatal exits — the timestamp is acceptable on termination.
+var stderr = log.New(os.Stderr, "", 0)
+
 func main() {
 	var repoFullName string
 	var prNumber int
@@ -276,7 +282,7 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 	self, _, err := client.Users.Get(ctx, "")
 	selfLogin := ""
 	if err != nil {
-		log.Printf("Warning: failed to get self user (likely due to GITHUB_TOKEN permissions): %v. Deduplication will rely solely on the tag.", err)
+		stderr.Printf("Warning: failed to get self user (likely due to GITHUB_TOKEN permissions): %v. Deduplication will rely solely on the tag.", err)
 	} else {
 		selfLogin = self.GetLogin()
 	}
@@ -318,7 +324,7 @@ func postCommentText(ctx context.Context, client *github.Client, owner, repo str
 	// Delete redundant comments first
 	for _, id := range redundantCommentIDs {
 		if _, err := client.Issues.DeleteComment(ctx, owner, repo, id); err != nil {
-			log.Printf("Warning: failed to delete redundant comment %d: %v", id, err)
+			stderr.Printf("Warning: failed to delete redundant comment %d: %v", id, err)
 		}
 	}
 
@@ -450,10 +456,10 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 	if metadataFile != "" {
 		metadataBytes, err := os.ReadFile(metadataFile)
 		if err != nil {
-			log.Printf("Warning: failed to read metadata file: %v. Deduplication will be limited.", err)
+			stderr.Printf("Warning: failed to read metadata file: %v. Deduplication will be limited.", err)
 		} else {
 			if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
-				log.Printf("Warning: failed to unmarshal metadata: %v", err)
+				stderr.Printf("Warning: failed to unmarshal metadata: %v", err)
 			}
 		}
 	}
@@ -465,7 +471,7 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 	// 1. Dismiss previous reviews BEFORE providing new review
 	if tag != "" {
 		if err := dismissPreviousReviews(ctx, client, owner, repo, prNumber, reviewTag, 0); err != nil {
-			log.Printf("Warning: failed to dismiss previous reviews: %v", err)
+			stderr.Printf("Warning: failed to dismiss previous reviews: %v", err)
 		}
 	}
 
@@ -474,7 +480,7 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 		for _, c := range metadata.Comments {
 			if c.IsSelf && strings.Contains(c.Body, inlineTag) {
 				if _, err := client.PullRequests.DeleteComment(ctx, owner, repo, c.ID); err != nil {
-					log.Printf("Warning: failed to delete old inline comment %d: %v", c.ID, err)
+					stderr.Printf("Warning: failed to delete old inline comment %d: %v", c.ID, err)
 				}
 			}
 		}
@@ -483,7 +489,7 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 	// 3. Post Non-Specific Review as a separate comment
 	if sr.NonSpecificReview != "" {
 		if err := postCommentText(ctx, client, owner, repo, prNumber, sr.NonSpecificReview, mainTag); err != nil {
-			log.Printf("Warning: failed to post non-specific review comment: %v", err)
+			stderr.Printf("Warning: failed to post non-specific review comment: %v", err)
 		}
 	}
 
@@ -493,7 +499,7 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 	for _, fr := range sr.FilesReview {
 		startLine, endLine, err := fr.ParseLines()
 		if err != nil {
-			log.Printf("Warning: failed to parse lines for %s: %v. Appending to main review rationale.", fr.Path, err)
+			stderr.Printf("Warning: failed to parse lines for %s: %v. Appending to main review rationale.", fr.Path, err)
 			reviewRationale = fmt.Sprintf("%s\n\n- **%s**: %s", reviewRationale, fr.Path, fr.Review)
 			continue
 		}
@@ -550,7 +556,7 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 			hasComments := len(reviewRequest.Comments) > 0
 
 			if isPermissionError {
-				log.Printf("Warning: GITHUB_TOKEN is not permitted to approve PRs. Falling back to COMMENT review.")
+				stderr.Printf("Warning: GITHUB_TOKEN is not permitted to approve PRs. Falling back to COMMENT review.")
 				reviewRequest.Event = github.Ptr("COMMENT")
 
 				// Try again with COMMENT action, keeping inline comments
@@ -569,7 +575,7 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 			}
 
 			if hasComments {
-				log.Printf("Warning: failed to post structured review (likely due to line hallucinations): %v. Retrying without inline comments.", errStr)
+				stderr.Printf("Warning: failed to post structured review (likely due to line hallucinations): %v. Retrying without inline comments.", errStr)
 				reviewRequest.Comments = nil
 				var sb strings.Builder
 				sb.WriteString(reviewRequest.GetBody())
@@ -615,7 +621,7 @@ func dismissPreviousReviews(ctx context.Context, client *github.Client, owner, r
 					})
 					return resp, err
 				}, 3); err != nil {
-					log.Printf("Warning: failed to dismiss review %d: %v", reviewID, err)
+					stderr.Printf("Warning: failed to dismiss review %d: %v", reviewID, err)
 				}
 			}
 		}

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -650,17 +650,10 @@ func getDiff(ctx context.Context, client *github.Client, owner, repo string, prN
 			// Extract the b/ path from "diff --git a/path/to/file b/path/to/file".
 			// Using strings.Fields would break for paths containing spaces, so we
 			// split on " b/" from the right to correctly isolate the destination path.
-			isLockFile := false
+			skipping = false
 			if idx := strings.LastIndex(line, " b/"); idx != -1 {
-				pathB := line[idx+3:]
-				for _, lf := range tools.LockFiles {
-					if pathB == lf || strings.HasSuffix(pathB, "/"+lf) {
-						isLockFile = true
-						break
-					}
-				}
+				skipping = tools.IsLockFile(line[idx+3:])
 			}
-			skipping = isLockFile
 		}
 
 		if !skipping {
@@ -683,15 +676,7 @@ func getFiles(ctx context.Context, client *github.Client, owner, repo string, pr
 			return nil, err
 		}
 		for _, f := range files {
-			path := f.GetFilename()
-			isLockFile := false
-			for _, lf := range tools.LockFiles {
-				if path == lf || strings.HasSuffix(path, "/"+lf) {
-					isLockFile = true
-					break
-				}
-			}
-			if !isLockFile {
+			if path := f.GetFilename(); !tools.IsLockFile(path) {
 				allFiles = append(allFiles, path)
 			}
 		}

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -583,7 +583,7 @@ func postStructuredReview(ctx context.Context, client *github.Client, owner, rep
 				for _, fr := range sr.FilesReview {
 					_, endLine, err := fr.ParseLines()
 					if err == nil && endLine > 0 {
-						sb.WriteString(fmt.Sprintf("- **%s** (%s): %s\n", fr.Path, fr.Lines, fr.Review))
+						fmt.Fprintf(&sb, "- **%s** (%s): %s\n", fr.Path, fr.Lines, fr.Review)
 					}
 				}
 				reviewRequest.Body = github.Ptr(sb.String())

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -26,6 +26,19 @@ func appendLockFileExcludes(args []string) []string {
 	return args
 }
 
+// IsLockFile reports whether path names a known dependency lockfile —
+// either at the repository root (path == name) or in any subdirectory
+// (path ends in "/name"). Used by callers that operate on pre-computed
+// paths (e.g. PR file lists) rather than via git pathspec excludes.
+func IsLockFile(path string) bool {
+	for _, lf := range LockFiles {
+		if path == lf || strings.HasSuffix(path, "/"+lf) {
+			return true
+		}
+	}
+	return false
+}
+
 // runGit invokes `git <args>` in the given working directory (or the current
 // directory when dir is empty) and returns combined stdout+stderr. Callers
 // wrap the returned error with their own context; runGit itself does not

--- a/tools/diff_test.go
+++ b/tools/diff_test.go
@@ -147,6 +147,29 @@ func TestFetchGitDiff(t *testing.T) {
 	})
 }
 
+func TestIsLockFile(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"go.sum", true},
+		{"backend/go.sum", true},
+		{"a/b/c/go.sum", true},
+		{"Cargo.lock", true},
+		{"main.go", false},
+		{"go.sum.bak", false},
+		{"my-go.sum", false}, // not a path-separated suffix
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			if got := IsLockFile(c.path); got != c.want {
+				t.Errorf("IsLockFile(%q) = %v, want %v", c.path, got, c.want)
+			}
+		})
+	}
+}
+
 func TestFetchGitCommits(t *testing.T) {
 	tmpDir := t.TempDir()
 	setupGitRepo(t, tmpDir)


### PR DESCRIPTION
## Summary

Same four-phase pattern as #54 (llm/), #55 (core/), #56 (tools/), now for `cmd/ai_reviewer/` and `cmd/github/`. Also reaches into `tools/` to promote `IsLockFile`.

- **P0 — bugs/correctness (2 commits):**
  - `cmd/github/main.go` used the default `log.Printf` (timestamp-prefixed) for 11 warning sites, violating AGENTS.md's output contract (`log.New(os.Stderr, "", 0)` is the prescribed pattern — and what `cmd/ai_reviewer` already does). Adds a package-level `stderr` logger and swaps all warning sites.
  - `retryGitHubWrite` had `baseDelay *= 2` inside the timer-fired `select` arm — same fragile coupling fixed in `llm/retry.go`. Hoisted after the `select`.
- **P1 — idioms (1 commit):** `WriteString(fmt.Sprintf(...))` at 8 sites across `formatMetadata` and the `postStructuredReview` fallback-body builder — linter QF1012. Switched to `fmt.Fprintf(&sb, ...)`.
- **P2 — reuse (3 commits):**
  - Tag prefixes `"cassandra-main-"` / `"cassandra-inline-"` repeated at 5 sites, all referencing documented contracts (DESIGN.md, README.md) — promoted to `tagPrefixMain` / `tagPrefixInline` consts with a coordination note.
  - 4 identical "write to outputFile or fall back to stdout" blocks in the main dispatcher — extracted `writeOutputOrStdout(outputFile, label, data)`.
  - Lockfile-matching loop duplicated between `cmd/github`'s `getDiff` and `getFiles` — promoted to `tools.IsLockFile(path)` alongside `tools.LockFiles`, with a table-driven test covering root, nested, and non-path-separated-suffix edge cases.

## Out of scope (deliberate)

- Unifying `retryGitHubWrite` with `llm.retry[T]`: different retry policies (HTTP status-code classification vs. any-error). Would force generalizing `llm.retry` with a predicate.
- Switch-based action dispatch in `cmd/github`: boilerplate, but a map-based refactor gains little and obscures the `log.Fatal` error contract at each arm.
- Pagination helper for `client.*.List*` calls: generic over three different options types; type gymnastics would outweigh the savings.
- New `cmd/AGENTS.md` or `cmd/REVIEWERS.md`: no new cross-cutting invariants surfaced beyond what's already in root AGENTS.md §2 (Diagnostic Reporting) and §Output Contract.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` — all packages green
- [x] New `TestIsLockFile` covers the promoted helper
- [x] `bazel run //:format` is a no-op
- [ ] CI green