### PR TITLE
docs: correct AGENTS.md/DESIGN.md and add CODE_STYLE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,9 @@ This project uses `aspect_rules_lint` (v2.3.0) to integrate standard tooling dir
 
 ## Architecture Reference
 
-Before introducing major changes or restructuring the review loop, please read the **[DESIGN.md](file:///Users/mennyevendanan/dev/menny/cassandra/DESIGN.md)** document. It covers:
+Before introducing major changes or restructuring the review loop, please read the **[DESIGN.md](DESIGN.md)** document. It covers:
 - The decision to use a native Go ReAct loop rather than complex Python graphs.
 - The rationale behind the custom Tool Registry.
-- The `Do / Try / Consider` feedback format.
 
 ## Output Contract
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,12 @@ Before introducing major changes or restructuring the review loop, please read t
 - The decision to use a native Go ReAct loop rather than complex Python graphs.
 - The rationale behind the custom Tool Registry.
 
+## Code Style Reference
+
+**[CODE_STYLE.md](CODE_STYLE.md)** captures recurring coding patterns with rule + example + rationale for each: error handling idioms (`errors.New`, `%w`, `errors.As`), helper extraction, sentinel handling, registries over switches, typed accessors for untyped maps, centralized `//nolint`, stdout/stderr discipline, test-double `ctx` forwarding, paired-edit documentation, and stdlib-idiom preferences.
+
+Consult it when writing new code or when a review comment cites an idiom you don't recognize. AGENTS.md states *what MUST be done*; CODE_STYLE.md shows *how to write it so it matches the rest of the codebase*.
+
 ## Output Contract
 
 All **diagnostic and progress output** (configuration summary, ReAct iteration progress, tool invocations, warnings) MUST be written to **stderr**. Only the **final review text** goes to **stdout**. This allows callers to capture the review cleanly via redirection (e.g., `cassandra --diff main > review.md`) without interleaving noise.

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -1,0 +1,196 @@
+# Cassandra Code Style
+
+Coding patterns settled across the refactor work. Complements
+[AGENTS.md](AGENTS.md) (rules you MUST follow) and [DESIGN.md](DESIGN.md)
+(architecture). This file is *how to write code that fits the codebase*.
+
+## Error handling
+
+Use `errors.New` for literal errors. Use `%w` to wrap. Use `errors.As` to
+inspect typed errors from stdlib.
+
+```go
+// bad
+return fmt.Errorf("no match found")
+return fmt.Errorf("read: %v", err)
+if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == 1 { ... }
+
+// good
+return errors.New("no match found")
+return fmt.Errorf("read: %w", err)
+var exitErr *exec.ExitError
+if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 { ... }
+```
+
+**Why:** `%w` preserves the error chain so callers can `errors.Is/As`.
+`errors.As` works off the returned value and doesn't rely on `ProcessState`
+being populated (it's nil on spawn failures).
+
+## Extract on the third copy
+
+Two identical blocks can live. Three is a pattern that will drift. Extract.
+
+```go
+// Three sites built `:(exclude)*<lockfile>` args → one helper
+func appendLockFileExcludes(args []string) []string { ... }
+```
+
+**Why:** Three copies signal a convention; the fourth reader will add an
+inconsistent fifth.
+
+## Sentinels belong to their type
+
+When a value uses a sentinel (e.g. `-1` for "unknown"), ship a
+constructor for the sentinel and put aggregation/validation on the type.
+Don't make every caller re-encode the convention.
+
+```go
+func UnknownUsage() Usage { return Usage{PromptTokens: -1, OutputTokens: -1} }
+
+func (u *Usage) Add(other Usage) {
+    if other.PromptTokens > 0 { u.PromptTokens += other.PromptTokens }
+    // ... ignores sentinel/zero fields
+}
+```
+
+**Why:** A caller writing `if x.PromptTokens > 0 { total += x.PromptTokens }`
+for each field is a bug waiting for a new field to be added.
+
+## Registries beat switches for variants
+
+When "adding a variant" should be a one-line change, use a map.
+
+```go
+var providers = map[Provider]providerFactory{
+    ProviderAnthropic: func(...) (llm.Model, error) { ... },
+    ProviderGoogle:    func(...) (llm.Model, error) { ... },
+}
+// The "unsupported provider" error list is derived from the map.
+```
+
+**Why:** A switch forces the error message and every `case` arm to be
+kept in sync by hand. A map derives both.
+
+## Typed accessors for untyped maps
+
+When storing values in a `map[string]any`, define a package-level const
+for the key and a typed accessor for the value.
+
+```go
+const thoughtSignatureKey = "google_thought_signature"
+
+func thoughtSignature(m llm.Message) []byte {
+    sig, _ := m.ProviderMetadata[thoughtSignatureKey].([]byte)
+    return sig
+}
+```
+
+**Why:** Hardcoding `"google_thought_signature"` at the write site and
+every read site is silent typo-bait. The const + accessor makes typos
+compile errors.
+
+## Fail loud on unknown inputs
+
+When mapping one enum to another, handle the unknown case explicitly. No
+silent fallthrough.
+
+```go
+if mapped, known := jsonSchemaTypes[t]; known {
+    s.Type = mapped
+} else {
+    fmt.Fprintf(os.Stderr, "unknown JSON Schema type %q\n", t)
+}
+```
+
+**Why:** A silent fallthrough surfaces far from the origin as an opaque
+provider error. A stderr warning names the root cause at the site.
+
+## Centralize `//nolint` pragmas in helpers
+
+Wrap the pragma in one named helper with a doc comment. Don't sprinkle
+pragmas at call sites.
+
+```go
+// clampInt32 saturates n into int32 range. Centralizes the //nolint:gosec
+// with an explicit bounds check so call sites stay clean.
+func clampInt32(n int) int32 {
+    if n > math.MaxInt32 { return math.MaxInt32 }
+    if n < math.MinInt32 { return math.MinInt32 }
+    return int32(n) //nolint:gosec
+}
+```
+
+**Why:** Call-site pragmas hide the invariant and accumulate copy-paste
+drift. One helper = one invariant.
+
+## Output contract: stdout vs stderr
+
+Primary output (the "product" of the command) goes to stdout. Everything
+else — progress, warnings, config — goes to stderr through a
+prefix-free logger. Never use the default `log.Printf` for diagnostics:
+it adds timestamps and breaks stdout redirection for callers.
+
+```go
+var stderr = log.New(os.Stderr, "", 0)
+
+stderr.Printf("Warning: %v", err) // diagnostic
+fmt.Println(result)               // product
+```
+
+**Why:** Callers doing `cassandra > review.md` must get clean product
+output. Timestamped log noise on stderr also breaks downstream parsers.
+
+## Test doubles: forward ctx
+
+A mock/stub of a `context.Context`-accepting interface MUST forward ctx.
+Check `ctx.Err()` at entry and return it — matching real SDK behavior.
+Add at least one cancellation-propagation test at the double's boundary.
+
+```go
+// bad — silently ignores ctx
+func (m *mockLLM) GenerateContent(_ context.Context, ...) { ... }
+
+// good — behaves like a real provider under cancellation
+func (m *mockLLM) GenerateContent(ctx context.Context, ...) {
+    if err := ctx.Err(); err != nil { return nil, err }
+    ...
+}
+```
+
+**Why:** A mock that ignores ctx makes every cancellation test pass even
+after a regression in ctx forwarding — the tests are verifying the wrong
+thing.
+
+## Document paired edits in REVIEWERS.md
+
+When two symbols must change together (a const and a CLI default, a
+tool name and a DESIGN.md claim), list the pair in a `REVIEWERS.md`
+under the relevant scope.
+
+```
+# llm/REVIEWERS.md
+- `submitReviewToolName` ↔ `DESIGN.md §Technical Decisions 4`.
+- `DefaultMaxTokens` ↔ CLI `--max-tokens` default in `cmd/ai_reviewer`.
+```
+
+**Why:** The compiler can't enforce these pairings; reviewers must.
+Making the pair explicit means no reader has to reconstruct it from
+memory.
+
+## Prefer stdlib idioms
+
+Use the standard library primitives — they're tested, they tell the
+reader what the code is doing, and they usually avoid an allocation.
+
+```go
+// bad
+for k, v := range src { dst[k] = v }            // → maps.Copy(dst, src)
+sb.WriteString(fmt.Sprintf("- %s\n", name))     // → fmt.Fprintf(&sb, "- %s\n", name)
+
+// good
+maps.Copy(dst, src)
+fmt.Fprintf(&sb, "- %s\n", name)
+```
+
+**Why:** Idiomatic code reads faster and passes the golangci-lint
+analyzers (`mapsloop`, `QF1012`) that catch drift in new code.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,7 +12,7 @@ The system is designed as a CLI-driven, autonomous AI worker. It acts essentiall
 - **Main Guidelines**: Defaults to `general`. This can be:
   - A path to a local Markdown file (absolute or relative to the current directory).
   - The name of a pre-defined prompt from the internal library (e.g., `asana-do-try-consider`, `google`, `palantir`).
-- **Approval Evaluation Guidelines**: Defines the criteria for `APPROVE`, `REJECT`, and `COMMENT` verdicts.
+- **Approval Evaluation Guidelines**: Defines the criteria for `APPROVE`, `REQUEST_CHANGES`, and `COMMENT` verdicts.
   - Defaults to an internal "velocity-first" prompt.
   - Can be overridden via `--approval-evaluation-prompt-file`.
 - Coordinates the flow from git diff extraction to system prompt building, and finally running the review agent.
@@ -38,7 +38,7 @@ The system is designed as a CLI-driven, autonomous AI worker. It acts essentiall
   5. **Iteration**: The loop repeats until a final answer is produced or the `maxIterations` cap is reached.
   6. **Cap Reached**: If the cap is reached, the agent forces a final review call by appending a system message and stripping tool definitions from the next LLM call.
 
-### 3. Tool Registry (`tools/`)
+### 4. Tool Registry (`tools/`)
 - **Interface**: The `ToolDispatcher` interface (defined in `core/agent.go`) is the minimal set of methods the Agent needs:
   ```go
   type ToolDispatcher interface {
@@ -52,7 +52,7 @@ The system is designed as a CLI-driven, autonomous AI worker. It acts essentiall
   - `glob_files`: Finds files matching a pattern or extension.
   - `grep_files`: Searches for patterns in the repository using `git grep`.
 
-### 4. LLM Abstraction (`llm/`)
+### 5. LLM Abstraction (`llm/`)
 - **Interface**: `llm.Model` (in `llm/llm.go`) is the provider-agnostic interface:
   ```go
   type Model interface {

--- a/llm/AGENTS.md
+++ b/llm/AGENTS.md
@@ -2,7 +2,7 @@
 
 Scoped guidance for code under `llm/`. These rules complement the repo-level
 [AGENTS.md](../AGENTS.md); follow both. See also the architectural contract
-in [DESIGN.md §4 LLM Abstraction](../DESIGN.md#4-llm-abstraction-llm).
+in [DESIGN.md §5 LLM Abstraction](../DESIGN.md#5-llm-abstraction-llm).
 
 ## Provider Implementation Pattern
 


### PR DESCRIPTION
## Summary

Two commits closing out the documentation pass that accompanied the refactor series (#54, #55, #56, #57).

### Corrections (`10d6667`)
Five small fixes across three files — nothing expanded, only inaccurate/unclear wording corrected:

- `AGENTS.md §Architecture Reference`: the DESIGN.md link used an absolute `file:///Users/...` path that resolves only on one machine. Changed to a relative link.
- `AGENTS.md §Architecture Reference`: removed the "Do / Try / Consider feedback format" bullet — DESIGN.md does not cover it (the format lives as the `asana-do-try-consider` named prompt in the library, nowhere in DESIGN.md). Removal, not replacement, to avoid expansion.
- `DESIGN.md §1 AI Review Entrypoint`: verdicts listed as "APPROVE, REJECT, COMMENT" — actual contract (see the JSON schema below and `core.Approval.Action`) uses `REQUEST_CHANGES`, not `REJECT`.
- `DESIGN.md`: had two `### 3.` headings. Renumbered `Tool Registry` → §4 and `LLM Abstraction` → §5.
- `llm/AGENTS.md`: anchor link updated to match the renumbered DESIGN.md §5.

### New `CODE_STYLE.md` (`0c75068`)
Captures 11 coding patterns that came up repeatedly across the refactor PRs. Each is a short rule + example + one-line *why*. The file is non-overlapping with AGENTS.md (which is *what MUST be done*) and DESIGN.md (which is *why the system is shaped this way*) — this is *how to write code that fits*.

Patterns covered: error handling idioms, extract-on-third-copy, sentinels owned by their type, registries over switches, typed accessors for untyped maps, fail-loud on unknown inputs, centralized `//nolint`, stdout vs stderr contract, test doubles forwarding ctx, paired-edit documentation in REVIEWERS.md, stdlib idiom preferences.

## Test plan

- [x] All five corrections verified against current code (`core.Approval.Action` values, DESIGN.md schema, symbol names referenced)
- [x] `bazel run //:format` is a no-op
- [x] Relative `DESIGN.md` link resolves from repo root and `llm/` subdirectory
- [ ] CI green