### PR TITLE
feat: add line-slicing to read_file tool

### DIFF
--- a/core/prompts/reviewer_prompt.md
+++ b/core/prompts/reviewer_prompt.md
@@ -10,7 +10,7 @@ If the input includes <reviewer_context>, treat it as additional focus or intent
 
 If the input includes <personal_review_guidelines>, treat them as the reviewer's personal preferences and style. Prioritize them over the general <code_review_guidelines> when they conflict.
 
-Use the read_file tool when you need context outside the diff — for example, to check a function signature, an import, or a related test.
+Use the `read_file` tool when you need context outside the diff — for example, to check a function signature, an import, or a related test. For large files, use the `line_start`, `line_end`, or `tail_lines` parameters to read only the relevant sections and save token context.
 
 Lockfile diffs (e.g. `yarn.lock`, `package-lock.json`, `Cargo.lock`, `go.sum`) are stripped from the input. If a lockfile change is relevant to your review (should be rarely), use read_file to inspect it directly.
 

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -16,13 +16,25 @@ import (
 func registerLocalReadFile(r *Registry) {
 	def := llm.ToolDef{
 		Name:        "read_file",
-		Description: "Read the contents of a local file from the repository.",
+		Description: "Read the contents of a local file. For large files, use line_start/line_end or tail_lines to save tokens.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"file_path": map[string]any{
 					"type":        "string",
 					"description": "Absolute or relative path to the file to read.",
+				},
+				"line_start": map[string]any{
+					"type":        "integer",
+					"description": "The 1-based line number to start reading from. Defaults to 1.",
+				},
+				"line_end": map[string]any{
+					"type":        "integer",
+					"description": "The 1-based line number to stop reading at (inclusive). If omitted, reads until the end of the file.",
+				},
+				"tail_lines": map[string]any{
+					"type":        "integer",
+					"description": "Read this many lines from the end of the file. If specified, line_start and line_end are ignored.",
 				},
 			},
 			"required": []string{"file_path"},
@@ -31,7 +43,10 @@ func registerLocalReadFile(r *Registry) {
 
 	r.RegisterTool(def, func(ctx context.Context, tc llm.ToolCall) (string, error) {
 		var args struct {
-			FilePath string `json:"file_path"`
+			FilePath  string `json:"file_path"`
+			LineStart int    `json:"line_start"`
+			LineEnd   int    `json:"line_end"`
+			TailLines int    `json:"tail_lines"`
 		}
 		if err := tc.UnmarshalArguments(&args); err != nil {
 			return "", err
@@ -41,7 +56,52 @@ func registerLocalReadFile(r *Registry) {
 		if err != nil {
 			return "", fmt.Errorf("read_file failed: %w", err)
 		}
-		return string(b), nil
+
+		// If no line-limiting arguments are provided, return the whole file.
+		if args.LineStart <= 0 && args.LineEnd <= 0 && args.TailLines <= 0 {
+			return string(b), nil
+		}
+
+		lines := strings.Split(string(b), "\n")
+		numLines := len(lines)
+
+		// Handle tail_lines first as it takes precedence.
+		if args.TailLines > 0 {
+			start := numLines - args.TailLines
+			if start < 0 {
+				start = 0
+			}
+			return strings.Join(lines[start:], "\n"), nil
+		}
+
+		// Handle line range.
+		start := args.LineStart
+		if start <= 0 {
+			start = 1
+		}
+		end := args.LineEnd
+		if end <= 0 || end > numLines {
+			end = numLines
+		}
+
+		// Adjust to 0-based indexing for slicing.
+		startIdx := start - 1
+		if startIdx < 0 {
+			startIdx = 0
+		}
+		if startIdx >= numLines {
+			return "", nil
+		}
+
+		endIdx := end
+		if endIdx > numLines {
+			endIdx = numLines
+		}
+		if endIdx < startIdx {
+			return "", nil
+		}
+
+		return strings.Join(lines[startIdx:endIdx], "\n"), nil
 	})
 }
 

--- a/tools/local_tools_test.go
+++ b/tools/local_tools_test.go
@@ -16,26 +16,117 @@ func TestLocalReadFile(t *testing.T) {
 	r := NewRegistry()
 	registerLocalReadFile(r)
 
-	// Create a temp file
+	// Create a temp file with multiple lines
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.txt")
-	content := "hello AI"
+	contentLines := []string{"line 1", "line 2", "line 3", "line 4", "line 5"}
+	content := strings.Join(contentLines, "\n")
 	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	args, _ := json.Marshal(map[string]any{"file_path": testFile})
-	result, err := r.HandleCall(context.Background(), llm.ToolCall{
-		Name:      "read_file",
-		Arguments: string(args),
+	t.Run("read entire file", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"file_path": testFile})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+		if result != content {
+			t.Errorf("expected %q, got %q", content, result)
+		}
 	})
-	if err != nil {
-		t.Fatalf("expected success, got error: %v", err)
-	}
-	if result != content {
-		t.Errorf("expected %q, got %q", content, result)
-	}
+
+	t.Run("read head (first 2 lines)", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"file_path": testFile, "line_end": 2})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := "line 1\nline 2"
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("read range (lines 2-4)", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"file_path": testFile, "line_start": 2, "line_end": 4})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := "line 2\nline 3\nline 4"
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("read from line 3 to end", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"file_path": testFile, "line_start": 3})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := "line 3\nline 4\nline 5"
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("read tail (last 2 lines)", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"file_path": testFile, "tail_lines": 2})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := "line 4\nline 5"
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("read more tail than exists", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"file_path": testFile, "tail_lines": 10})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != content {
+			t.Errorf("expected %q, got %q", content, result)
+		}
+	})
+
+	t.Run("out of bounds line_start", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"file_path": testFile, "line_start": 10})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != "" {
+			t.Errorf("expected empty string, got %q", result)
+		}
+	})
 }
 
 func TestLocalGlobFiles(t *testing.T) {


### PR DESCRIPTION
This PR enhances the `read_file` tool with the ability to read specific line ranges (`line_start`, `line_end`) or the end of a file (`tail_lines`). 

This improves token efficiency when the AI reviewer needs to inspect large files like lockfiles or logs.

Fixes https://github.com/menny/cassandra/issues/63