### PR TITLE
feat: add additive supplemental guidelines support

### DIFF
--- a/.github/ai-reviewer/drive-by-fixes.md
+++ b/.github/ai-reviewer/drive-by-fixes.md
@@ -1,0 +1,1 @@
+While reviewing the diff, keep an eye out for small, easy wins in the immediate surrounding context (e.g., fixing a nearby typo, simplifying a complex boolean expression, or removing an unused local variable). Suggest these as "drive-by fixes" if they are extremely low risk and related to the PR's scope.

--- a/.github/ai-reviewer/haiku-praise.md
+++ b/.github/ai-reviewer/haiku-praise.md
@@ -1,0 +1,1 @@
+If the pull request is excellent, well-structured, and you are approving it, include a short, relevant haiku praising the author's specific work at the end of your review rationale.

--- a/.github/workflows/cassandra_review.yml
+++ b/.github/workflows/cassandra_review.yml
@@ -25,3 +25,5 @@ jobs:
           base: ${{ github.event.pull_request.base.sha }}
           head: ${{ github.event.pull_request.head.sha }}
           submit_review_action: 'true'
+          supplemental_guidelines: |
+            .github/ai-reviewer/haiku-praise.md

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ To review changes between a base and a head commit/branch:
 | `--model` | LLM provider's specific model ID | | **Yes** |
 | `--provider-api-key` | API key for the selected provider | | **Yes** |
 | `--main-guidelines` | Path to a file or a named prompt from the library (`general`, `asana-do-try-consider`, `google`, `conventional-comments`, `palantir`, `minimalist`, `security-first`) | `general` | No |
+| `--supplemental-guidelines` | Additive paths or named library prompts for supplemental guidelines (can be used multiple times) | | No |
 | `--approval-evaluation-prompt-file` | Path to a file containing custom approval evaluation guidelines | | No |
 | `--review-output-file` | Path to a file where the final review will be written | | No |
 | `--output-json` | Path to a file where the structured JSON review will be written | | No |
@@ -72,6 +73,7 @@ To review changes between a base and a head commit/branch:
 | `head` | Head commit/branch for diff | `HEAD` | No |
 | `working_directory` | Working directory to review | `.` | No |
 | `main_guidelines` | Path to a file or a named prompt from the library (`general`, `asana-do-try-consider`, `google`, `conventional-comments`, `palantir`, `minimalist`, `security-first`) | `general` | No |
+| `supplemental_guidelines` | Additive guidelines to supplement the main guidelines. Multiline string where each line is a path or library prompt name. | | No |
 | `approval_evaluation_prompt_file` | Path to a file containing custom approval evaluation guidelines | | No |
 | `metadata_tag` | Tag to identify Cassandra comments (inner text only, will be wrapped in `<!-- ... -->`) | `cassandra-ai-review-${{ github.workflow }}` | No |
 | `reaction_icon` | The reaction icon to add to the PR description while the review is in progress (e.g., `eyes`, `rocket`, `heart`) | `eyes` | No |

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Path to a file or a named prompt from the library (general, asana-do-try-consider, google, conventional-comments, palantir, minimalist, security-first)'
     required: false
     default: 'general'
+  supplemental_guidelines:
+    description: 'Additive guidelines to supplement the main guidelines. Multiline string where each line is a path or library prompt name.'
+    required: false
+    default: ''
   approval_evaluation_prompt_file:
     description: 'Optional path to a file containing custom approval evaluation guidelines'
     required: false
@@ -252,6 +256,7 @@ runs:
         HEAD: ${{ inputs.head }}
         WORKING_DIRECTORY: ${{ inputs.working_directory }}
         MAIN_GUIDELINES: ${{ inputs.main_guidelines }}
+        SUPPLEMENTAL_GUIDELINES: ${{ inputs.supplemental_guidelines }}
         APPROVAL_EVALUATION_PROMPT_FILE: ${{ inputs.approval_evaluation_prompt_file }}
         MCP_CONFIG: ${{ inputs.mcp_config }}
       run: |
@@ -269,6 +274,20 @@ runs:
           --review-output-file "$REVIEW_FILE"
           --output-json "$JSON_FILE"
         )
+
+        if [[ -n "$SUPPLEMENTAL_GUIDELINES" ]]; then
+          while read -r line || [[ -n "$line" ]]; do
+            if [[ -z "$line" ]]; then continue; fi
+            # Try to resolve relative to workspace
+            RESOLVED="${{ github.workspace }}/$WORKING_DIRECTORY/$line"
+            if [[ -f "$RESOLVED" ]]; then
+              ARGS+=(--supplemental-guidelines "$RESOLVED")
+            else
+              # Assume library name
+              ARGS+=(--supplemental-guidelines "$line")
+            fi
+          done <<< "$SUPPLEMENTAL_GUIDELINES"
+        fi
 
         if [[ -n "$MCP_CONFIG" ]]; then
           MCP_PATH="${{ github.workspace }}/$WORKING_DIRECTORY/$MCP_CONFIG"

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -35,6 +35,7 @@ func run(ctx context.Context, stderr *log.Logger) error {
 	var providerAPIKey string
 	var workingDir string
 	var mainGuidelines string
+	var supplementalGuidelines []string
 	var maxTokens int
 	var reviewOutputFile string
 	var outputJSONFile string
@@ -48,6 +49,7 @@ func run(ctx context.Context, stderr *log.Logger) error {
 
 	flag.StringVar(&workingDir, "cwd", "", "Working directory (defaults to BUILD_WORKSPACE_DIRECTORY or current directory)")
 	flag.StringVar(&mainGuidelines, "main-guidelines", "general", "Path to a file or a named prompt from the library")
+	flag.StringArrayVar(&supplementalGuidelines, "supplemental-guidelines", nil, "Optional additive paths or named library prompts for supplemental guidelines (can be used multiple times)")
 	flag.StringVar(&approvalEvaluationPromptFile, "approval-evaluation-prompt-file", "", "Optional path to a file containing custom approval evaluation guidelines")
 	flag.IntVar(&maxTokens, "max-tokens", llm.DefaultMaxTokens, "Max tokens for the LLM response")
 	flag.StringVar(&base, "base", "main", "Base commit/branch for diff")
@@ -100,9 +102,18 @@ func run(ctx context.Context, stderr *log.Logger) error {
 	}
 
 	// Resolve main guidelines content
-	mainGuidelinesContent, err := resolveMainGuidelinesContent(mainGuidelines)
+	mainGuidelinesContent, err := resolveGuidelinesContent(mainGuidelines)
 	if err != nil {
 		return fmt.Errorf("failed to resolve main guidelines: %w", err)
+	}
+
+	var supplementalGuidelinesContent []string
+	for _, sg := range supplementalGuidelines {
+		content, err := resolveGuidelinesContent(sg)
+		if err != nil {
+			return fmt.Errorf("failed to resolve supplemental guideline %q: %w", sg, err)
+		}
+		supplementalGuidelinesContent = append(supplementalGuidelinesContent, content)
 	}
 
 	var approvalEvaluationContent string
@@ -122,6 +133,9 @@ func run(ctx context.Context, stderr *log.Logger) error {
 	stderr.Printf("  LLM Model: %s\n", modelName)
 	if mainGuidelines != "" {
 		stderr.Printf("  Main Guidelines: %s\n", mainGuidelines)
+	}
+	if len(supplementalGuidelines) > 0 {
+		stderr.Printf("  Supplemental Guidelines: %s\n", strings.Join(supplementalGuidelines, ", "))
 	}
 	if outputJSONFile != "" {
 		stderr.Printf("  Structured Output JSON: %s\n", outputJSONFile)
@@ -260,7 +274,7 @@ func run(ctx context.Context, stderr *log.Logger) error {
 	// Compute max ReAct iterations based on changed files.
 	maxIterations := core.CalculateMaxIterations(len(changedFiles))
 
-	systemStable, systemDynamic, promptSummary, err := prompts.BuildSystemPrompt(targetDir, changedFiles, mainGuidelinesContent, approvalEvaluationContent)
+	systemStable, systemDynamic, promptSummary, err := prompts.BuildSystemPrompt(targetDir, changedFiles, mainGuidelinesContent, supplementalGuidelinesContent, approvalEvaluationContent)
 	if err != nil {
 		return fmt.Errorf("failed to build system prompt: %w", err)
 	}
@@ -320,7 +334,7 @@ func run(ctx context.Context, stderr *log.Logger) error {
 	return nil
 }
 
-func resolveMainGuidelinesContent(guidelinesPath string) (string, error) {
+func resolveGuidelinesContent(guidelinesPath string) (string, error) {
 	// Try the path as provided first
 	if content, err := os.ReadFile(guidelinesPath); err == nil {
 		return string(content), nil

--- a/cmd/ai_reviewer/main_test.go
+++ b/cmd/ai_reviewer/main_test.go
@@ -71,7 +71,7 @@ func TestFormatMetadata(t *testing.T) {
 	require.Contains(t, formatted, "  > comment 2")
 }
 
-func TestResolveMainGuidelinesContent(t *testing.T) {
+func TestResolveGuidelinesContent(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create a local file
@@ -80,19 +80,19 @@ func TestResolveMainGuidelinesContent(t *testing.T) {
 	require.NoError(t, os.WriteFile(localFile, []byte(localContent), 0o644))
 
 	t.Run("resolves local file path", func(t *testing.T) {
-		content, err := resolveMainGuidelinesContent(localFile)
+		content, err := resolveGuidelinesContent(localFile)
 		require.NoError(t, err)
 		require.Equal(t, localContent, content)
 	})
 
 	t.Run("resolves named prompt from embedded library", func(t *testing.T) {
-		content, err := resolveMainGuidelinesContent("google")
+		content, err := resolveGuidelinesContent("google")
 		require.NoError(t, err)
 		require.Contains(t, content, "Google Engineering Practices")
 	})
 
 	t.Run("fails on non-existent path and name", func(t *testing.T) {
-		_, err := resolveMainGuidelinesContent("non-existent-at-all")
+		_, err := resolveGuidelinesContent("non-existent-at-all")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "prompt \"non-existent-at-all\" not found in library")
 	})

--- a/core/prompts/prompts.go
+++ b/core/prompts/prompts.go
@@ -54,7 +54,8 @@ type PromptSummary struct {
 }
 
 // BuildSystemPrompt constructs the full system prompt by combining base prompts,
-// the selected general guidelines (mainGuidelinesContent), any repository-specific rules found
+// the selected general guidelines (mainGuidelinesContent), any additive
+// supplementalGuidelinesContent, any repository-specific rules found
 // in REVIEWERS.md or AGENTS.md files, and optional personal preferences from
 // personal.ai_code_review_guidelines.md located in the workspace root.
 //
@@ -70,13 +71,14 @@ type PromptSummary struct {
 // Stable (Zone 1+2):
 //  1. reviewerPrompt            — static, embedded at build time
 //  2. <code_review_guidelines>  — semi-static, one value per deployment config
-//  3. <approval_evaluation_guidelines> — semi-static
-//  4. <personal_review_guidelines>     — semi-static, optional
+//  3. <supplemental_guideline>  — semi-static, additive guidelines
+//  4. <approval_evaluation_guidelines> — semi-static
+//  5. <personal_review_guidelines>     — semi-static, optional
 //
 // Dynamic (Zone 3):
-//  5. <agents_guidelines>       — dynamic, varies per PR (AGENTS.md files)
-//  6. <reviewer_context>        — dynamic, varies per PR (REVIEWERS.md files)
-func BuildSystemPrompt(workspaceRoot string, changedFiles []string, mainGuidelinesContent, approvalEvaluationContent string) (stable, dynamic string, summary PromptSummary, err error) {
+//  6. <agents_guidelines>       — dynamic, varies per PR (AGENTS.md files)
+//  7. <reviewer_context>        — dynamic, varies per PR (REVIEWERS.md files)
+func BuildSystemPrompt(workspaceRoot string, changedFiles []string, mainGuidelinesContent string, supplementalGuidelinesContent []string, approvalEvaluationContent string) (stable, dynamic string, summary PromptSummary, err error) {
 	if mainGuidelinesContent == "" {
 		return "", "", summary, fmt.Errorf("main guidelines content is required")
 	}
@@ -87,6 +89,12 @@ func BuildSystemPrompt(workspaceRoot string, changedFiles []string, mainGuidelin
 
 	// Zone 1 (static) + Zone 2 (semi-static) — identical across all PRs on the same config.
 	stable = reviewerPrompt + "\n<code_review_guidelines>\n" + mainGuidelinesContent + "\n</code_review_guidelines>\n"
+
+	for _, sg := range supplementalGuidelinesContent {
+		if sg != "" {
+			stable += "\n<supplemental_guideline>\n" + sg + "\n</supplemental_guideline>\n"
+		}
+	}
 
 	stable += "\n<approval_evaluation_guidelines>\n" + approvalEvaluationContent + "\n</approval_evaluation_guidelines>\n"
 

--- a/core/prompts/prompts_test.go
+++ b/core/prompts/prompts_test.go
@@ -53,7 +53,7 @@ func TestBuildSystemPrompt(t *testing.T) {
 
 	changedFiles := []string{"foo.go"}
 
-	stable, dynamic, _, err := BuildSystemPrompt(tmpDir, changedFiles, "Is this code maintainable, easy to work with, and safe?", "")
+	stable, dynamic, _, err := BuildSystemPrompt(tmpDir, changedFiles, "Is this code maintainable, easy to work with, and safe?", nil, "")
 	require.NoError(t, err)
 
 	// Combine for checks that don't care about the split point.
@@ -121,7 +121,7 @@ func TestBuildSystemPrompt_DeterministicZone3Ordering(t *testing.T) {
 	const runs = 20
 	var firstDynamic string
 	for i := range runs {
-		_, dynamic, _, err := BuildSystemPrompt(tmpDir, changedFiles, "guidelines", "")
+		_, dynamic, _, err := BuildSystemPrompt(tmpDir, changedFiles, "guidelines", nil, "")
 		require.NoError(t, err)
 		if i == 0 {
 			firstDynamic = dynamic
@@ -153,7 +153,7 @@ func TestBuildSystemPrompt_Override(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 
-	stable, dynamic, _, err := BuildSystemPrompt(tmpDir, nil, "CUSTOM GUIDELINES HERE", "CUSTOM APPROVAL HERE")
+	stable, dynamic, _, err := BuildSystemPrompt(tmpDir, nil, "CUSTOM GUIDELINES HERE", nil, "CUSTOM APPROVAL HERE")
 	require.NoError(t, err)
 
 	require.True(t, strings.Contains(stable, "You are a code review bot - named Cassandra - for the provided codebase."))
@@ -191,7 +191,7 @@ func TestBuildSystemPrompt_Summary(t *testing.T) {
 	))
 
 	changedFiles := []string{"main.go", "pkg/sub/helper.go"}
-	stable, dynamic, summary, err := BuildSystemPrompt(tmpDir, changedFiles, "guidelines content", "")
+	stable, dynamic, summary, err := BuildSystemPrompt(tmpDir, changedFiles, "guidelines content", nil, "")
 	require.NoError(t, err)
 
 	// Lengths must match the actual strings.
@@ -217,4 +217,24 @@ func TestBuildSystemPrompt_Summary(t *testing.T) {
 		"root REVIEWERS.md should appear as 'REVIEWERS.md' (no leading slash)")
 	require.True(t, loaded[fileKey{filepath.Join("pkg", "sub", "REVIEWERS.md"), "reviewers"}],
 		"nested REVIEWERS.md should appear with its relative path")
+}
+
+func TestBuildSystemPrompt_SupplementalGuidelines(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	main := "MAIN GUIDELINES"
+	supplemental := []string{"SUPP 1", "SUPP 2"}
+
+	stable, _, _, err := BuildSystemPrompt(tmpDir, nil, main, supplemental, "")
+	require.NoError(t, err)
+
+	require.True(t, strings.Contains(stable, "<code_review_guidelines>\nMAIN GUIDELINES\n</code_review_guidelines>"))
+	require.True(t, strings.Contains(stable, "<supplemental_guideline>\nSUPP 1\n</supplemental_guideline>"))
+	require.True(t, strings.Contains(stable, "<supplemental_guideline>\nSUPP 2\n</supplemental_guideline>"))
+
+	// Verify order
+	supp1Idx := strings.Index(stable, "SUPP 1")
+	supp2Idx := strings.Index(stable, "SUPP 2")
+	require.True(t, supp1Idx < supp2Idx, "supplemental guidelines should maintain provided order")
 }


### PR DESCRIPTION
Introduce `--supplemental-guidelines` to allow mixing and matching review behaviors (e.g., tone, specialized focus) without replacing the main guidelines. These are placed in the stable, cacheable zone of the system prompt to minimize token costs.

### Key Changes
- **Core**: Updated `BuildSystemPrompt` to support multiple supplemental guidelines in the stable zone.
- **CLI**: Added `--supplemental-guidelines` flag (supports file paths and library prompts).
- **Action**: Updated `action.yml` with `supplemental_guidelines` input and safe whitespace trimming.
- **Guidelines**: Added `haiku-praise` and `drive-by-fixes` example guidelines.
- **Workflow**: Updated this repo's workflow to use the haiku praise guideline.