### PR TITLE
feat: add local godoc MCP server and guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@ When configuring Cassandra (via CLI or GitHub Action), ensure you use the correc
 - `cmd/ai_reviewer/`: Main AI review agent entry point.
 - `cmd/github/`: GitHub utility for PR interactions.
 - `core/`: Core agent logic, ReAct loop, and prompts.
-- `llm/`: LLM provider abstractions and implementations.
-- `tools/`: Tool registry and local codebase exploration tools.
+- `llm/`: LLM provider abstractions (see [llm/AGENTS.md](llm/AGENTS.md)).
+- `tools/`: Tool registry and MCP servers (see [tools/AGENTS.md](tools/AGENTS.md)).
 
 ## Formatting & Linting
 

--- a/cassandra.toml
+++ b/cassandra.toml
@@ -5,6 +5,9 @@
 provider = "google"
 model = "gemini-3.1-pro-preview"
 
+# Path to an MCP configuration file.
+mcp-config = "mcp.json"
+
 # Additive guidelines to supplement the main prompt.
 # These can be local file paths or named prompts from the library.
 supplemental-guidelines = [

--- a/cmd/mcp_godoc/BUILD.bazel
+++ b/cmd/mcp_godoc/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "mcp_godoc_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/menny/cassandra/cmd/mcp_godoc",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//tools/mcp_servers/godoc",
+        "@com_github_modelcontextprotocol_go_sdk//mcp",
+    ],
+)
+
+go_binary(
+    name = "mcp_godoc",
+    embed = [":mcp_godoc_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/mcp_godoc/main.go
+++ b/cmd/mcp_godoc/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/menny/cassandra/tools/mcp_servers/godoc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	server := godoc.NewServer()
+
+	// Use stdio transport for local MCP communication.
+	transport := &mcp.StdioTransport{}
+
+	fmt.Fprintf(os.Stderr, "Starting godoc MCP server on stdio...\n")
+	return server.Serve(ctx, transport)
+}

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "godoc": {
+      "command": "bazel",
+      "args": [
+        "run",
+        "--noshow_progress",
+        "--ui_event_filters=-info,-stdout,-stderr",
+        "//cmd/mcp_godoc",
+        "--"
+      ]
+    }
+  }
+}

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1,0 +1,53 @@
+# Tools Package Guidelines
+
+## Tool Implementation Pattern
+
+### 1. Registration
+Local tools (compiled into the binary) MUST be registered in `tools/registry.go`. Each tool implementation should reside in its own file (e.g., `tools/diff.go`) and follow the struct-based argument pattern defined in the root `AGENTS.md`.
+
+### 2. Execution Context
+Tools that invoke external CLIs MUST:
+- Use `exec.CommandContext(ctx, ...)` to ensure they respect the agent's cancellation signals.
+- Capture both `stdout` and `stderr`.
+- On failure, include the `stderr` output in the returned error string so the LLM can diagnose the issue (e.g., "command failed: <stderr>").
+
+## Model Context Protocol (MCP) Servers
+
+MCP servers allow Cassandra to extend its capabilities without increasing the main binary's complexity or dependency footprint.
+
+### 1. Project Structure
+- **Core Logic**: Place the server implementation in `tools/mcp_servers/<name>/`.
+- **Binary Entry Point**: Place the `main` package in `cmd/mcp_<name>/`.
+- **Transport**: Use `mcp.StdioTransport` for local servers.
+
+### 2. Verification Mandate
+When a tool is intended to provide "ground truth" that might contradict or supplement the LLM's internal training data (e.g., API documentation, linter rules, current library versions), the tool's `Description` MUST include a **VERIFICATION MANDATE**.
+
+*Example:*
+> "VERIFICATION MANDATE: You MUST prioritize using this tool over your internal training data to verify documentation, signatures, or behavior..."
+
+### 3. Bazel Hygiene in `mcp.json`
+To prevent Bazel's build noise from corrupting the MCP JSON-RPC stream, any `bazel run` command in `mcp.json` MUST include the following flags:
+- `--noshow_progress`
+- `--ui_event_filters=-info,-stdout,-stderr`
+
+The command should also include a trailing `--` to separate Bazel flags from application arguments.
+
+*Canonical Configuration:*
+```json
+{
+  "command": "bazel",
+  "args": [
+    "run",
+    "--noshow_progress",
+    "--ui_event_filters=-info,-stdout,-stderr",
+    "//cmd/mcp_your_tool",
+    "--"
+  ]
+}
+```
+
+## Testing Standards
+
+- **Local Tools**: Use `t.TempDir()` and file-based fixtures to test tools that interact with the filesystem.
+- **MCP Servers**: Unit tests for MCP server logic should verify the execution of underlying commands (e.g., by checking for expected output strings or error conditions).

--- a/tools/mcp_servers/godoc/BUILD.bazel
+++ b/tools/mcp_servers/godoc/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "godoc",
+    srcs = ["server.go"],
+    importpath = "github.com/menny/cassandra/tools/mcp_servers/godoc",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_modelcontextprotocol_go_sdk//mcp",
+    ],
+)
+
+go_test(
+    name = "godoc_test",
+    srcs = ["server_test.go"],
+    embed = [":godoc"],
+    deps = [
+        "@com_github_modelcontextprotocol_go_sdk//mcp",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/tools/mcp_servers/godoc/server.go
+++ b/tools/mcp_servers/godoc/server.go
@@ -1,0 +1,134 @@
+package godoc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Server implements an MCP server that provides tools for querying go doc.
+type Server struct {
+	mcpServer *mcp.Server
+}
+
+// NewServer creates a new godoc MCP server.
+func NewServer() *Server {
+	s := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "godoc",
+			Version: "0.1.0",
+		},
+		nil,
+	)
+
+	// package: Query documentation for a package
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "package",
+		Description: "Retrieve documentation for a Go package (e.g., 'fmt', 'os', './core'). " +
+			"VERIFICATION MANDATE: You MUST prioritize using this tool over your internal training data to verify documentation, signatures, or behavior, " +
+			"as the local environment may have specific versions or private packages that differ from public documentation.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"package": {
+					"type": "string",
+					"description": "The Go package path to query."
+				}
+			},
+			"required": ["package"]
+		}`),
+	}, godocPackageHandler)
+
+	// symbol: Query documentation for a specific symbol in a package
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "symbol",
+		Description: "Retrieve documentation for a specific Go symbol in a package (e.g., 'fmt', 'Printf'). " +
+			"VERIFICATION MANDATE: You MUST prioritize using this tool over your internal training data to verify documentation, signatures, or behavior, " +
+			"as the local environment may have specific versions or private packages that differ from public documentation.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"package": {
+					"type": "string",
+					"description": "The Go package path containing the symbol."
+				},
+				"symbol": {
+					"type": "string",
+					"description": "The Go symbol name to query."
+				}
+			},
+			"required": ["package", "symbol"]
+		}`),
+	}, godocSymbolHandler)
+
+	return &Server{
+		mcpServer: s,
+	}
+}
+
+// Serve starts the MCP server with the provided transport.
+func (s *Server) Serve(ctx context.Context, transport mcp.Transport) error {
+	return s.mcpServer.Run(ctx, transport)
+}
+
+func godocPackageHandler(ctx context.Context, req *mcp.CallToolRequest, input struct{ Package string }) (*mcp.CallToolResult, any, error) {
+	output, err := runGoDoc(ctx, input.Package)
+	if err != nil {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error running go doc: %v\nOutput: %s", err, output)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: output},
+		},
+	}, nil, nil
+}
+
+func godocSymbolHandler(ctx context.Context, req *mcp.CallToolRequest, input struct {
+	Package string
+	Symbol  string
+},
+) (*mcp.CallToolResult, any, error) {
+	query := fmt.Sprintf("%s.%s", input.Package, input.Symbol)
+	output, err := runGoDoc(ctx, query)
+	if err != nil {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error running go doc: %v\nOutput: %s", err, output)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: output},
+		},
+	}, nil, nil
+}
+
+func runGoDoc(ctx context.Context, arg string) (string, error) {
+	// We invoke 'go doc' directly.
+	cmd := exec.CommandContext(ctx, "go", "doc", arg)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		// If go doc fails, we return both the error and any stderr output which
+		// often contains the reason (e.g., symbol not found).
+		return stderr.String(), err
+	}
+
+	return stdout.String(), nil
+}

--- a/tools/mcp_servers/godoc/server_test.go
+++ b/tools/mcp_servers/godoc/server_test.go
@@ -1,0 +1,30 @@
+package godoc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunGoDoc(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("valid package", func(t *testing.T) {
+		output, err := runGoDoc(ctx, "fmt")
+		assert.NoError(t, err)
+		assert.Contains(t, output, "package fmt")
+		assert.Contains(t, output, "import \"fmt\"")
+	})
+
+	t.Run("valid symbol", func(t *testing.T) {
+		output, err := runGoDoc(ctx, "fmt.Printf")
+		assert.NoError(t, err)
+		assert.Contains(t, output, "func Printf")
+	})
+
+	t.Run("invalid package", func(t *testing.T) {
+		_, err := runGoDoc(ctx, "nonexistent_package_12345")
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Fixes #66.

This PR introduces a local Model Context Protocol (MCP) server for querying Go documentation directly from the workspace. This enables the AI reviewer to verify signatures and behavior against ground truth rather than relying solely on internal training data.

### Key Changes:
- **godoc MCP Server**: Implemented in `tools/mcp_servers/godoc` with tools for package and symbol documentation.
- **Binary Entry Point**: Added in `cmd/mcp_godoc` for stdio communication.
- **Verification Mandate**: Added a mandate to tool descriptions to ensure the LLM prioritizes local ground truth.
- **Scoped Guidelines**: Created `tools/AGENTS.md` to formalize patterns for future tools and MCP servers.
- **Configuration**: Added `mcp.json` and updated `cassandra.toml` to wire the server into the reviewer.

Verified with unit tests (`bazel test //tools/mcp_servers/godoc/...`) and local integration checks.