### PR TITLE
Improve GitHub Authentication and Workflow Security

### DIFF
--- a/.github/workflows/cassandra_review.yml
+++ b/.github/workflows/cassandra_review.yml
@@ -6,8 +6,8 @@ jobs:
   review:
     name: AI Code Review
     runs-on: ubuntu-24.04
-    # Skip the job if required secrets are missing (e.g., on PRs from forks)
-    if: secrets.GEMINI_API_KEY != '' && secrets.CASSANDRA_APP_PRIVATE_KEY != ''
+    # Skip the job if it is a PR from a fork (secrets are not available for forks)
+    if: github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/cassandra_review.yml
+++ b/.github/workflows/cassandra_review.yml
@@ -6,20 +6,28 @@ jobs:
   review:
     name: AI Code Review
     runs-on: ubuntu-24.04
+    # Skip the job if required secrets are missing (e.g., on PRs from forks)
+    if: ${{ secrets.GEMINI_API_KEY != '' && secrets.CASSANDRA_APP_PRIVATE_KEY != '' }}
     permissions:
       contents: read
       pull-requests: write
-      # 'issues: write' is required to post general PR comments via the Issues API.
       issues: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 3562238
+          private-key: ${{ secrets.CASSANDRA_APP_PRIVATE_KEY }}
       - name: Run Cassandra Review
         uses: ./
         with:
           provider_api_key: ${{ secrets.GEMINI_API_KEY }}
+          reviewer_github_token: ${{ steps.app-token.outputs.token }}
           base: ${{ github.event.pull_request.base.sha }}
           head: ${{ github.event.pull_request.head.sha }}
           submit_review_action: 'true'

--- a/.github/workflows/cassandra_review.yml
+++ b/.github/workflows/cassandra_review.yml
@@ -6,8 +6,8 @@ jobs:
   review:
     name: AI Code Review
     runs-on: ubuntu-24.04
-    # Skip the job if it is a PR from a fork (secrets are not available for forks)
-    if: github.event.pull_request.head.repo.fork == false
+    # Skip the job if it is a cross-repository PR (secrets are not available for external PRs)
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/cassandra_review.yml
+++ b/.github/workflows/cassandra_review.yml
@@ -7,7 +7,7 @@ jobs:
     name: AI Code Review
     runs-on: ubuntu-24.04
     # Skip the job if required secrets are missing (e.g., on PRs from forks)
-    if: ${{ secrets.GEMINI_API_KEY != '' && secrets.CASSANDRA_APP_PRIVATE_KEY != '' }}
+    if: secrets.GEMINI_API_KEY != '' && secrets.CASSANDRA_APP_PRIVATE_KEY != ''
     permissions:
       contents: read
       pull-requests: write

--- a/README.md
+++ b/README.md
@@ -324,6 +324,18 @@ Alternatively, set `submit_review_action: 'false'` to use comment-only mode.
 
 **Fix:** Check that the secret name is correct in your repository settings. The action falls back to `github.token` automatically, but if that is also unavailable the step will fail.
 
+### Choosing the Right GitHub Token
+
+Cassandra can work with any GitHub token passed via the `reviewer_github_token` input. Choosing the right one depends on your needs for cross-repo access and PR approval.
+
+| Feature | `GITHUB_TOKEN` (Default) | Classic PAT (`repo` scope) | GitHub App Token |
+|---|---|---|---|
+| **Setup Complexity** | None (Automatic) | Low (Create token) | Medium (Create & Install App) |
+| **Identity** | `github-actions[bot]` | Your User Account | Your App Name |
+| **Self-Approval** | No | **Yes** | **Yes** |
+| **Cross-Repo Access** | Limited | **Full** (Everything you see) | Scoped (Where installed) |
+| **Security** | Highest (Ephemeral) | Lower (Long-lived/Global) | High (Scoped/Short-lived) |
+
 ## Architecture
 
 The project features a lean, custom native Go ReAct loop. Provider-specific interactions are handled via native SDKs (not `langchaingo`). Tools for codebase context gathering are injected securely through model-native Function Calling capabilities.


### PR DESCRIPTION
This PR adds a guide for choosing the right GitHub token to the README and updates the CI workflow to use GitHub App authentication with security guards for fork PRs.

### Changes:
- Added 'Choosing the Right GitHub Token' comparison table to README.md.
- Updated .github/workflows/cassandra_review.yml to use GitHub App authentication.
- Added job-level 'if' condition to skip the review job on forks (where secrets are missing).