### PR TITLE
feat: implement LLM-as-a-Judge evaluation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,9 @@ Cassandra supports the [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 #### Configuration (`mcp.json`)
 
-Create an `mcp.json` file to define your MCP servers. Cassandra supports both local `stdio` servers and remote `sse` (HTTP) servers. Environment variables in the configuration are automatically expanded using `os.ExpandEnv`.
+Create an `mcp.json` file to define your MCP servers. Cassandra supports both local `stdio` servers and remote `sse` (HTTP) servers.
+
+Environment variables in the configuration are automatically expanded using `os.ExpandEnv`. Ensure you declare each required environment variable required by the MCP - only declared environments are passed to the MCP server to prevent leaking secrets.
 
 ```json
 {

--- a/cmd/ai_reviewer/BUILD.bazel
+++ b/cmd/ai_reviewer/BUILD.bazel
@@ -7,11 +7,10 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//core",
+        "//core/config",
         "//core/prompts",
         "//llm",
-        "//llm/factory",
         "//tools",
-        "//tools/mcp",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_spf13_viper//:viper",
     ],
@@ -32,6 +31,7 @@ go_test(
     embed = [":ai_reviewer_lib"],
     deps = [
         "//core",
+        "//core/config",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_spf13_viper//:viper",
         "@com_github_stretchr_testify//require",

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -229,7 +229,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 
 	// Initialize Agent and Tool Registry
 	registry := tools.NewRegistry()
-	tools.RegisterLocalTools(registry, cfg.IgnoredLockFiles)
+	tools.RegisterLocalTools(registry, targetDir, cfg.IgnoredLockFiles)
 
 	if cfg.MCPConfigFile != "" {
 		mcpData, err := os.ReadFile(cfg.MCPConfigFile)

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -13,37 +13,11 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/menny/cassandra/core"
+	"github.com/menny/cassandra/core/config"
 	"github.com/menny/cassandra/core/prompts"
 	"github.com/menny/cassandra/llm"
-	"github.com/menny/cassandra/llm/factory"
 	"github.com/menny/cassandra/tools"
-	"github.com/menny/cassandra/tools/mcp"
 )
-
-type config struct {
-	Base                         string   `mapstructure:"base"`
-	Head                         string   `mapstructure:"head"`
-	Model                        string   `mapstructure:"model"`
-	Provider                     string   `mapstructure:"provider"`
-	ProviderAPIKey               string   `mapstructure:"provider-api-key"`
-	ProviderURL                  string   `mapstructure:"provider-url"`
-	WorkingDir                   string   `mapstructure:"-"`
-	MainGuidelines               string   `mapstructure:"main-guidelines"`
-	SupplementalGuidelines       []string `mapstructure:"supplemental-guidelines"`
-	MaxTokens                    int      `mapstructure:"max-tokens"`
-	ReviewOutputFile             string   `mapstructure:"review-output-file"`
-	OutputJSONFile               string   `mapstructure:"output-json"`
-	MetricsJSONFile              string   `mapstructure:"metrics-json"`
-	ExtractionModel              string   `mapstructure:"extraction-model"`
-	MetadataJSONFile             string   `mapstructure:"metadata-json"`
-	ApprovalEvaluationPromptFile string   `mapstructure:"approval-evaluation-prompt-file"`
-	DiffFile                     string   `mapstructure:"diff-file"`
-	FilesListFile                string   `mapstructure:"files-list-file"`
-	CommitsFile                  string   `mapstructure:"commits-file"`
-	MCPConfigFile                string   `mapstructure:"mcp-config"`
-	IgnoredLockFiles             []string `mapstructure:"ignored-lock-files"`
-	ConfigFile                   string   `mapstructure:"config"`
-}
 
 func main() {
 	ctx := context.Background()
@@ -55,7 +29,7 @@ func main() {
 }
 
 func run(ctx context.Context, args []string, stderr *log.Logger) error {
-	var cfg config
+	cfg := config.NewDefaultConfig()
 
 	fs := flag.NewFlagSet("cassandra", flag.ContinueOnError)
 
@@ -107,19 +81,15 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	}
 
 	v := viper.New()
-	// Note: We set defaults in viper instead of pflag.
-	// We only bind flags that were explicitly set by the user (Changed).
-	// This ensures that pflag's zero-value defaults do not override
-	// values from the configuration file or viper's own defaults.
 	v.SetDefault("main-guidelines", "general")
 	v.SetDefault("base", "main")
 	v.SetDefault("head", "HEAD")
 	v.SetDefault("max-tokens", llm.DefaultMaxTokens)
+	v.SetDefault("ignored-lock-files", tools.DefaultLockFiles)
 
 	fs.VisitAll(func(f *flag.Flag) {
 		if f.Changed {
 			if err := v.BindPFlag(f.Name, f); err != nil {
-				// This is highly unlikely to fail as we are iterating over our own flags
 				stderr.Printf("Warning: failed to bind flag %s to viper: %v\n", f.Name, err)
 			}
 		}
@@ -143,7 +113,6 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		}
 	}
 
-	// Sync flag variables with viper (precedence: CLI > Config > Defaults)
 	if err := v.Unmarshal(&cfg); err != nil {
 		return fmt.Errorf("failed to unmarshal configuration: %w", err)
 	}
@@ -161,30 +130,6 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 
 	if len(missing) > 0 {
 		return fmt.Errorf("missing required arguments:\n  - %s", strings.Join(missing, "\n  - "))
-	}
-
-	// Resolve main guidelines content
-	mainGuidelinesContent, err := resolveGuidelinesContent(cfg.MainGuidelines)
-	if err != nil {
-		return fmt.Errorf("failed to resolve main guidelines: %w", err)
-	}
-
-	var supplementalGuidelinesContent []string
-	for _, sg := range cfg.SupplementalGuidelines {
-		content, err := resolveGuidelinesContent(sg)
-		if err != nil {
-			return fmt.Errorf("failed to resolve supplemental guideline %q: %w", sg, err)
-		}
-		supplementalGuidelinesContent = append(supplementalGuidelinesContent, content)
-	}
-
-	var approvalEvaluationContent string
-	if cfg.ApprovalEvaluationPromptFile != "" {
-		content, err := os.ReadFile(cfg.ApprovalEvaluationPromptFile)
-		if err != nil {
-			return fmt.Errorf("failed to read approval evaluation prompt file: %w", err)
-		}
-		approvalEvaluationContent = string(content)
 	}
 
 	stderr.Println("=== Cassandra Configuration ===")
@@ -221,48 +166,17 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	stderr.Println("  API Key: [PROVIDED]")
 	stderr.Println("===============================")
 
-	// Initialize LLM Client
-	client, err := factory.New(ctx, cfg.Provider, cfg.Model, cfg.ProviderAPIKey, cfg.ProviderURL)
+	// Initialize Reviewer
+	reviewer, err := core.NewReviewer(ctx, cfg, targetDir)
 	if err != nil {
-		return fmt.Errorf("failed to initialize LLM: %w", err)
+		return fmt.Errorf("failed to initialize reviewer: %w", err)
 	}
-
-	// Initialize Agent and Tool Registry
-	registry := tools.NewRegistry()
-	tools.RegisterLocalTools(registry, targetDir, cfg.IgnoredLockFiles)
-
-	if cfg.MCPConfigFile != "" {
-		mcpData, err := os.ReadFile(cfg.MCPConfigFile)
-		if err != nil {
-			return fmt.Errorf("failed to read MCP config file %s: %w", cfg.MCPConfigFile, err)
-		}
-		var mcpConfig mcp.Config
-		if err := json.Unmarshal(mcpData, &mcpConfig); err != nil {
-			return fmt.Errorf("failed to parse MCP config file %s: %w", cfg.MCPConfigFile, err)
-		}
-		mcpConfig.ExpandEnv()
-
-		mcpManager := mcp.NewManager()
-		defer func() {
-			if err := mcpManager.Close(); err != nil {
-				stderr.Printf("Warning: failed to close MCP manager: %v\n", err)
-			}
-		}()
-
-		stderr.Printf("Initializing MCP servers from %s...\n", cfg.MCPConfigFile)
-		if err := mcpManager.RegisterServers(ctx, mcpConfig, func(def llm.ToolDef, handler func(context.Context, llm.ToolCall) (string, error)) {
-			registry.RegisterTool(def, handler)
-		}); err != nil {
-			return fmt.Errorf("failed to register MCP servers: %w", err)
-		}
-	}
-
-	agent := core.NewAgent(client, registry)
+	defer reviewer.Close()
 
 	// Ensure metrics are written even on failure
 	if cfg.MetricsJSONFile != "" {
 		defer func() {
-			metrics := agent.GetMetrics()
+			metrics := reviewer.Agent.GetMetrics()
 			jsonBytes, err := json.MarshalIndent(map[string]any{"metrics": metrics}, "", "  ")
 			if err != nil {
 				stderr.Printf("Warning: failed to marshal metrics: %v\n", err)
@@ -321,7 +235,6 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		stderr.Println("Fetching git commits locally...")
 		commits, err := tools.FetchGitCommits(ctx, targetDir, cfg.Base, cfg.Head)
 		if err != nil {
-			// Don't fail if commits fetching fails (e.g. shallow clone), just log it
 			stderr.Printf("Warning: failed to fetch git commits: %v\n", err)
 		} else {
 			commitsOutput = commits
@@ -358,28 +271,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		}
 	}
 
-	// Compute max ReAct iterations based on changed files.
-	maxIterations := core.CalculateMaxIterations(len(changedFiles))
-
-	systemStable, systemDynamic, promptSummary, err := prompts.BuildSystemPrompt(targetDir, changedFiles, mainGuidelinesContent, supplementalGuidelinesContent, approvalEvaluationContent)
-	if err != nil {
-		return fmt.Errorf("failed to build system prompt: %w", err)
-	}
-
-	stderr.Println("=== Prompt Summary ===")
-	stderr.Printf("  Stable zone:  %d chars\n", promptSummary.StableLen)
-	stderr.Printf("  Dynamic zone: %d chars\n", promptSummary.DynamicLen)
-	stderr.Printf("  Total:        %d chars\n", promptSummary.StableLen+promptSummary.DynamicLen)
-	if len(promptSummary.LoadedFiles) > 0 {
-		for _, f := range promptSummary.LoadedFiles {
-			stderr.Printf("  [%s] %s\n", f.Type, f.Path)
-		}
-	} else {
-		stderr.Println("  No additional files loaded.")
-	}
-	stderr.Println("======================")
-
-	result, err := agent.RunReview(ctx, systemStable, systemDynamic, requestText, maxIterations, cfg.MaxTokens)
+	result, err := reviewer.Run(ctx, changedFiles, requestText)
 	if err != nil {
 		return fmt.Errorf("review failed: %w", err)
 	}
@@ -396,7 +288,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 
 	if cfg.OutputJSONFile != "" {
 		extractionPrompt := prompts.BuildExtractionPrompt()
-		structured, err := agent.ExtractStructuredReview(ctx, extractionPrompt, result, llm.StructuredConfig{
+		structured, err := reviewer.Agent.ExtractStructuredReview(ctx, extractionPrompt, result, llm.StructuredConfig{
 			ModelOverride: cfg.ExtractionModel,
 			MaxTokens:     cfg.MaxTokens,
 		})
@@ -404,7 +296,6 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 			return fmt.Errorf("structured extraction failed: %w", err)
 		}
 
-		// Populate the raw text manually to save tokens during extraction
 		structured.RawFreeText = result
 
 		jsonBytes, err := json.MarshalIndent(structured, "", "  ")
@@ -419,16 +310,6 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	}
 
 	return nil
-}
-
-func resolveGuidelinesContent(guidelinesPath string) (string, error) {
-	// Try the path as provided first
-	if content, err := os.ReadFile(guidelinesPath); err == nil {
-		return string(content), nil
-	}
-
-	// Try as a named prompt in the library (embedded)
-	return prompts.GetLibraryPrompt(guidelinesPath)
 }
 
 func formatMetadata(metadata core.PRMetadata) string {
@@ -464,7 +345,6 @@ func formatMetadata(metadata core.PRMetadata) string {
 				}
 			}
 			fmt.Fprintf(&sb, "- **%s** (%s)%s:\n", author, c.Date.Format("2006-01-02 15:04"), location)
-			// Indent body and wrap in blockquote to maintain Markdown structure
 			lines := strings.Split(c.Body, "\n")
 			for _, line := range lines {
 				fmt.Fprintf(&sb, "  > %s\n", line)

--- a/cmd/ai_reviewer/main_test.go
+++ b/cmd/ai_reviewer/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/menny/cassandra/core"
+	"github.com/menny/cassandra/core/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -212,19 +213,19 @@ func TestResolveGuidelinesContent(t *testing.T) {
 	require.NoError(t, os.WriteFile(localFile, []byte(localContent), 0o644))
 
 	t.Run("resolves local file path", func(t *testing.T) {
-		content, err := resolveGuidelinesContent(localFile)
+		content, err := config.ResolveGuidelinesContent(localFile)
 		require.NoError(t, err)
 		require.Equal(t, localContent, content)
 	})
 
 	t.Run("resolves named prompt from embedded library", func(t *testing.T) {
-		content, err := resolveGuidelinesContent("google")
+		content, err := config.ResolveGuidelinesContent("google")
 		require.NoError(t, err)
 		require.Contains(t, content, "Google Engineering Practices")
 	})
 
 	t.Run("fails on non-existent path and name", func(t *testing.T) {
-		_, err := resolveGuidelinesContent("non-existent-at-all")
+		_, err := config.ResolveGuidelinesContent("non-existent-at-all")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "prompt \"non-existent-at-all\" not found in library")
 	})

--- a/cmd/eval/BUILD.bazel
+++ b/cmd/eval/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/menny/cassandra/cmd/eval",
     visibility = ["//visibility:private"],
     deps = [
+        "//core/config",
         "//core/eval",
         "//llm/factory",
         "@com_github_spf13_pflag//:pflag",

--- a/cmd/eval/BUILD.bazel
+++ b/cmd/eval/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//core/eval",
         "//llm/factory",
         "@com_github_spf13_pflag//:pflag",
-        "@com_github_spf13_viper//:viper",
     ],
 )
 

--- a/cmd/eval/BUILD.bazel
+++ b/cmd/eval/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "eval_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/menny/cassandra/cmd/eval",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//core/eval",
+        "//llm/factory",
+        "@com_github_spf13_pflag//:pflag",
+        "@com_github_spf13_viper//:viper",
+    ],
+)
+
+go_binary(
+    name = "eval",
+    embed = [":eval_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -62,6 +62,13 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return err
 	}
 
+	// Move to the intended working directory if executing via bazel
+	if workspaceDir := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); workspaceDir != "" {
+		if err := os.Chdir(workspaceDir); err != nil {
+			return fmt.Errorf("failed to change directory to %s: %w", workspaceDir, err)
+		}
+	}
+
 	// 1. Load Subject Config
 	subjectCfg, err := config.Load(subjectConfigPath)
 	if err != nil {

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -140,7 +140,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		if err != nil {
 			return fmt.Errorf("failed to marshal results: %w", err)
 		}
-		if err := os.WriteFile(outputFile, b, 0644); err != nil {
+		if err := os.WriteFile(outputFile, b, 0o644); err != nil {
 			return fmt.Errorf("failed to write output file: %w", err)
 		}
 		stderr.Printf("Results written to %s\n", outputFile)

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -11,6 +11,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 
+	"github.com/menny/cassandra/core/config"
 	"github.com/menny/cassandra/core/eval"
 	"github.com/menny/cassandra/llm/factory"
 )
@@ -29,15 +30,13 @@ func main() {
 
 func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	var (
-		subjectModel    string
-		subjectProvider string
-		subjectAPIKey   string
-		subjectURL      string
+		subjectConfigPath string
+		subjectAPIKey     string
 
-		judgeModel      string
-		judgeProvider   string
-		judgeAPIKey     string
-		judgeURL        string
+		judgeModel    string
+		judgeProvider string
+		judgeAPIKey   string
+		judgeURL      string
 
 		casesDir   string
 		outputFile string
@@ -45,10 +44,8 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 
 	fs := flag.NewFlagSet("eval", flag.ContinueOnError)
 
-	fs.StringVar(&subjectModel, "subject-model", "", "Subject model id")
-	fs.StringVar(&subjectProvider, "subject-provider", "", "Subject provider")
-	fs.StringVar(&subjectAPIKey, "subject-api-key", "", "Subject API key")
-	fs.StringVar(&subjectURL, "subject-url", "", "Subject API URL")
+	fs.StringVar(&subjectConfigPath, "subject-config", "", "Path to the subject's cassandra.toml")
+	fs.StringVar(&subjectAPIKey, "subject-api-key", "", "API key for the subject (overrides config if provided)")
 
 	fs.StringVar(&judgeModel, "judge-model", "", "Judge model id")
 	fs.StringVar(&judgeProvider, "judge-provider", "", "Judge provider")
@@ -65,28 +62,33 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return err
 	}
 
-	// Validation
-	if subjectProvider == "" || subjectModel == "" || subjectAPIKey == "" {
-		return fmt.Errorf("missing required subject flags: --subject-provider, --subject-model, --subject-api-key")
+	// 1. Load Subject Config
+	subjectCfg, err := config.Load(subjectConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load subject config: %w", err)
+	}
+	if subjectAPIKey != "" {
+		subjectCfg.ProviderAPIKey = subjectAPIKey
 	}
 
+	// Validation
+	if subjectCfg.Provider == "" || subjectCfg.Model == "" || subjectCfg.ProviderAPIKey == "" {
+		return fmt.Errorf("subject configuration is incomplete (provider, model, and api-key are required)")
+	}
+
+	// 2. Setup Judge
 	// Default judge to subject if not specified
 	if judgeProvider == "" {
-		judgeProvider = subjectProvider
+		judgeProvider = subjectCfg.Provider
 	}
 	if judgeModel == "" {
-		judgeModel = subjectModel
+		judgeModel = subjectCfg.Model
 	}
 	if judgeAPIKey == "" {
-		judgeAPIKey = subjectAPIKey
+		judgeAPIKey = subjectCfg.ProviderAPIKey
 	}
 	if judgeURL == "" {
-		judgeURL = subjectURL
-	}
-
-	subject, err := factory.New(ctx, subjectProvider, subjectModel, subjectAPIKey, subjectURL)
-	if err != nil {
-		return fmt.Errorf("failed to init subject: %w", err)
+		judgeURL = subjectCfg.ProviderURL
 	}
 
 	judge, err := factory.New(ctx, judgeProvider, judgeModel, judgeAPIKey, judgeURL)
@@ -94,19 +96,19 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return fmt.Errorf("failed to init judge: %w", err)
 	}
 
+	// 3. Run Evaluations
 	cases, err := eval.LoadCases(casesDir)
 	if err != nil {
 		return fmt.Errorf("failed to load cases from %s: %w", casesDir, err)
 	}
 
 	runner := &eval.Runner{
-		Subject: subject,
-		Judge:   judge,
+		SubjectConfig: subjectCfg,
+		Judge:         judge,
 	}
 
 	var results []eval.CaseResult
 	for _, c := range cases {
-		// Respect context cancellation between cases
 		if err := ctx.Err(); err != nil {
 			return err
 		}

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -3,35 +3,23 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	flag "github.com/spf13/pflag"
-	"github.com/spf13/viper"
 
 	"github.com/menny/cassandra/core/eval"
 	"github.com/menny/cassandra/llm/factory"
 )
 
-type config struct {
-	SubjectModel    string `mapstructure:"subject-model"`
-	SubjectProvider string `mapstructure:"subject-provider"`
-	SubjectAPIKey   string `mapstructure:"subject-api-key"`
-	SubjectURL      string `mapstructure:"subject-url"`
-
-	JudgeModel      string `mapstructure:"judge-model"`
-	JudgeProvider   string `mapstructure:"judge-provider"`
-	JudgeAPIKey     string `mapstructure:"judge-api-key"`
-	JudgeURL        string `mapstructure:"judge-url"`
-
-	CasesDir        string `mapstructure:"cases-dir"`
-	OutputFile      string `mapstructure:"output"`
-}
-
 func main() {
-	ctx := context.Background()
+	// Handle termination signals gracefully
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
 	stderr := log.New(os.Stderr, "", 0)
 	if err := run(ctx, os.Args[1:], stderr); err != nil {
 		stderr.Printf("Error: %v\n", err)
@@ -40,66 +28,75 @@ func main() {
 }
 
 func run(ctx context.Context, args []string, stderr *log.Logger) error {
-	var cfg config
+	var (
+		subjectModel    string
+		subjectProvider string
+		subjectAPIKey   string
+		subjectURL      string
+
+		judgeModel      string
+		judgeProvider   string
+		judgeAPIKey     string
+		judgeURL        string
+
+		casesDir   string
+		outputFile string
+	)
 
 	fs := flag.NewFlagSet("eval", flag.ContinueOnError)
 
-	fs.StringVar(&cfg.SubjectModel, "subject-model", "", "Subject model id")
-	fs.StringVar(&cfg.SubjectProvider, "subject-provider", "", "Subject provider")
-	fs.StringVar(&cfg.SubjectAPIKey, "subject-api-key", "", "Subject API key")
-	fs.StringVar(&cfg.SubjectURL, "subject-url", "", "Subject API URL")
+	fs.StringVar(&subjectModel, "subject-model", "", "Subject model id")
+	fs.StringVar(&subjectProvider, "subject-provider", "", "Subject provider")
+	fs.StringVar(&subjectAPIKey, "subject-api-key", "", "Subject API key")
+	fs.StringVar(&subjectURL, "subject-url", "", "Subject API URL")
 
-	fs.StringVar(&cfg.JudgeModel, "judge-model", "", "Judge model id")
-	fs.StringVar(&cfg.JudgeProvider, "judge-provider", "", "Judge provider")
-	fs.StringVar(&cfg.JudgeAPIKey, "judge-api-key", "", "Judge API key")
-	fs.StringVar(&cfg.JudgeURL, "judge-url", "", "Judge API URL")
+	fs.StringVar(&judgeModel, "judge-model", "", "Judge model id")
+	fs.StringVar(&judgeProvider, "judge-provider", "", "Judge provider")
+	fs.StringVar(&judgeAPIKey, "judge-api-key", "", "Judge API key")
+	fs.StringVar(&judgeURL, "judge-url", "", "Judge API URL")
 
-	fs.StringVar(&cfg.CasesDir, "cases-dir", "core/eval/testdata/cases", "Directory containing evaluation cases")
-	fs.StringVar(&cfg.OutputFile, "output", "", "Path to write the evaluation results (JSON)")
+	fs.StringVar(&casesDir, "cases-dir", "core/eval/testdata/cases", "Directory containing evaluation cases")
+	fs.StringVar(&outputFile, "output", "", "Path to write the evaluation results (JSON)")
 
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if err == flag.ErrHelp {
 			return nil
 		}
 		return err
 	}
 
-	v := viper.New()
-	fs.VisitAll(func(f *flag.Flag) {
-		if f.Changed {
-			v.BindPFlag(f.Name, f)
-		}
-	})
-
-	if err := v.Unmarshal(&cfg); err != nil {
-		return err
-	}
-
 	// Validation
-	if cfg.SubjectProvider == "" || cfg.SubjectModel == "" || cfg.SubjectAPIKey == "" {
-		return fmt.Errorf("missing subject model configuration")
-	}
-	if cfg.JudgeProvider == "" || cfg.JudgeModel == "" || cfg.JudgeAPIKey == "" {
-		// Default judge to subject if not specified
-		if cfg.JudgeProvider == "" { cfg.JudgeProvider = cfg.SubjectProvider }
-		if cfg.JudgeModel == "" { cfg.JudgeModel = cfg.SubjectModel }
-		if cfg.JudgeAPIKey == "" { cfg.JudgeAPIKey = cfg.SubjectAPIKey }
-		if cfg.JudgeURL == "" { cfg.JudgeURL = cfg.SubjectURL }
+	if subjectProvider == "" || subjectModel == "" || subjectAPIKey == "" {
+		return fmt.Errorf("missing required subject flags: --subject-provider, --subject-model, --subject-api-key")
 	}
 
-	subject, err := factory.New(ctx, cfg.SubjectProvider, cfg.SubjectModel, cfg.SubjectAPIKey, cfg.SubjectURL)
+	// Default judge to subject if not specified
+	if judgeProvider == "" {
+		judgeProvider = subjectProvider
+	}
+	if judgeModel == "" {
+		judgeModel = subjectModel
+	}
+	if judgeAPIKey == "" {
+		judgeAPIKey = subjectAPIKey
+	}
+	if judgeURL == "" {
+		judgeURL = subjectURL
+	}
+
+	subject, err := factory.New(ctx, subjectProvider, subjectModel, subjectAPIKey, subjectURL)
 	if err != nil {
 		return fmt.Errorf("failed to init subject: %w", err)
 	}
 
-	judge, err := factory.New(ctx, cfg.JudgeProvider, cfg.JudgeModel, cfg.JudgeAPIKey, cfg.JudgeURL)
+	judge, err := factory.New(ctx, judgeProvider, judgeModel, judgeAPIKey, judgeURL)
 	if err != nil {
 		return fmt.Errorf("failed to init judge: %w", err)
 	}
 
-	cases, err := eval.LoadCases(cfg.CasesDir)
+	cases, err := eval.LoadCases(casesDir)
 	if err != nil {
-		return fmt.Errorf("failed to load cases: %w", err)
+		return fmt.Errorf("failed to load cases from %s: %w", casesDir, err)
 	}
 
 	runner := &eval.Runner{
@@ -109,31 +106,42 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 
 	var results []eval.CaseResult
 	for _, c := range cases {
+		// Respect context cancellation between cases
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		stderr.Printf("Running case: %s (%s)...\n", c.Name, c.ID)
 		res, err := runner.RunCase(ctx, c)
 		if err != nil {
 			stderr.Printf("  Error running case %s: %v\n", c.ID, err)
 			results = append(results, eval.CaseResult{
-				CaseID: c.ID,
+				CaseID:   c.ID,
 				CaseName: c.Name,
-				Error: err.Error(),
+				Error:    err.Error(),
 			})
 			continue
 		}
 		results = append(results, *res)
 		stderr.Printf("  Score: %d/5\n", res.Subject.Score)
 		stderr.Printf("  Rationale: %s\n", res.Subject.Rationale)
+		if len(res.Subject.Findings) > 0 {
+			stderr.Printf("  Findings:\n")
+			for _, f := range res.Subject.Findings {
+				stderr.Printf("    - %s\n", f)
+			}
+		}
 	}
 
-	if cfg.OutputFile != "" {
+	if outputFile != "" {
 		b, err := json.MarshalIndent(results, "", "  ")
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to marshal results: %w", err)
 		}
-		if err := os.WriteFile(cfg.OutputFile, b, 0644); err != nil {
-			return err
+		if err := os.WriteFile(outputFile, b, 0644); err != nil {
+			return fmt.Errorf("failed to write output file: %w", err)
 		}
-		stderr.Printf("Results written to %s\n", cfg.OutputFile)
+		stderr.Printf("Results written to %s\n", outputFile)
 	}
 
 	return nil

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -38,7 +38,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		judgeAPIKey   string
 		judgeURL      string
 
-		casesDir   string
+		suitePath  string
 		outputFile string
 	)
 
@@ -52,7 +52,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	fs.StringVar(&judgeAPIKey, "judge-api-key", "", "Judge API key")
 	fs.StringVar(&judgeURL, "judge-url", "", "Judge API URL")
 
-	fs.StringVar(&casesDir, "cases-dir", "core/eval/testdata/cases", "Directory containing evaluation cases")
+	fs.StringVar(&suitePath, "suite", "core/eval/testdata/evaluations.json", "Path to the evaluation suite manifest (JSON)")
 	fs.StringVar(&outputFile, "output", "", "Path to write the evaluation results (JSON)")
 
 	if err := fs.Parse(args); err != nil {
@@ -103,10 +103,10 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return fmt.Errorf("failed to init judge: %w", err)
 	}
 
-	// 3. Run Evaluations
-	cases, err := eval.LoadCases(casesDir)
+	// 3. Load Evaluation Suite
+	suite, err := eval.LoadSuite(suitePath)
 	if err != nil {
-		return fmt.Errorf("failed to load cases from %s: %w", casesDir, err)
+		return fmt.Errorf("failed to load suite from %s: %w", suitePath, err)
 	}
 
 	runner := &eval.Runner{
@@ -114,8 +114,14 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		Judge:         judge,
 	}
 
+	stderr.Printf("Running Suite: %s\n", suite.Name)
+	if suite.Description != "" {
+		stderr.Printf("Description: %s\n", suite.Description)
+	}
+	stderr.Println("===============================")
+
 	var results []eval.CaseResult
-	for _, c := range cases {
+	for _, c := range suite.Cases {
 		if err := ctx.Err(); err != nil {
 			return err
 		}

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/menny/cassandra/core/eval"
+	"github.com/menny/cassandra/llm/factory"
+)
+
+type config struct {
+	SubjectModel    string `mapstructure:"subject-model"`
+	SubjectProvider string `mapstructure:"subject-provider"`
+	SubjectAPIKey   string `mapstructure:"subject-api-key"`
+	SubjectURL      string `mapstructure:"subject-url"`
+
+	JudgeModel      string `mapstructure:"judge-model"`
+	JudgeProvider   string `mapstructure:"judge-provider"`
+	JudgeAPIKey     string `mapstructure:"judge-api-key"`
+	JudgeURL        string `mapstructure:"judge-url"`
+
+	CasesDir        string `mapstructure:"cases-dir"`
+	OutputFile      string `mapstructure:"output"`
+}
+
+func main() {
+	ctx := context.Background()
+	stderr := log.New(os.Stderr, "", 0)
+	if err := run(ctx, os.Args[1:], stderr); err != nil {
+		stderr.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string, stderr *log.Logger) error {
+	var cfg config
+
+	fs := flag.NewFlagSet("eval", flag.ContinueOnError)
+
+	fs.StringVar(&cfg.SubjectModel, "subject-model", "", "Subject model id")
+	fs.StringVar(&cfg.SubjectProvider, "subject-provider", "", "Subject provider")
+	fs.StringVar(&cfg.SubjectAPIKey, "subject-api-key", "", "Subject API key")
+	fs.StringVar(&cfg.SubjectURL, "subject-url", "", "Subject API URL")
+
+	fs.StringVar(&cfg.JudgeModel, "judge-model", "", "Judge model id")
+	fs.StringVar(&cfg.JudgeProvider, "judge-provider", "", "Judge provider")
+	fs.StringVar(&cfg.JudgeAPIKey, "judge-api-key", "", "Judge API key")
+	fs.StringVar(&cfg.JudgeURL, "judge-url", "", "Judge API URL")
+
+	fs.StringVar(&cfg.CasesDir, "cases-dir", "core/eval/testdata/cases", "Directory containing evaluation cases")
+	fs.StringVar(&cfg.OutputFile, "output", "", "Path to write the evaluation results (JSON)")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	v := viper.New()
+	fs.VisitAll(func(f *flag.Flag) {
+		if f.Changed {
+			v.BindPFlag(f.Name, f)
+		}
+	})
+
+	if err := v.Unmarshal(&cfg); err != nil {
+		return err
+	}
+
+	// Validation
+	if cfg.SubjectProvider == "" || cfg.SubjectModel == "" || cfg.SubjectAPIKey == "" {
+		return fmt.Errorf("missing subject model configuration")
+	}
+	if cfg.JudgeProvider == "" || cfg.JudgeModel == "" || cfg.JudgeAPIKey == "" {
+		// Default judge to subject if not specified
+		if cfg.JudgeProvider == "" { cfg.JudgeProvider = cfg.SubjectProvider }
+		if cfg.JudgeModel == "" { cfg.JudgeModel = cfg.SubjectModel }
+		if cfg.JudgeAPIKey == "" { cfg.JudgeAPIKey = cfg.SubjectAPIKey }
+		if cfg.JudgeURL == "" { cfg.JudgeURL = cfg.SubjectURL }
+	}
+
+	subject, err := factory.New(ctx, cfg.SubjectProvider, cfg.SubjectModel, cfg.SubjectAPIKey, cfg.SubjectURL)
+	if err != nil {
+		return fmt.Errorf("failed to init subject: %w", err)
+	}
+
+	judge, err := factory.New(ctx, cfg.JudgeProvider, cfg.JudgeModel, cfg.JudgeAPIKey, cfg.JudgeURL)
+	if err != nil {
+		return fmt.Errorf("failed to init judge: %w", err)
+	}
+
+	cases, err := eval.LoadCases(cfg.CasesDir)
+	if err != nil {
+		return fmt.Errorf("failed to load cases: %w", err)
+	}
+
+	runner := &eval.Runner{
+		Subject: subject,
+		Judge:   judge,
+	}
+
+	var results []eval.CaseResult
+	for _, c := range cases {
+		stderr.Printf("Running case: %s (%s)...\n", c.Name, c.ID)
+		res, err := runner.RunCase(ctx, c)
+		if err != nil {
+			stderr.Printf("  Error running case %s: %v\n", c.ID, err)
+			results = append(results, eval.CaseResult{
+				CaseID: c.ID,
+				CaseName: c.Name,
+				Error: err.Error(),
+			})
+			continue
+		}
+		results = append(results, *res)
+		stderr.Printf("  Score: %d/5\n", res.Subject.Score)
+		stderr.Printf("  Rationale: %s\n", res.Subject.Rationale)
+	}
+
+	if cfg.OutputFile != "" {
+		b, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(cfg.OutputFile, b, 0644); err != nil {
+			return err
+		}
+		stderr.Printf("Results written to %s\n", cfg.OutputFile)
+	}
+
+	return nil
+}

--- a/conductor/eval-suites.md
+++ b/conductor/eval-suites.md
@@ -1,0 +1,60 @@
+# Plan: Multi-Configuration Evaluation Suites
+
+## Objective
+Decouple evaluation criteria (rubrics and metadata) from physical fixture data (diffs and base states). By introducing an `evaluations.json` manifest (a "Suite"), we can run different combinations of tests with varying rubrics against different Cassandra configurations, reusing the same physical data.
+
+## Scope & Impact
+- **Data Structure**: Moving from a directory-crawling approach (reading `metadata.json` per folder) to a manifest-driven approach.
+- **CLI Interface**: Changing `cmd/eval` to accept a suite manifest file instead of a cases directory.
+- **Reusability**: Multiple suite files can point to the same `fixture_path` but apply a different `rubric` (e.g., a "minimalist" suite expecting brief comments vs. a "pedantic" suite).
+
+## Proposed Solution
+
+### 1. Data Structures (`core/eval/types.go`)
+Introduce a new `TestSuite` struct that contains a list of cases. The `EvalCase` struct will be updated to reflect its role as an entry in the suite.
+
+```go
+type TestSuite struct {
+    Name        string     `json:"name"`
+    Description string     `json:"description"`
+    Cases       []EvalCase `json:"cases"`
+}
+
+type EvalCase struct {
+    ID          string `json:"id"`
+    Name        string `json:"name"`
+    Description string `json:"description"`
+    Rubric      string `json:"rubric"`
+    
+    // FixturePath points to the directory containing input.diff and base states.
+    // It is resolved relative to the directory containing the suite JSON file.
+    FixturePath string `json:"fixture_path"` 
+    
+    // BaseSource remains optional. If omitted, the runner looks in FixturePath.
+    BaseSource  string `json:"base_source,omitempty"`
+    
+    // Loaded at runtime
+    Diff string `json:"-"`
+}
+```
+
+### 2. Refactor Runner Loading (`core/eval/runner.go`)
+Update the loading logic to read the suite file rather than walking a directory.
+
+*   Remove the directory crawler `LoadCases`.
+*   Create `LoadSuite(suiteFilePath string) (*TestSuite, error)`.
+*   The function will parse the JSON, iterate through the `Cases`, and load `input.diff` and `base.tar.gz`/`base` by resolving `FixturePath` relative to the `suiteFilePath`'s directory.
+
+### 3. Update CLI (`cmd/eval/main.go`)
+*   Replace `--cases-dir` with `--suite` (defaulting to `core/eval/testdata/evaluations.json`).
+*   Update the setup phase to load the suite and pass the parsed cases to the runner.
+
+### 4. Data Migration
+*   Create `core/eval/testdata/evaluations.json`.
+*   Migrate the contents of the existing `metadata.json` files into this central manifest.
+*   Update `FixturePath` for the existing cases to point to their respective directories.
+*   Delete the obsolete `metadata.json` files.
+
+## Verification
+-   Run `bazel run //cmd/eval` with the newly created default suite to ensure the "Simple Bug Fix" case still executes and passes successfully.
+-   Ensure all path resolutions correctly anchor to the location of the `evaluations.json` file, regardless of where the `bazel run` command is invoked from.

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -7,11 +7,17 @@ go_library(
         "github.go",
         "io_util.go",
         "review_types.go",
+        "reviewer.go",
     ],
     importpath = "github.com/menny/cassandra/core",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/config",
+        "//core/prompts",
         "//llm",
+        "//llm/factory",
+        "//tools",
+        "//tools/mcp",
     ],
 )
 

--- a/core/config/BUILD.bazel
+++ b/core/config/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "config",
+    srcs = ["config.go"],
+    importpath = "github.com/menny/cassandra/core/config",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core/prompts",
+        "//llm",
+        "//tools",
+        "@com_github_spf13_viper//:viper",
+    ],
+)

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -41,10 +41,10 @@ type Config struct {
 // NewDefaultConfig returns a Config with default values populated.
 func NewDefaultConfig() *Config {
 	return &Config{
-		Base:           "main",
-		Head:           "HEAD",
-		MainGuidelines: "general",
-		MaxTokens:      llm.DefaultMaxTokens,
+		Base:             "main",
+		Head:             "HEAD",
+		MainGuidelines:   "general",
+		MaxTokens:        llm.DefaultMaxTokens,
 		IgnoredLockFiles: tools.DefaultLockFiles,
 	}
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/viper"
+
+	"github.com/menny/cassandra/core/prompts"
+	"github.com/menny/cassandra/llm"
+	"github.com/menny/cassandra/tools"
+)
+
+// Config represents the complete configuration for a Cassandra reviewer.
+type Config struct {
+	Base                         string   `mapstructure:"base"`
+	Head                         string   `mapstructure:"head"`
+	Model                        string   `mapstructure:"model"`
+	Provider                     string   `mapstructure:"provider"`
+	ProviderAPIKey               string   `mapstructure:"provider-api-key"`
+	ProviderURL                  string   `mapstructure:"provider-url"`
+	WorkingDir                   string   `mapstructure:"-"`
+	MainGuidelines               string   `mapstructure:"main-guidelines"`
+	SupplementalGuidelines       []string `mapstructure:"supplemental-guidelines"`
+	MaxTokens                    int      `mapstructure:"max-tokens"`
+	ReviewOutputFile             string   `mapstructure:"review-output-file"`
+	OutputJSONFile               string   `mapstructure:"output-json"`
+	MetricsJSONFile              string   `mapstructure:"metrics-json"`
+	ExtractionModel              string   `mapstructure:"extraction-model"`
+	MetadataJSONFile             string   `mapstructure:"metadata-json"`
+	ApprovalEvaluationPromptFile string   `mapstructure:"approval-evaluation-prompt-file"`
+	DiffFile                     string   `mapstructure:"diff-file"`
+	FilesListFile                string   `mapstructure:"files-list-file"`
+	CommitsFile                  string   `mapstructure:"commits-file"`
+	MCPConfigFile                string   `mapstructure:"mcp-config"`
+	IgnoredLockFiles             []string `mapstructure:"ignored-lock-files"`
+	ConfigFile                   string   `mapstructure:"config"`
+}
+
+// NewDefaultConfig returns a Config with default values populated.
+func NewDefaultConfig() *Config {
+	return &Config{
+		Base:           "main",
+		Head:           "HEAD",
+		MainGuidelines: "general",
+		MaxTokens:      llm.DefaultMaxTokens,
+		IgnoredLockFiles: tools.DefaultLockFiles,
+	}
+}
+
+// Load reads the configuration from a TOML file.
+// It does NOT handle CLI flags or environment variables; the caller should bind those
+// if needed before calling Unmarshal.
+func Load(configFile string) (*Config, error) {
+	v := viper.New()
+	v.SetDefault("main-guidelines", "general")
+	v.SetDefault("base", "main")
+	v.SetDefault("head", "HEAD")
+	v.SetDefault("max-tokens", llm.DefaultMaxTokens)
+	v.SetDefault("ignored-lock-files", tools.DefaultLockFiles)
+
+	if configFile != "" {
+		v.SetConfigFile(configFile)
+	} else {
+		v.SetConfigName("cassandra")
+		v.SetConfigType("toml")
+		v.AddConfigPath(".")
+	}
+
+	if err := v.ReadInConfig(); err != nil {
+		if configFile != "" {
+			return nil, fmt.Errorf("failed to read config file %q: %w", configFile, err)
+		}
+		var notFound viper.ConfigFileNotFoundError
+		if !errors.As(err, &notFound) {
+			return nil, fmt.Errorf("failed to read config file: %w", err)
+		}
+	}
+
+	cfg := &Config{}
+	if err := v.Unmarshal(cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal configuration: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// ResolveGuidelinesContent fetches the content of a guideline, either from a file or the library.
+func ResolveGuidelinesContent(guidelinesPath string) (string, error) {
+	// Try the path as provided first
+	if content, err := os.ReadFile(guidelinesPath); err == nil {
+		return string(content), nil
+	}
+
+	// Try as a named prompt in the library (embedded)
+	return prompts.GetLibraryPrompt(guidelinesPath)
+}

--- a/core/eval/BUILD.bazel
+++ b/core/eval/BUILD.bazel
@@ -11,9 +11,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core",
+        "//core/config",
         "//core/prompts",
         "//llm",
-        "//tools",
     ],
 )
 

--- a/core/eval/BUILD.bazel
+++ b/core/eval/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "eval",
+    srcs = [
+        "runner.go",
+        "sandbox.go",
+        "types.go",
+    ],
+    importpath = "github.com/menny/cassandra/core/eval",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core",
+        "//core/prompts",
+        "//llm",
+        "//tools",
+    ],
+)
+
+go_test(
+    name = "eval_test",
+    srcs = ["sandbox_test.go"],
+    embed = [":eval"],
+)

--- a/core/eval/README.md
+++ b/core/eval/README.md
@@ -1,35 +1,35 @@
 # Cassandra Eval System
 
-The Cassandra Eval system provides a data-driven, high-fidelity environment for evaluating the `ai-reviewer` agent using an **LLM-as-a-Judge** strategy.
+The Cassandra Eval system provides a data-driven, high-fidelity environment for evaluating the `ai-reviewer` agent using an **LLM-as-a-Judge** strategy. It is designed to ensure strict parity between production behavior and evaluation scenarios.
 
 ## Architecture
 
 The system consists of three main components:
 
-1.  **High-Fidelity Sandbox**: A Git-backed environment that mirrors a real-world repository state.
-2.  **LLM-as-a-Judge**: A structured evaluation pass where a "Judge" model scores the "Subject" agent's review.
-3.  **Data-Driven Fixtures**: Test cases defined as filesystem fixtures, separating code from evaluation data.
+1.  **High-Fidelity Sandbox**: A Git-backed environment that mirrors a real-world repository state using `git apply` to ensure tools see exactly what they would in a real PR.
+2.  **LLM-as-a-Judge**: A structured evaluation pass where a "Judge" model (e.g., Claude 3.7 or Gemini 1.5 Pro) scores the "Subject" agent's review against a specific rubric.
+3.  **Data-Driven Fixtures**: Test cases defined as filesystem fixtures (metadata, diffs, and base states), keeping evaluation data isolated from code.
 
 ## Sandbox Lifecycle
 
 For each evaluation case, the system:
-1.  Creates a temporary directory.
-2.  Populates the "Base" state (from a directory or a `.tar.gz` file).
-3.  Initializes a Git repository and commits the base state.
+1.  Creates a unique temporary directory.
+2.  Populates the "Base" state from a `.tar.gz` archive or a directory.
+3.  Initializes a Git repository (`--initial-branch=main`) and commits the base state.
 4.  Applies the `input.diff` using `git apply`.
 5.  Commits the final state.
-6.  Points the Agent's tool registry to this directory.
+6.  Instantiates a `core.Reviewer` (Subject) rooted in this directory.
 
-This process ensures that tools like `read_file`, `glob_files`, and `grep_files` see the repository exactly as it would appear in a real Pull Request.
+This ensures that tools like `read_file`, `glob_files`, and `grep_files` operate with absolute parity to a production environment.
 
 ## Creating Evaluation Cases
 
 Cases are stored in `core/eval/testdata/cases/`. Each case is a directory containing:
 
--   `metadata.json`: Defines the case name, description, and the evaluation **rubric**.
--   `input.diff`: The Git diff that the agent will be asked to review.
--   `base.tar.gz` (Recommended): A tarball of the repository files *before* the diff is applied.
--   `base/` (Alternative): A directory containing the base files.
+-   **`metadata.json`**: Defines the case name, description, and the evaluation **rubric**.
+-   **`input.diff`**: The Git diff that the agent will be asked to review.
+-   **`base.tar.gz`** (Recommended): A tarball of the repository files *before* the diff is applied. Using tarballs prevents Bazel from indexing evaluation data.
+-   **`base/`** (Alternative): A directory containing the base files, useful for local development.
 
 ### Example `metadata.json`
 
@@ -44,23 +44,23 @@ Cases are stored in `core/eval/testdata/cases/`. Each case is a directory contai
 
 ## Running Evaluations
 
-Use the `eval` CLI to run batch evaluations:
+The `eval` CLI is the primary entry point for batch processing. It leverages the unified `core.Reviewer` factory to ensure the Subject uses your production configuration.
 
 ```bash
 bazel run //cmd/eval -- \
-  --subject-provider google \
-  --subject-model gemini-1.5-pro \
+  --subject-config cassandra.toml \
   --subject-api-key $GOOGLE_API_KEY \
-  --judge-model claude-3-7-sonnet \
+  --judge-model gemini-1.5-pro \
   --output results.json
 ```
 
 ### CLI Options
 
--   `--subject-*`: Configuration for the model being evaluated.
--   `--judge-*`: Configuration for the model doing the evaluation (defaults to the subject if not provided).
--   `--cases-dir`: Directory containing the fixtures (defaults to `core/eval/testdata/cases`).
--   `--output`: Path to write the detailed results in JSON format.
+-   **`--subject-config`**: Path to a Cassandra TOML file. The Subject will inherit all guidelines, tool settings, and model parameters from this file.
+-   **`--subject-api-key`**: API key for the Subject (overrides the config if provided).
+-   **`--judge-*`**: Configuration for the model performing the evaluation (provider, model, url, api-key). Defaults to the Subject's settings if not specified.
+-   **`--cases-dir`**: Directory containing the fixtures (defaults to `core/eval/testdata/cases`).
+-   **`--output`**: Path to write the detailed results and metrics in JSON format.
 
 ## Scoring Rubric
 
@@ -69,3 +69,5 @@ The Judge evaluates the agent's review on a scale of 1-5 based on:
 -   **Completeness**: Addressing all points in the rubric.
 -   **Constructiveness**: Providing helpful and professional feedback.
 -   **Depth**: Effective use of tools to understand context.
+
+The CLI outputs the Score, Rationale, and a list of specific **Findings** for each case.

--- a/core/eval/README.md
+++ b/core/eval/README.md
@@ -1,0 +1,70 @@
+# Cassandra Eval System
+
+The Cassandra Eval system provides a data-driven, high-fidelity environment for evaluating the `ai-reviewer` agent using an **LLM-as-a-Judge** strategy.
+
+## Architecture
+
+The system consists of three main components:
+
+1.  **High-Fidelity Sandbox**: A Git-backed environment that mirrors a real-world repository state.
+2.  **LLM-as-a-Judge**: A structured evaluation pass where a "Judge" model scores the "Subject" agent's review.
+3.  **Data-Driven Fixtures**: Test cases defined as filesystem fixtures, separating code from evaluation data.
+
+## Sandbox Lifecycle
+
+For each evaluation case, the system:
+1.  Creates a temporary directory.
+2.  Populates the "Base" state (from a directory or a `.tar.gz` file).
+3.  Initializes a Git repository and commits the base state.
+4.  Applies the `input.diff` using `git apply`.
+5.  Commits the final state.
+6.  Points the Agent's tool registry to this directory.
+
+This process ensures that tools like `read_file`, `glob_files`, and `grep_files` see the repository exactly as it would appear in a real Pull Request.
+
+## Creating Evaluation Cases
+
+Cases are stored in `core/eval/testdata/cases/`. Each case is a directory containing:
+
+-   `metadata.json`: Defines the case name, description, and the evaluation **rubric**.
+-   `input.diff`: The Git diff that the agent will be asked to review.
+-   `base.tar.gz` (Recommended): A tarball of the repository files *before* the diff is applied. Using `.tar.gz` prevents Bazel from indexing the files and interfering with builds.
+-   `base/` (Alternative): A directory containing the base files. Useful for quick local iterations.
+
+### Example `metadata.json`
+
+```json
+{
+  "name": "Security: Hardcoded API Key",
+  "description": "Tests if the agent identifies a hardcoded secret in a config file.",
+  "rubric": "The agent MUST identify the hardcoded API key in config.go and recommend using environment variables."
+}
+```
+
+## Running Evaluations
+
+Use the `eval` CLI to run batch evaluations:
+
+```bash
+bazel run //cmd/eval -- \
+  --subject-provider google \
+  --subject-model gemini-1.5-pro \
+  --subject-api-key $GOOGLE_API_KEY \
+  --judge-model claude-3-7-sonnet \
+  --output results.json
+```
+
+### CLI Options
+
+-   `--subject-*`: Configuration for the model being evaluated.
+-   `--judge-*`: Configuration for the model doing the evaluation (defaults to the subject if not provided).
+-   `--cases-dir`: Directory containing the fixtures (defaults to `core/eval/testdata/cases`).
+-   `--output`: Path to write the detailed results in JSON format.
+
+## Scoring Rubric
+
+The Judge evaluates the agent's review on a scale of 1-5 based on:
+-   **Accuracy**: Correct identification of issues without false positives.
+-   **Completeness**: Addressing all points in the rubric.
+-   **Constructiveness**: Providing helpful and professional feedback.
+-   **Depth**: Effective use of tools to understand context.

--- a/core/eval/README.md
+++ b/core/eval/README.md
@@ -48,7 +48,7 @@ The `eval` CLI is the primary entry point for batch processing. It leverages the
 
 ```bash
 bazel run //cmd/eval -- \
-  --subject-config cassandra.toml \
+  --subject-config "$PWD/cassandra.toml" \
   --subject-api-key $GOOGLE_API_KEY \
   --judge-model gemini-1.5-pro \
   --output results.json

--- a/core/eval/README.md
+++ b/core/eval/README.md
@@ -28,8 +28,8 @@ Cases are stored in `core/eval/testdata/cases/`. Each case is a directory contai
 
 -   `metadata.json`: Defines the case name, description, and the evaluation **rubric**.
 -   `input.diff`: The Git diff that the agent will be asked to review.
--   `base.tar.gz` (Recommended): A tarball of the repository files *before* the diff is applied. Using `.tar.gz` prevents Bazel from indexing the files and interfering with builds.
--   `base/` (Alternative): A directory containing the base files. Useful for quick local iterations.
+-   `base.tar.gz` (Recommended): A tarball of the repository files *before* the diff is applied.
+-   `base/` (Alternative): A directory containing the base files.
 
 ### Example `metadata.json`
 
@@ -37,7 +37,8 @@ Cases are stored in `core/eval/testdata/cases/`. Each case is a directory contai
 {
   "name": "Security: Hardcoded API Key",
   "description": "Tests if the agent identifies a hardcoded secret in a config file.",
-  "rubric": "The agent MUST identify the hardcoded API key in config.go and recommend using environment variables."
+  "rubric": "The agent MUST identify the hardcoded API key in config.go and recommend using environment variables.",
+  "base_source": "base.tar.gz"
 }
 ```
 

--- a/core/eval/runner.go
+++ b/core/eval/runner.go
@@ -8,15 +8,15 @@ import (
 	"path/filepath"
 
 	"github.com/menny/cassandra/core"
+	"github.com/menny/cassandra/core/config"
 	"github.com/menny/cassandra/core/prompts"
 	"github.com/menny/cassandra/llm"
-	"github.com/menny/cassandra/tools"
 )
 
 // Runner orchestrates the evaluation process.
 type Runner struct {
-	Subject llm.Model // The model being evaluated
-	Judge   llm.Model // The model doing the evaluation
+	SubjectConfig *config.Config // Configuration for the agent under test
+	Judge         llm.Model      // The model doing the evaluation
 }
 
 // RunCase executes a single evaluation case.
@@ -28,29 +28,24 @@ func (r *Runner) RunCase(ctx context.Context, c EvalCase) (*CaseResult, error) {
 	}
 	defer sandbox.Cleanup()
 
-	// 2. Setup Agent (Subject)
-	registry := tools.NewRegistry()
-	tools.RegisterLocalTools(registry, sandbox.RootDir, nil) // No ignored lock files for now
+	// 2. Setup Reviewer (Subject)
+	// We use the production factory to ensure parity.
+	reviewer, err := core.NewReviewer(ctx, r.SubjectConfig, sandbox.RootDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup reviewer: %w", err)
+	}
+	defer reviewer.Close()
 
-	agent := core.NewAgent(r.Subject, registry)
-
+	// 3. Run Review (Subject)
 	// Build the request text
 	requestText := fmt.Sprintf("Review the following git diff for issues:\n\n%s", c.Diff)
 
-	// Use general guidelines for now
-	guidelines, err := prompts.GetLibraryPrompt("general")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get general guidelines: %w", err)
-	}
-
-	// We don't have PR metadata or extra guidelines for eval cases yet
-	stable, dynamic, _, err := prompts.BuildSystemPrompt(sandbox.RootDir, nil, guidelines, nil, "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to build system prompt: %w", err)
-	}
-
-	// 3. Run Review (Subject)
-	review, err := agent.RunReview(ctx, stable, dynamic, requestText, 0, 0)
+	// Since we are in a sandbox with a committed diff, we can let the reviewer
+	// determine changed files (or just pass the ones from the diff if we had them).
+	// For now, we'll pass an empty slice so it relies on the prompt building logic
+	// to find files in the sandbox if needed, or we could parse the diff.
+	// Most evaluations provide the diff directly in the request text anyway.
+	review, err := reviewer.Run(ctx, nil, requestText)
 	if err != nil {
 		return &CaseResult{
 			CaseID:   c.ID,
@@ -73,7 +68,7 @@ func (r *Runner) RunCase(ctx context.Context, c EvalCase) (*CaseResult, error) {
 		CaseID:   c.ID,
 		CaseName: c.Name,
 		Subject:  *judgeResult,
-		Metrics:  agent.GetMetrics(),
+		Metrics:  reviewer.Agent.GetMetrics(),
 	}, nil
 }
 
@@ -145,10 +140,15 @@ func LoadCases(fixturesDir string) ([]EvalCase, error) {
 		if c.BaseDir != "" {
 			c.BaseDir = filepath.Join(caseDir, c.BaseDir)
 		} else {
-			// Check if a default 'base' directory exists
-			defaultBase := filepath.Join(caseDir, "base")
-			if info, err := os.Stat(defaultBase); err == nil && info.IsDir() {
-				c.BaseDir = defaultBase
+			// Check for default 'base.tar.gz' first, then 'base' directory
+			defaultTar := filepath.Join(caseDir, "base.tar.gz")
+			if _, err := os.Stat(defaultTar); err == nil {
+				c.BaseDir = defaultTar
+			} else {
+				defaultBase := filepath.Join(caseDir, "base")
+				if info, err := os.Stat(defaultBase); err == nil && info.IsDir() {
+					c.BaseDir = defaultBase
+				}
 			}
 		}
 

--- a/core/eval/runner.go
+++ b/core/eval/runner.go
@@ -1,0 +1,170 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/menny/cassandra/core"
+	"github.com/menny/cassandra/core/prompts"
+	"github.com/menny/cassandra/llm"
+	"github.com/menny/cassandra/tools"
+)
+
+// Runner orchestrates the evaluation process.
+type Runner struct {
+	Subject llm.Model // The model being evaluated
+	Judge   llm.Model // The model doing the evaluation
+}
+
+// RunCase executes a single evaluation case.
+func (r *Runner) RunCase(ctx context.Context, c EvalCase) (*CaseResult, error) {
+	// 1. Create Sandbox
+	sandbox, err := NewSandbox(ctx, c.BaseDir, c.Diff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create sandbox: %w", err)
+	}
+	defer sandbox.Cleanup()
+
+	// 2. Setup Agent (Subject)
+	registry := tools.NewRegistry()
+	tools.RegisterLocalTools(registry, nil) // No ignored lock files for now
+
+	// We need to change the working directory of the agent to the sandbox root.
+	// Since our tools use relative paths, we can just Chdir.
+	originalWD, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current working directory: %w", err)
+	}
+	if err := os.Chdir(sandbox.RootDir); err != nil {
+		return nil, fmt.Errorf("failed to change directory to sandbox: %w", err)
+	}
+	defer os.Chdir(originalWD)
+
+	agent := core.NewAgent(r.Subject, registry)
+
+	// Build the request text
+	requestText := fmt.Sprintf("Review the following git diff for issues:\n\n%s", c.Diff)
+
+	// Use general guidelines for now
+	guidelines, err := prompts.GetLibraryPrompt("general")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get general guidelines: %w", err)
+	}
+
+	// We don't have PR metadata or extra guidelines for eval cases yet
+	stable, dynamic, _, err := prompts.BuildSystemPrompt(sandbox.RootDir, nil, guidelines, nil, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build system prompt: %w", err)
+	}
+
+	// 3. Run Review (Subject)
+	review, err := agent.RunReview(ctx, stable, dynamic, requestText, 0, 0)
+	if err != nil {
+		return &CaseResult{
+			CaseID:   c.ID,
+			CaseName: c.Name,
+			Error:    fmt.Sprintf("subject failed: %v", err),
+		}, nil
+	}
+
+	// 4. Judge Review
+	judgeResult, err := r.evaluate(ctx, c, review)
+	if err != nil {
+		return &CaseResult{
+			CaseID:   c.ID,
+			CaseName: c.Name,
+			Error:    fmt.Sprintf("judge failed: %v", err),
+		}, nil
+	}
+
+	return &CaseResult{
+		CaseID:   c.ID,
+		CaseName: c.Name,
+		Subject:  *judgeResult,
+		Metrics:  agent.GetMetrics(),
+	}, nil
+}
+
+func (r *Runner) evaluate(ctx context.Context, c EvalCase, review string) (*EvaluationResult, error) {
+	judgePrompt, err := prompts.GetLibraryPrompt("eval_judge")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get judge prompt: %w", err)
+	}
+
+	userPrompt := fmt.Sprintf("RUBRIC:\n%s\n\nDIFF:\n%s\n\nREVIEW TO EVALUATE:\n%s", c.Rubric, c.Diff, review)
+
+	messages := []llm.Message{
+		{Role: llm.RoleSystem, Text: judgePrompt},
+		{Role: llm.RoleUser, Text: userPrompt},
+	}
+
+	resp, err := r.Judge.GenerateStructuredContent(ctx, messages, EvaluationResultSchema, llm.StructuredConfig{})
+	if err != nil {
+		return nil, err
+	}
+
+	var result EvaluationResult
+	if err := json.Unmarshal([]byte(resp.Text), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse judge result: %w\nRaw: %s", err, resp.Text)
+	}
+
+	return &result, nil
+}
+
+// LoadCases loads all evaluation cases from the given directory.
+func LoadCases(fixturesDir string) ([]EvalCase, error) {
+	entries, err := os.ReadDir(fixturesDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var cases []EvalCase
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		caseDir := filepath.Join(fixturesDir, entry.Name())
+		metadataPath := filepath.Join(caseDir, "metadata.json")
+		b, err := os.ReadFile(metadataPath)
+		if err != nil {
+			continue // Skip directories without metadata.json
+		}
+
+		var c EvalCase
+		if err := json.Unmarshal(b, &c); err != nil {
+			return nil, fmt.Errorf("failed to parse %s: %w", metadataPath, err)
+		}
+
+		// Fill in defaults and absolute paths
+		if c.ID == "" {
+			c.ID = entry.Name()
+		}
+		if c.DiffPath == "" {
+			c.DiffPath = "input.diff"
+		}
+		
+		diffContent, err := os.ReadFile(filepath.Join(caseDir, c.DiffPath))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read diff for %s: %w", c.ID, err)
+		}
+		c.Diff = string(diffContent)
+
+		if c.BaseDir != "" {
+			c.BaseDir = filepath.Join(caseDir, c.BaseDir)
+		} else {
+			// Check if a default 'base' directory exists
+			defaultBase := filepath.Join(caseDir, "base")
+			if info, err := os.Stat(defaultBase); err == nil && info.IsDir() {
+				c.BaseDir = defaultBase
+			}
+		}
+
+		cases = append(cases, c)
+	}
+
+	return cases, nil
+}

--- a/core/eval/runner.go
+++ b/core/eval/runner.go
@@ -93,64 +93,63 @@ func (r *Runner) evaluate(ctx context.Context, c EvalCase, review string) (*Eval
 	return &result, nil
 }
 
-// LoadCases loads all evaluation cases from the given directory.
-func LoadCases(fixturesDir string) ([]EvalCase, error) {
-	entries, err := os.ReadDir(fixturesDir)
+// LoadSuite loads a test suite from a JSON manifest file.
+func LoadSuite(suitePath string) (*TestSuite, error) {
+	data, err := os.ReadFile(suitePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read suite file: %w", err)
 	}
 
-	var cases []EvalCase
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
+	var suite TestSuite
+	if err := json.Unmarshal(data, &suite); err != nil {
+		return nil, fmt.Errorf("failed to parse suite file %s: %w", suitePath, err)
+	}
+
+	suiteDir := filepath.Dir(suitePath)
+
+	for i := range suite.Cases {
+		c := &suite.Cases[i]
+		if c.FixturePath == "" {
+			return nil, fmt.Errorf("case %s missing fixture_path", c.ID)
 		}
 
-		caseDir := filepath.Join(fixturesDir, entry.Name())
-		metadataPath := filepath.Join(caseDir, "metadata.json")
-		b, err := os.ReadFile(metadataPath)
-		if err != nil {
-			continue // Skip directories without metadata.json
+		// Resolve physical directory containing files
+		absFixturePath := c.FixturePath
+		if !filepath.IsAbs(absFixturePath) {
+			absFixturePath = filepath.Join(suiteDir, absFixturePath)
 		}
 
-		var c EvalCase
-		if err := json.Unmarshal(b, &c); err != nil {
-			return nil, fmt.Errorf("failed to parse %s: %w", metadataPath, err)
+		// 1. Load Diff
+		diffName := c.DiffPath
+		if diffName == "" {
+			diffName = "input.diff"
 		}
-
-		// Fill in defaults and absolute paths
-		if c.ID == "" {
-			c.ID = entry.Name()
-		}
-		if c.DiffPath == "" {
-			c.DiffPath = "input.diff"
-		}
-
-		diffContent, err := os.ReadFile(filepath.Join(caseDir, c.DiffPath))
+		diffContent, err := os.ReadFile(filepath.Join(absFixturePath, diffName))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read diff for %s: %w", c.ID, err)
 		}
 		c.Diff = string(diffContent)
 
+		// 2. Resolve Base State
 		if c.BaseSource != "" {
-			c.BaseSource = filepath.Join(caseDir, c.BaseSource)
+			if !filepath.IsAbs(c.BaseSource) {
+				c.BaseSource = filepath.Join(absFixturePath, c.BaseSource)
+			}
 		} else {
-			// Check for default 'base.tar.gz' first, then 'base' directory
-			defaultTar := filepath.Join(caseDir, "base.tar.gz")
+			// Auto-detect base.tar.gz or base/
+			defaultTar := filepath.Join(absFixturePath, "base.tar.gz")
 			if _, err := os.Stat(defaultTar); err == nil {
 				c.BaseSource = defaultTar
 			} else {
-				defaultBase := filepath.Join(caseDir, "base")
+				defaultBase := filepath.Join(absFixturePath, "base")
 				if info, err := os.Stat(defaultBase); err == nil && info.IsDir() {
 					c.BaseSource = defaultBase
 				}
 			}
 		}
-
-		cases = append(cases, c)
 	}
 
-	return cases, nil
+	return &suite, nil
 }
 
 func extractChangedFiles(diff string) []string {

--- a/core/eval/runner.go
+++ b/core/eval/runner.go
@@ -30,18 +30,7 @@ func (r *Runner) RunCase(ctx context.Context, c EvalCase) (*CaseResult, error) {
 
 	// 2. Setup Agent (Subject)
 	registry := tools.NewRegistry()
-	tools.RegisterLocalTools(registry, nil) // No ignored lock files for now
-
-	// We need to change the working directory of the agent to the sandbox root.
-	// Since our tools use relative paths, we can just Chdir.
-	originalWD, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	if err := os.Chdir(sandbox.RootDir); err != nil {
-		return nil, fmt.Errorf("failed to change directory to sandbox: %w", err)
-	}
-	defer os.Chdir(originalWD)
+	tools.RegisterLocalTools(registry, sandbox.RootDir, nil) // No ignored lock files for now
 
 	agent := core.NewAgent(r.Subject, registry)
 

--- a/core/eval/runner.go
+++ b/core/eval/runner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/menny/cassandra/core"
 	"github.com/menny/cassandra/core/config"
@@ -22,14 +23,13 @@ type Runner struct {
 // RunCase executes a single evaluation case.
 func (r *Runner) RunCase(ctx context.Context, c EvalCase) (*CaseResult, error) {
 	// 1. Create Sandbox
-	sandbox, err := NewSandbox(ctx, c.BaseDir, c.Diff)
+	sandbox, err := NewSandbox(ctx, c.BaseSource, c.Diff)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sandbox: %w", err)
 	}
 	defer sandbox.Cleanup()
 
 	// 2. Setup Reviewer (Subject)
-	// We use the production factory to ensure parity.
 	reviewer, err := core.NewReviewer(ctx, r.SubjectConfig, sandbox.RootDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup reviewer: %w", err)
@@ -37,15 +37,10 @@ func (r *Runner) RunCase(ctx context.Context, c EvalCase) (*CaseResult, error) {
 	defer reviewer.Close()
 
 	// 3. Run Review (Subject)
-	// Build the request text
 	requestText := fmt.Sprintf("Review the following git diff for issues:\n\n%s", c.Diff)
+	changedFiles := extractChangedFiles(c.Diff)
 
-	// Since we are in a sandbox with a committed diff, we can let the reviewer
-	// determine changed files (or just pass the ones from the diff if we had them).
-	// For now, we'll pass an empty slice so it relies on the prompt building logic
-	// to find files in the sandbox if needed, or we could parse the diff.
-	// Most evaluations provide the diff directly in the request text anyway.
-	review, err := reviewer.Run(ctx, nil, requestText)
+	review, err := reviewer.Run(ctx, changedFiles, requestText)
 	if err != nil {
 		return &CaseResult{
 			CaseID:   c.ID,
@@ -130,24 +125,24 @@ func LoadCases(fixturesDir string) ([]EvalCase, error) {
 		if c.DiffPath == "" {
 			c.DiffPath = "input.diff"
 		}
-		
+
 		diffContent, err := os.ReadFile(filepath.Join(caseDir, c.DiffPath))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read diff for %s: %w", c.ID, err)
 		}
 		c.Diff = string(diffContent)
 
-		if c.BaseDir != "" {
-			c.BaseDir = filepath.Join(caseDir, c.BaseDir)
+		if c.BaseSource != "" {
+			c.BaseSource = filepath.Join(caseDir, c.BaseSource)
 		} else {
 			// Check for default 'base.tar.gz' first, then 'base' directory
 			defaultTar := filepath.Join(caseDir, "base.tar.gz")
 			if _, err := os.Stat(defaultTar); err == nil {
-				c.BaseDir = defaultTar
+				c.BaseSource = defaultTar
 			} else {
 				defaultBase := filepath.Join(caseDir, "base")
 				if info, err := os.Stat(defaultBase); err == nil && info.IsDir() {
-					c.BaseDir = defaultBase
+					c.BaseSource = defaultBase
 				}
 			}
 		}
@@ -156,4 +151,16 @@ func LoadCases(fixturesDir string) ([]EvalCase, error) {
 	}
 
 	return cases, nil
+}
+
+func extractChangedFiles(diff string) []string {
+	var files []string
+	lines := strings.Split(diff, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "+++ b/") {
+			file := strings.TrimPrefix(line, "+++ b/")
+			files = append(files, file)
+		}
+	}
+	return files
 }

--- a/core/eval/sandbox.go
+++ b/core/eval/sandbox.go
@@ -18,10 +18,10 @@ type Sandbox struct {
 }
 
 // NewSandbox initializes a new git-backed sandbox.
-// It copies or extracts files from baseSource (if non-empty), initializes git,
+// It copies or extracts files from baseState (if non-empty), initializes git,
 // commits the base state, applies the diff, and commits the final state.
-// baseSource can be a directory path or a .tar.gz file path.
-func NewSandbox(ctx context.Context, baseSource string, diff string) (*Sandbox, error) {
+// baseState can be a directory path or a .tar.gz file path.
+func NewSandbox(ctx context.Context, baseState string, diff string) (*Sandbox, error) {
 	tmp, err := os.MkdirTemp("", "cassandra-eval-sandbox-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp dir: %w", err)
@@ -29,26 +29,26 @@ func NewSandbox(ctx context.Context, baseSource string, diff string) (*Sandbox, 
 	s := &Sandbox{RootDir: tmp}
 
 	// 1. Setup base files
-	if baseSource != "" {
-		info, err := os.Stat(baseSource)
+	if baseState != "" {
+		info, err := os.Stat(baseState)
 		if err != nil {
 			s.Cleanup()
-			return nil, fmt.Errorf("failed to stat base source %q: %w", baseSource, err)
+			return nil, fmt.Errorf("failed to stat base state %q: %w", baseState, err)
 		}
 
 		if info.IsDir() {
-			if err := copyDir(baseSource, tmp); err != nil {
+			if err := copyDir(baseState, tmp); err != nil {
 				s.Cleanup()
 				return nil, fmt.Errorf("failed to copy base directory: %w", err)
 			}
-		} else if strings.HasSuffix(baseSource, ".tar.gz") {
-			if err := extractTarGz(baseSource, tmp); err != nil {
+		} else if strings.HasSuffix(baseState, ".tar.gz") {
+			if err := extractTarGz(baseState, tmp); err != nil {
 				s.Cleanup()
 				return nil, fmt.Errorf("failed to extract base tarball: %w", err)
 			}
 		} else {
 			s.Cleanup()
-			return nil, fmt.Errorf("unsupported base source type (must be dir or .tar.gz): %s", baseSource)
+			return nil, fmt.Errorf("unsupported base state type (must be dir or .tar.gz): %s", baseState)
 		}
 	}
 
@@ -90,7 +90,7 @@ func NewSandbox(ctx context.Context, baseSource string, diff string) (*Sandbox, 
 	// 4. Apply diff
 	if diff != "" {
 		diffFile := filepath.Join(tmp, "input.diff")
-		if err := os.WriteFile(diffFile, []byte(diff), 0644); err != nil {
+		if err := os.WriteFile(diffFile, []byte(diff), 0o644); err != nil {
 			s.Cleanup()
 			return nil, fmt.Errorf("failed to write diff file: %w", err)
 		}
@@ -172,11 +172,11 @@ func extractTarGz(gzipPath, dst string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0755); err != nil {
+			if err := os.MkdirAll(target, 0o755); err != nil {
 				return err
 			}
 		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return err
 			}
 			// Use O_TRUNC to ensure existing files are completely overwritten.

--- a/core/eval/sandbox.go
+++ b/core/eval/sandbox.go
@@ -1,0 +1,153 @@
+package eval
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// Sandbox provides a high-fidelity git environment for evaluating the agent.
+type Sandbox struct {
+	RootDir string
+}
+
+// NewSandbox initializes a new git-backed sandbox.
+// It copies files from baseSourceDir (if non-empty), initializes git,
+// commits the base state, applies the diff, and commits the final state.
+func NewSandbox(ctx context.Context, baseSourceDir string, diff string) (*Sandbox, error) {
+	tmp, err := os.MkdirTemp("", "cassandra-eval-sandbox-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	s := &Sandbox{RootDir: tmp}
+
+	// 1. Copy base files
+	if baseSourceDir != "" {
+		if err := copyDir(baseSourceDir, tmp); err != nil {
+			s.Cleanup()
+			return nil, fmt.Errorf("failed to copy base files: %w", err)
+		}
+	}
+
+	// 2. Git init
+	if err := s.runGit(ctx, "init"); err != nil {
+		s.Cleanup()
+		return nil, err
+	}
+	// Configure git identity for the sandbox
+	if err := s.runGit(ctx, "config", "user.email", "eval@cassandra.ai"); err != nil {
+		s.Cleanup()
+		return nil, err
+	}
+	if err := s.runGit(ctx, "config", "user.name", "Cassandra Eval"); err != nil {
+		s.Cleanup()
+		return nil, err
+	}
+
+	// 3. Commit base state
+	// We need to check if there are any files to add
+	files, _ := os.ReadDir(tmp)
+	if len(files) > 0 {
+		if err := s.runGit(ctx, "add", "."); err != nil {
+			s.Cleanup()
+			return nil, err
+		}
+		if err := s.runGit(ctx, "commit", "-m", "base state"); err != nil {
+			s.Cleanup()
+			return nil, err
+		}
+	} else {
+		// Even if empty, create an initial commit to avoid "no branch" errors
+		if err := s.runGit(ctx, "commit", "--allow-empty", "-m", "initial empty commit"); err != nil {
+			s.Cleanup()
+			return nil, err
+		}
+	}
+
+	// 4. Apply diff
+	if diff != "" {
+		diffFile := filepath.Join(tmp, "input.diff")
+		if err := os.WriteFile(diffFile, []byte(diff), 0644); err != nil {
+			s.Cleanup()
+			return nil, fmt.Errorf("failed to write diff file: %w", err)
+		}
+		// Use git apply for higher fidelity
+		if err := s.runGit(ctx, "apply", "input.diff"); err != nil {
+			s.Cleanup()
+			return nil, fmt.Errorf("failed to apply diff: %w", err)
+		}
+		if err := os.Remove(diffFile); err != nil {
+			s.Cleanup()
+			return nil, fmt.Errorf("failed to remove diff file: %w", err)
+		}
+
+		// 5. Commit diff state
+		if err := s.runGit(ctx, "add", "."); err != nil {
+			s.Cleanup()
+			return nil, err
+		}
+		if err := s.runGit(ctx, "commit", "-m", "applied diff"); err != nil {
+			s.Cleanup()
+			return nil, err
+		}
+	}
+
+	return s, nil
+}
+
+// Cleanup removes the sandbox directory.
+func (s *Sandbox) Cleanup() {
+	if s.RootDir != "" {
+		os.RemoveAll(s.RootDir)
+	}
+}
+
+func (s *Sandbox) runGit(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = s.RootDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git %v failed in %s: %w\nOutput: %s", args, s.RootDir, err, string(out))
+	}
+	return nil
+}
+
+func copyDir(src string, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	si, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(dst, si.Mode())
+}

--- a/core/eval/sandbox.go
+++ b/core/eval/sandbox.go
@@ -68,23 +68,15 @@ func NewSandbox(ctx context.Context, baseState string, diff string) (*Sandbox, e
 	}
 
 	// 3. Commit base state
-	// We need to check if there are any files to add
-	files, _ := os.ReadDir(tmp)
-	if len(files) > 0 {
-		if err := s.runGit(ctx, "add", "."); err != nil {
-			s.Cleanup()
-			return nil, err
-		}
-		if err := s.runGit(ctx, "commit", "-m", "base state"); err != nil {
-			s.Cleanup()
-			return nil, err
-		}
-	} else {
-		// Even if empty, create an initial commit to avoid "no branch" errors
-		if err := s.runGit(ctx, "commit", "--allow-empty", "-m", "initial empty commit"); err != nil {
-			s.Cleanup()
-			return nil, err
-		}
+	// Unconditionally add and commit with --allow-empty to avoid "nothing to commit"
+	// errors when there are no base files or only the .git directory exists.
+	if err := s.runGit(ctx, "add", "."); err != nil {
+		s.Cleanup()
+		return nil, err
+	}
+	if err := s.runGit(ctx, "commit", "--allow-empty", "-m", "base state"); err != nil {
+		s.Cleanup()
+		return nil, err
 	}
 
 	// 4. Apply diff
@@ -109,7 +101,8 @@ func NewSandbox(ctx context.Context, baseState string, diff string) (*Sandbox, e
 			s.Cleanup()
 			return nil, err
 		}
-		if err := s.runGit(ctx, "commit", "-m", "applied diff"); err != nil {
+		// Use --allow-empty in case the diff is functionally empty or ignored.
+		if err := s.runGit(ctx, "commit", "--allow-empty", "-m", "applied diff"); err != nil {
 			s.Cleanup()
 			return nil, err
 		}
@@ -188,7 +181,9 @@ func extractTarGz(gzipPath, dst string) error {
 				f.Close()
 				return err
 			}
-			f.Close()
+			if err := f.Close(); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/core/eval/sandbox.go
+++ b/core/eval/sandbox.go
@@ -166,7 +166,7 @@ func extractTarGz(gzipPath, dst string) error {
 
 		// Security: Prevent "Tar Slip" (directory traversal)
 		rel, err := filepath.Rel(dst, target)
-		if err != nil || strings.HasPrefix(rel, "..") {
+		if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
 			return fmt.Errorf("tar slip detected: %s", header.Name)
 		}
 

--- a/core/eval/sandbox.go
+++ b/core/eval/sandbox.go
@@ -3,7 +3,6 @@ package eval
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,7 +32,7 @@ func NewSandbox(ctx context.Context, baseSourceDir string, diff string) (*Sandbo
 	}
 
 	// 2. Git init
-	if err := s.runGit(ctx, "init"); err != nil {
+	if err := s.runGit(ctx, "init", "--initial-branch=main"); err != nil {
 		s.Cleanup()
 		return nil, err
 	}
@@ -115,39 +114,5 @@ func (s *Sandbox) runGit(ctx context.Context, args ...string) error {
 }
 
 func copyDir(src string, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(target, info.Mode())
-		}
-		return copyFile(path, target)
-	})
-}
-
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-	if _, err = io.Copy(out, in); err != nil {
-		return err
-	}
-	si, err := os.Stat(src)
-	if err != nil {
-		return err
-	}
-	return os.Chmod(dst, si.Mode())
+	return os.CopyFS(dst, os.DirFS(src))
 }

--- a/core/eval/sandbox.go
+++ b/core/eval/sandbox.go
@@ -1,11 +1,15 @@
 package eval
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 // Sandbox provides a high-fidelity git environment for evaluating the agent.
@@ -14,20 +18,37 @@ type Sandbox struct {
 }
 
 // NewSandbox initializes a new git-backed sandbox.
-// It copies files from baseSourceDir (if non-empty), initializes git,
+// It copies or extracts files from baseSource (if non-empty), initializes git,
 // commits the base state, applies the diff, and commits the final state.
-func NewSandbox(ctx context.Context, baseSourceDir string, diff string) (*Sandbox, error) {
+// baseSource can be a directory path or a .tar.gz file path.
+func NewSandbox(ctx context.Context, baseSource string, diff string) (*Sandbox, error) {
 	tmp, err := os.MkdirTemp("", "cassandra-eval-sandbox-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}
 	s := &Sandbox{RootDir: tmp}
 
-	// 1. Copy base files
-	if baseSourceDir != "" {
-		if err := copyDir(baseSourceDir, tmp); err != nil {
+	// 1. Setup base files
+	if baseSource != "" {
+		info, err := os.Stat(baseSource)
+		if err != nil {
 			s.Cleanup()
-			return nil, fmt.Errorf("failed to copy base files: %w", err)
+			return nil, fmt.Errorf("failed to stat base source %q: %w", baseSource, err)
+		}
+
+		if info.IsDir() {
+			if err := copyDir(baseSource, tmp); err != nil {
+				s.Cleanup()
+				return nil, fmt.Errorf("failed to copy base directory: %w", err)
+			}
+		} else if strings.HasSuffix(baseSource, ".tar.gz") {
+			if err := extractTarGz(baseSource, tmp); err != nil {
+				s.Cleanup()
+				return nil, fmt.Errorf("failed to extract base tarball: %w", err)
+			}
+		} else {
+			s.Cleanup()
+			return nil, fmt.Errorf("unsupported base source type (must be dir or .tar.gz): %s", baseSource)
 		}
 	}
 
@@ -115,4 +136,60 @@ func (s *Sandbox) runGit(ctx context.Context, args ...string) error {
 
 func copyDir(src string, dst string) error {
 	return os.CopyFS(dst, os.DirFS(src))
+}
+
+func extractTarGz(gzipPath, dst string) error {
+	f, err := os.Open(gzipPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(dst, header.Name)
+
+		// Security: Prevent "Tar Slip" (directory traversal)
+		rel, err := filepath.Rel(dst, target)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return fmt.Errorf("tar slip detected: %s", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			// Use O_TRUNC to ensure existing files are completely overwritten.
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return err
+			}
+			f.Close()
+		}
+	}
+	return nil
 }

--- a/core/eval/sandbox_test.go
+++ b/core/eval/sandbox_test.go
@@ -42,8 +42,8 @@ func TestSandbox(t *testing.T) {
 	}
 
 	// 5. Verify git status
-	cmd := s.runGit(ctx, "log", "--oneline")
-	if cmd != nil {
-		t.Errorf("git log failed: %v", cmd)
+	err = s.runGit(ctx, "log", "--oneline")
+	if err != nil {
+		t.Errorf("git log failed: %v", err)
 	}
 }

--- a/core/eval/sandbox_test.go
+++ b/core/eval/sandbox_test.go
@@ -1,0 +1,49 @@
+package eval
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSandbox(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Setup base directory
+	baseDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(baseDir, "hello.txt"), []byte("hello world\n"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Define diff
+	diff := `--- hello.txt
++++ hello.txt
+@@ -1 +1 @@
+-hello world
++hello cassandra
+`
+
+	// 3. Create sandbox
+	s, err := NewSandbox(ctx, baseDir, diff)
+	if err != nil {
+		t.Fatalf("NewSandbox failed: %v", err)
+	}
+	defer s.Cleanup()
+
+	// 4. Verify file content
+	content, err := os.ReadFile(filepath.Join(s.RootDir, "hello.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "hello cassandra\n" {
+		t.Errorf("expected 'hello cassandra\\n', got %q", string(content))
+	}
+
+	// 5. Verify git status
+	cmd := s.runGit(ctx, "log", "--oneline")
+	if cmd != nil {
+		t.Errorf("git log failed: %v", cmd)
+	}
+}

--- a/core/eval/sandbox_test.go
+++ b/core/eval/sandbox_test.go
@@ -1,9 +1,13 @@
 package eval
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -45,5 +49,111 @@ func TestSandbox(t *testing.T) {
 	err = s.runGit(ctx, "log", "--oneline")
 	if err != nil {
 		t.Errorf("git log failed: %v", err)
+	}
+}
+
+func TestExtractTarGz_TarSlip(t *testing.T) {
+	// 1. Setup a clean destination and a parent directory we want to protect
+	parentDir := t.TempDir()
+	dstDir := filepath.Join(parentDir, "sandbox")
+	if err := os.MkdirAll(dstDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Create a malicious tar.gz in memory
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	// This path attempts to escape dstDir and write into parentDir
+	maliciousPath := "../../evil.txt"
+	content := "unauthorized access"
+
+	hdr := &tar.Header{
+		Name: maliciousPath,
+		Mode: 0644,
+		Size: int64(len(content)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+
+	tw.Close()
+	gw.Close()
+
+	// 3. Write it to disk for the extractor to read
+	tarPath := filepath.Join(parentDir, "malicious.tar.gz")
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. Attempt extraction
+	err := extractTarGz(tarPath, dstDir)
+
+	// 5. Assert failure
+	if err == nil {
+		t.Error("Expected error for malicious tarball, but got nil")
+	}
+	if !strings.Contains(err.Error(), "tar slip detected") {
+		t.Errorf("Expected 'tar slip detected' error, got: %v", err)
+	}
+
+	// 6. Final safety check: Verify the file was NOT created outside the sandbox
+	evilFilePath := filepath.Join(parentDir, "evil.txt")
+	if _, err := os.Stat(evilFilePath); err == nil {
+		t.Errorf("CRITICAL SECURITY FAILURE: Malicious file was extracted to %s", evilFilePath)
+	}
+}
+
+func TestExtractTarGz_Truncation(t *testing.T) {
+	tmpDir := t.TempDir()
+	dstDir := filepath.Join(tmpDir, "dst")
+	os.MkdirAll(dstDir, 0755)
+
+	// 1. Create an existing file with long content
+	targetFile := filepath.Join(dstDir, "data.txt")
+	originalContent := "This is a very long piece of content that should be overwritten completely."
+	if err := os.WriteFile(targetFile, []byte(originalContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Create a tarball with the same filename but shorter content
+	shortContent := "Short."
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	hdr := &tar.Header{
+		Name: "data.txt",
+		Mode: 0644,
+		Size: int64(len(shortContent)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte(shortContent)); err != nil {
+		t.Fatal(err)
+	}
+	tw.Close()
+	gw.Close()
+
+	tarPath := filepath.Join(tmpDir, "update.tar.gz")
+	os.WriteFile(tarPath, buf.Bytes(), 0644)
+
+	// 3. Extract
+	if err := extractTarGz(tarPath, dstDir); err != nil {
+		t.Fatalf("Extraction failed: %v", err)
+	}
+
+	// 4. Verify content is exactly the short content (no trailing bytes from the long content)
+	got, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != shortContent {
+		t.Errorf("Expected content %q, got %q. Truncation failed.", shortContent, string(got))
 	}
 }

--- a/core/eval/sandbox_test.go
+++ b/core/eval/sandbox_test.go
@@ -111,7 +111,9 @@ func TestExtractTarGz_TarSlip(t *testing.T) {
 func TestExtractTarGz_Truncation(t *testing.T) {
 	tmpDir := t.TempDir()
 	dstDir := filepath.Join(tmpDir, "dst")
-	os.MkdirAll(dstDir, 0o755)
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	// 1. Create an existing file with long content
 	targetFile := filepath.Join(dstDir, "data.txt")
@@ -141,7 +143,9 @@ func TestExtractTarGz_Truncation(t *testing.T) {
 	gw.Close()
 
 	tarPath := filepath.Join(tmpDir, "update.tar.gz")
-	os.WriteFile(tarPath, buf.Bytes(), 0o644)
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// 3. Extract
 	if err := extractTarGz(tarPath, dstDir); err != nil {

--- a/core/eval/sandbox_test.go
+++ b/core/eval/sandbox_test.go
@@ -16,7 +16,7 @@ func TestSandbox(t *testing.T) {
 
 	// 1. Setup base directory
 	baseDir := t.TempDir()
-	err := os.WriteFile(filepath.Join(baseDir, "hello.txt"), []byte("hello world\n"), 0644)
+	err := os.WriteFile(filepath.Join(baseDir, "hello.txt"), []byte("hello world\n"), 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestExtractTarGz_TarSlip(t *testing.T) {
 	// 1. Setup a clean destination and a parent directory we want to protect
 	parentDir := t.TempDir()
 	dstDir := filepath.Join(parentDir, "sandbox")
-	if err := os.MkdirAll(dstDir, 0755); err != nil {
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -71,7 +71,7 @@ func TestExtractTarGz_TarSlip(t *testing.T) {
 
 	hdr := &tar.Header{
 		Name: maliciousPath,
-		Mode: 0644,
+		Mode: 0o644,
 		Size: int64(len(content)),
 	}
 	if err := tw.WriteHeader(hdr); err != nil {
@@ -86,7 +86,7 @@ func TestExtractTarGz_TarSlip(t *testing.T) {
 
 	// 3. Write it to disk for the extractor to read
 	tarPath := filepath.Join(parentDir, "malicious.tar.gz")
-	if err := os.WriteFile(tarPath, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -111,12 +111,12 @@ func TestExtractTarGz_TarSlip(t *testing.T) {
 func TestExtractTarGz_Truncation(t *testing.T) {
 	tmpDir := t.TempDir()
 	dstDir := filepath.Join(tmpDir, "dst")
-	os.MkdirAll(dstDir, 0755)
+	os.MkdirAll(dstDir, 0o755)
 
 	// 1. Create an existing file with long content
 	targetFile := filepath.Join(dstDir, "data.txt")
 	originalContent := "This is a very long piece of content that should be overwritten completely."
-	if err := os.WriteFile(targetFile, []byte(originalContent), 0644); err != nil {
+	if err := os.WriteFile(targetFile, []byte(originalContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -128,7 +128,7 @@ func TestExtractTarGz_Truncation(t *testing.T) {
 
 	hdr := &tar.Header{
 		Name: "data.txt",
-		Mode: 0644,
+		Mode: 0o644,
 		Size: int64(len(shortContent)),
 	}
 	if err := tw.WriteHeader(hdr); err != nil {
@@ -141,7 +141,7 @@ func TestExtractTarGz_Truncation(t *testing.T) {
 	gw.Close()
 
 	tarPath := filepath.Join(tmpDir, "update.tar.gz")
-	os.WriteFile(tarPath, buf.Bytes(), 0644)
+	os.WriteFile(tarPath, buf.Bytes(), 0o644)
 
 	// 3. Extract
 	if err := extractTarGz(tarPath, dstDir); err != nil {

--- a/core/eval/testdata/cases/interface-contract/base/repository.go
+++ b/core/eval/testdata/cases/interface-contract/base/repository.go
@@ -1,0 +1,16 @@
+package user
+
+import "context"
+
+type User struct {
+	ID   string
+	Name string
+}
+
+// SaveUser persists a user. It now requires a non-nil User pointer.
+func SaveUser(ctx context.Context, u *User) error {
+	if u == nil {
+		return context.DeadlineExceeded // Just for simulation
+	}
+	return nil
+}

--- a/core/eval/testdata/cases/interface-contract/input.diff
+++ b/core/eval/testdata/cases/interface-contract/input.diff
@@ -1,0 +1,18 @@
+diff --git a/service.go b/service.go
+new file mode 100644
+index 0000000..e69de29
+--- /dev/null
++++ b/service.go
+@@ -0,0 +1,11 @@
++package user
++
++import "context"
++
++func CreateAndSave(ctx context.Context, name string) error {
++	var u *User
++	if name != "" {
++		u = &User{Name: name}
++	}
++	// BUG: SaveUser requires a non-nil User, but 'u' can be nil here.
++	return SaveUser(ctx, u)
++}

--- a/core/eval/testdata/cases/library-godoc-verification/base/lib/db/db.go
+++ b/core/eval/testdata/cases/library-godoc-verification/base/lib/db/db.go
@@ -1,0 +1,11 @@
+package db
+
+import "fmt"
+
+type DB struct{}
+
+// Execute runs a query. Note: There is NO ExecuteAsync method.
+func (d *DB) Execute(query string) error {
+	fmt.Println("Executing:", query)
+	return nil
+}

--- a/core/eval/testdata/cases/library-godoc-verification/input.diff
+++ b/core/eval/testdata/cases/library-godoc-verification/input.diff
@@ -1,0 +1,15 @@
+diff --git a/app.go b/app.go
+new file mode 100644
+index 0000000..e69de29
+--- /dev/null
++++ b/app.go
+@@ -0,0 +1,9 @@
++package main
++
++import "lib/db"
++
++func RunQuery(conn *db.DB) error {
++	// BUG: ExecuteAsync does not exist in the 'db' package.
++	// The agent should verify this using tools.
++	return conn.ExecuteAsync("SELECT 1")
++}

--- a/core/eval/testdata/cases/local-agents-convention/base/internal/db/AGENTS.md
+++ b/core/eval/testdata/cases/local-agents-convention/base/internal/db/AGENTS.md
@@ -1,0 +1,2 @@
+# Database Convention
+All database queries MUST use the `SafeQuery` wrapper, never the raw `sql.DB` directly. This ensures consistent error logging and metric collection.

--- a/core/eval/testdata/cases/local-agents-convention/base/internal/db/db.go
+++ b/core/eval/testdata/cases/local-agents-convention/base/internal/db/db.go
@@ -1,0 +1,12 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// SafeQuery is the required wrapper for all DB queries.
+func SafeQuery(db *sql.DB, query string, args ...any) (*sql.Rows, error) {
+	fmt.Printf("Executing safe query: %s\n", query)
+	return db.Query(query, args...)
+}

--- a/core/eval/testdata/cases/local-agents-convention/input.diff
+++ b/core/eval/testdata/cases/local-agents-convention/input.diff
@@ -1,0 +1,21 @@
+diff --git a/internal/db/app.go b/internal/db/app.go
+new file mode 100644
+index 0000000..e69de29
+--- /dev/null
++++ b/internal/db/app.go
+@@ -0,0 +1,11 @@
++package db
++
++import (
++	"database/sql"
++)
++
++func GetUserCount(db *sql.DB) (int, error) {
++	// BUG: Violates AGENTS.md in this folder. Should use SafeQuery.
++	rows, err := db.Query("SELECT COUNT(*) FROM users")
++	if err != nil {
++		return 0, err
++	}
++	defer rows.Close()
++	return 0, nil
++}

--- a/core/eval/testdata/cases/security-path-traversal/base/server.go
+++ b/core/eval/testdata/cases/security-path-traversal/base/server.go
@@ -1,0 +1,10 @@
+package main
+
+import "net/http"
+
+func main() {
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("OK"))
+	})
+	http.ListenAndServe(":8080", nil)
+}

--- a/core/eval/testdata/cases/security-path-traversal/input.diff
+++ b/core/eval/testdata/cases/security-path-traversal/input.diff
@@ -1,0 +1,26 @@
+--- a/server.go
++++ b/server.go
+@@ -1,6 +1,8 @@
+ package main
+ 
+ import (
++	"os"
++	"path/filepath"
+ 	"net/http"
+ )
+ 
+@@ -8,5 +10,13 @@
+ 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+ 		w.Write([]byte("OK"))
+ 	})
++
++	http.HandleFunc("/file", func(w http.ResponseWriter, r *http.Request) {
++		name := r.URL.Query().Get("name")
++		// VULNERABILITY: Path traversal. Missing filepath.Clean or boundary check.
++		path := filepath.Join("/var/www/static", name)
++		data, _ := os.ReadFile(path)
++		w.Write(data)
++	})
++
+ 	http.ListenAndServe(":8080", nil)
+ }

--- a/core/eval/testdata/cases/simple-bug/base/BUILD.bazel
+++ b/core/eval/testdata/cases/simple-bug/base/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "base",
+    srcs = ["math.go"],
+    importpath = "github.com/menny/cassandra/core/eval/testdata/cases/simple-bug/base",
+    visibility = ["//visibility:public"],
+)

--- a/core/eval/testdata/cases/simple-bug/base/math.go
+++ b/core/eval/testdata/cases/simple-bug/base/math.go
@@ -1,0 +1,5 @@
+package math
+
+func Divide(a, b int) int {
+	return a + b
+}

--- a/core/eval/testdata/cases/simple-bug/input.diff
+++ b/core/eval/testdata/cases/simple-bug/input.diff
@@ -1,0 +1,9 @@
+--- math.go
++++ math.go
+@@ -1,5 +1,5 @@
+ package math
+ 
+ func Divide(a, b int) int {
+-	return a + b
++	return a / b
+ }

--- a/core/eval/testdata/cases/simple-bug/metadata.json
+++ b/core/eval/testdata/cases/simple-bug/metadata.json
@@ -1,5 +1,0 @@
-{
-  "name": "Simple Bug Fix",
-  "description": "Tests if the agent can find a simple logic bug in a Go function.",
-  "rubric": "The agent should identify that the `Divide` function does not check for division by zero."
-}

--- a/core/eval/testdata/cases/simple-bug/metadata.json
+++ b/core/eval/testdata/cases/simple-bug/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "Simple Bug Fix",
+  "description": "Tests if the agent can find a simple logic bug in a Go function.",
+  "rubric": "The agent should identify that the `Divide` function does not check for division by zero."
+}

--- a/core/eval/testdata/evaluations.json
+++ b/core/eval/testdata/evaluations.json
@@ -1,0 +1,41 @@
+{
+  "name": "Cassandra Core Suite",
+  "description": "Comprehensive evaluation cases for reasoning, context, and security.",
+  "cases": [
+    {
+      "id": "simple-bug",
+      "name": "Simple Bug Fix",
+      "description": "Tests if the agent can find a simple logic bug in a Go function.",
+      "rubric": "The agent should identify that the `Divide` function does not check for division by zero.",
+      "fixture_path": "cases/simple-bug"
+    },
+    {
+      "id": "interface-contract",
+      "name": "Interface Contract Violation",
+      "description": "Tests if the agent gathers cross-file context to identify signature/contract mismatches.",
+      "rubric": "The agent MUST identify that `CreateAndSave` in `service.go` passes a potentially nil user to `SaveUser`, which explicitly requires a non-nil pointer in `repository.go`.",
+      "fixture_path": "cases/interface-contract"
+    },
+    {
+      "id": "security-path-traversal",
+      "name": "Security: Path Traversal",
+      "description": "Tests if the agent identifies logical security vulnerabilities in file-serving code.",
+      "rubric": "The agent MUST identify the path traversal vulnerability in the `/file` handler and recommend using `filepath.Clean` or a boundary check.",
+      "fixture_path": "cases/security-path-traversal"
+    },
+    {
+      "id": "local-agents-convention",
+      "name": "Local Agents Convention",
+      "description": "Tests if the agent discovers and adheres to local directory-specific instructions (AGENTS.md).",
+      "rubric": "The agent MUST identify that the new code uses raw `db.Query` instead of the mandated `SafeQuery` wrapper defined in `internal/db/AGENTS.md`.",
+      "fixture_path": "cases/local-agents-convention"
+    },
+    {
+      "id": "library-godoc-verification",
+      "name": "Library API Verification",
+      "description": "Tests if the agent verifies library signatures using tools (or reading source) instead of assuming methods exist.",
+      "rubric": "The agent MUST identify that `ExecuteAsync` is not a valid method on the `db.DB` type by inspecting the `lib/db/db.go` file or using godoc.",
+      "fixture_path": "cases/library-godoc-verification"
+    }
+  ]
+}

--- a/core/eval/types.go
+++ b/core/eval/types.go
@@ -1,5 +1,9 @@
 package eval
 
+import (
+	"github.com/menny/cassandra/core"
+)
+
 // EvalCase represents a single evaluation scenario.
 type EvalCase struct {
 	ID          string `json:"id"`
@@ -28,11 +32,11 @@ type EvaluationResult struct {
 
 // CaseResult captures the outcome of running a single EvalCase.
 type CaseResult struct {
-	CaseID   string           `json:"case_id"`
-	CaseName string           `json:"case_name"`
-	Subject  EvaluationResult `json:"subject_result"`
-	Metrics  any              `json:"metrics"` // Subject metrics (core.SessionMetrics)
-	Error    string           `json:"error,omitempty"`
+	CaseID   string              `json:"case_id"`
+	CaseName string              `json:"case_name"`
+	Subject  EvaluationResult    `json:"subject_result"`
+	Metrics  core.SessionMetrics `json:"metrics"` // Subject metrics
+	Error    string              `json:"error,omitempty"`
 }
 
 // EvaluationResultSchema is the JSON Schema for the Judge's output.

--- a/core/eval/types.go
+++ b/core/eval/types.go
@@ -4,6 +4,13 @@ import (
 	"github.com/menny/cassandra/core"
 )
 
+// TestSuite represents a collection of evaluation cases.
+type TestSuite struct {
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Cases       []EvalCase `json:"cases"`
+}
+
 // EvalCase represents a single evaluation scenario.
 type EvalCase struct {
 	ID          string `json:"id"`
@@ -11,14 +18,19 @@ type EvalCase struct {
 	Description string `json:"description"`
 	// Rubric is the specific criteria the Judge should use to score the review.
 	Rubric string `json:"rubric"`
-	// BaseSource is the path to the directory or .tar.gz containing the "before" state.
-	// This is relative to the fixture directory.
-	BaseSource string `json:"base_source"`
-	// DiffPath is the path to the diff file (input.diff).
-	// This is relative to the fixture directory.
-	DiffPath string `json:"diff_path"`
 
-	// Loaded data
+	// FixturePath is the relative path to the directory containing input.diff and base state.
+	// This is resolved relative to the suite manifest file.
+	FixturePath string `json:"fixture_path"`
+
+	// BaseSource optionally overrides the default 'base.tar.gz' or 'base/' directory
+	// resolution inside FixturePath.
+	BaseSource string `json:"base_source,omitempty"`
+
+	// DiffPath optionally overrides the default 'input.diff' inside FixturePath.
+	DiffPath string `json:"diff_path,omitempty"`
+
+	// Loaded data (not in manifest)
 	Diff string `json:"-"`
 }
 
@@ -26,7 +38,7 @@ type EvalCase struct {
 type EvaluationResult struct {
 	Score     int      `json:"score"`      // 1-5 Scale
 	Rationale string   `json:"rationale"`  // Detailed explanation of the score
-	Findings  []string `json:"findings"`   // Specific observations (e.g., "Missed a bug in X", "Great catch on Y")
+	Findings  []string `json:"findings"`   // Specific observations
 	MetRubric bool     `json:"met_rubric"` // Whether the review satisfied the core rubric
 }
 

--- a/core/eval/types.go
+++ b/core/eval/types.go
@@ -1,0 +1,65 @@
+package eval
+
+// EvalCase represents a single evaluation scenario.
+type EvalCase struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// Rubric is the specific criteria the Judge should use to score the review.
+	Rubric string `json:"rubric"`
+	// BaseDir is the path to the directory containing the "before" state.
+	// This is relative to the fixture directory.
+	BaseDir string `json:"base_dir"`
+	// DiffPath is the path to the diff file (input.diff).
+	// This is relative to the fixture directory.
+	DiffPath string `json:"diff_path"`
+
+	// Loaded data
+	Diff string `json:"-"`
+}
+
+// EvaluationResult is the structured output from the Judge.
+type EvaluationResult struct {
+	Score     int      `json:"score"`      // 1-5 Scale
+	Rationale string   `json:"rationale"`  // Detailed explanation of the score
+	Findings  []string `json:"findings"`   // Specific observations (e.g., "Missed a bug in X", "Great catch on Y")
+	MetRubric bool     `json:"met_rubric"` // Whether the review satisfied the core rubric
+}
+
+// CaseResult captures the outcome of running a single EvalCase.
+type CaseResult struct {
+	CaseID   string           `json:"case_id"`
+	CaseName string           `json:"case_name"`
+	Subject  EvaluationResult `json:"subject_result"`
+	Metrics  any              `json:"metrics"` // Subject metrics (core.SessionMetrics)
+	Error    string           `json:"error,omitempty"`
+}
+
+// EvaluationResultSchema is the JSON Schema for the Judge's output.
+var EvaluationResultSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"score": map[string]any{
+			"type":        "integer",
+			"description": "A score from 1 to 5, where 5 is an excellent, accurate, and helpful review, and 1 is a poor or misleading review.",
+			"minimum":     1,
+			"maximum":     5,
+		},
+		"rationale": map[string]any{
+			"type":        "string",
+			"description": "A detailed explanation of why this score was given, referencing the rubric and the diff.",
+		},
+		"findings": map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"type": "string",
+			},
+			"description": "Specific strengths or weaknesses identified in the review.",
+		},
+		"met_rubric": map[string]any{
+			"type":        "boolean",
+			"description": "Whether the review successfully addressed the primary requirements of the rubric.",
+		},
+	},
+	"required": []string{"score", "rationale", "findings", "met_rubric"},
+}

--- a/core/eval/types.go
+++ b/core/eval/types.go
@@ -11,9 +11,9 @@ type EvalCase struct {
 	Description string `json:"description"`
 	// Rubric is the specific criteria the Judge should use to score the review.
 	Rubric string `json:"rubric"`
-	// BaseDir is the path to the directory containing the "before" state.
+	// BaseSource is the path to the directory or .tar.gz containing the "before" state.
 	// This is relative to the fixture directory.
-	BaseDir string `json:"base_dir"`
+	BaseSource string `json:"base_source"`
 	// DiffPath is the path to the diff file (input.diff).
 	// This is relative to the fixture directory.
 	DiffPath string `json:"diff_path"`

--- a/core/prompts/BUILD.bazel
+++ b/core/prompts/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "library/palantir.md",
         "library/security-first.md",
         "reviewer_prompt.md",
+        "library/eval_judge.md",
     ],
     importpath = "github.com/menny/cassandra/core/prompts",
     visibility = ["//visibility:public"],

--- a/core/prompts/library/eval_judge.md
+++ b/core/prompts/library/eval_judge.md
@@ -1,0 +1,23 @@
+# Persona
+You are a Senior Software Engineer and Expert Code Reviewer. Your goal is to evaluate the quality of a code review produced by an AI agent.
+
+# Task
+You will be provided with:
+1. A **RUBRIC**: Specific criteria for what the review should have identified.
+2. A **DIFF**: The code changes that were reviewed.
+3. A **REVIEW**: The actual review produced by the AI agent.
+
+Evaluate the **REVIEW** against the **RUBRIC** and the **DIFF**.
+
+# Evaluation Criteria
+- **Accuracy**: Did the review correctly identify real issues? Did it produce false positives?
+- **Completeness**: Did it find all the issues mentioned in the rubric?
+- **Constructiveness**: Is the feedback helpful and professional?
+- **Depth**: Did it use tools effectively to understand the context (if the review mentions tool use)?
+
+# Scoring (1-5)
+- **5 (Excellent)**: Caught all major issues in the rubric with no false positives. High-quality explanations.
+- **4 (Good)**: Caught most issues. Clear and helpful.
+- **3 (Fair)**: Caught some issues but missed others, or had minor false positives.
+- **2 (Poor)**: Missed major issues or had significant false positives.
+- **1 (Unacceptable)**: Misleading, entirely incorrect, or ignored the rubric.

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -1,0 +1,118 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/menny/cassandra/core/config"
+	"github.com/menny/cassandra/core/prompts"
+	"github.com/menny/cassandra/llm"
+	"github.com/menny/cassandra/llm/factory"
+	"github.com/menny/cassandra/tools"
+	"github.com/menny/cassandra/tools/mcp"
+)
+
+// Reviewer encapsulates an initialized Agent and its environment.
+type Reviewer struct {
+	Agent                    *Agent
+	Config                   *config.Config
+	RootDir                  string
+	StablePrompt             string
+	Guidelines               string
+	SupplementalGuidelines   []string
+	ApprovalEvaluationPrompt string
+	mcpManager               *mcp.Manager
+}
+
+// NewReviewer instantiates a Reviewer based on the provided configuration.
+// targetDir is the directory where local tools (like grep) will operate.
+func NewReviewer(ctx context.Context, cfg *config.Config, targetDir string) (*Reviewer, error) {
+	client, err := factory.New(ctx, cfg.Provider, cfg.Model, cfg.ProviderAPIKey, cfg.ProviderURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize LLM: %w", err)
+	}
+
+	registry := tools.NewRegistry()
+	tools.RegisterLocalTools(registry, targetDir, cfg.IgnoredLockFiles)
+
+	var mcpManager *mcp.Manager
+	if cfg.MCPConfigFile != "" {
+		mcpData, err := os.ReadFile(cfg.MCPConfigFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read MCP config file %s: %w", cfg.MCPConfigFile, err)
+		}
+		var mcpConfig mcp.Config
+		if err := json.Unmarshal(mcpData, &mcpConfig); err != nil {
+			return nil, fmt.Errorf("failed to parse MCP config file %s: %w", cfg.MCPConfigFile, err)
+		}
+		mcpConfig.ExpandEnv()
+
+		mcpManager = mcp.NewManager()
+		if err := mcpManager.RegisterServers(ctx, mcpConfig, func(def llm.ToolDef, handler func(context.Context, llm.ToolCall) (string, error)) {
+			registry.RegisterTool(def, handler)
+		}); err != nil {
+			mcpManager.Close()
+			return nil, fmt.Errorf("failed to register MCP servers: %w", err)
+		}
+	}
+
+	mainGuidelines, err := config.ResolveGuidelinesContent(cfg.MainGuidelines)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve main guidelines: %w", err)
+	}
+
+	var supplementalGuidelines []string
+	for _, sg := range cfg.SupplementalGuidelines {
+		content, err := config.ResolveGuidelinesContent(sg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve supplemental guideline %q: %w", sg, err)
+		}
+		supplementalGuidelines = append(supplementalGuidelines, content)
+	}
+
+	var approvalEvaluationPrompt string
+	if cfg.ApprovalEvaluationPromptFile != "" {
+		content, err := os.ReadFile(cfg.ApprovalEvaluationPromptFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read approval evaluation prompt file: %w", err)
+		}
+		approvalEvaluationPrompt = string(content)
+	}
+
+	stable, _, _, err := prompts.BuildSystemPrompt(targetDir, nil, mainGuidelines, supplementalGuidelines, approvalEvaluationPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build stable system prompt: %w", err)
+	}
+
+	return &Reviewer{
+		Agent:                    NewAgent(client, registry),
+		Config:                   cfg,
+		RootDir:                  targetDir,
+		StablePrompt:             stable,
+		Guidelines:               mainGuidelines,
+		SupplementalGuidelines:   supplementalGuidelines,
+		ApprovalEvaluationPrompt: approvalEvaluationPrompt,
+		mcpManager:               mcpManager,
+	}, nil
+}
+
+// Close releases resources (like MCP server connections).
+func (r *Reviewer) Close() error {
+	if r.mcpManager != nil {
+		return r.mcpManager.Close()
+	}
+	return nil
+}
+
+// Run executes a review for the given changes.
+func (r *Reviewer) Run(ctx context.Context, changedFiles []string, requestText string) (string, error) {
+	_, dynamic, _, err := prompts.BuildSystemPrompt(r.RootDir, changedFiles, r.Guidelines, r.SupplementalGuidelines, r.ApprovalEvaluationPrompt)
+	if err != nil {
+		return "", fmt.Errorf("failed to build dynamic system prompt: %w", err)
+	}
+
+	maxIterations := CalculateMaxIterations(len(changedFiles))
+	return r.Agent.RunReview(ctx, r.StablePrompt, dynamic, requestText, maxIterations, r.Config.MaxTokens)
+}

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -28,7 +28,7 @@ type Reviewer struct {
 
 // NewReviewer instantiates a Reviewer based on the provided configuration.
 // targetDir is the directory where local tools (like grep) will operate.
-func NewReviewer(ctx context.Context, cfg *config.Config, targetDir string) (*Reviewer, error) {
+func NewReviewer(ctx context.Context, cfg *config.Config, targetDir string) (r *Reviewer, err error) {
 	client, err := factory.New(ctx, cfg.Provider, cfg.Model, cfg.ProviderAPIKey, cfg.ProviderURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize LLM: %w", err)
@@ -38,6 +38,13 @@ func NewReviewer(ctx context.Context, cfg *config.Config, targetDir string) (*Re
 	tools.RegisterLocalTools(registry, targetDir, cfg.IgnoredLockFiles)
 
 	var mcpManager *mcp.Manager
+	// Ensure we close the MCP manager if we encounter an error later in this function.
+	defer func() {
+		if err != nil && mcpManager != nil {
+			_ = mcpManager.Close()
+		}
+	}()
+
 	if cfg.MCPConfigFile != "" {
 		mcpData, err := os.ReadFile(cfg.MCPConfigFile)
 		if err != nil {
@@ -53,7 +60,6 @@ func NewReviewer(ctx context.Context, cfg *config.Config, targetDir string) (*Re
 		if err := mcpManager.RegisterServers(ctx, mcpConfig, func(def llm.ToolDef, handler func(context.Context, llm.ToolCall) (string, error)) {
 			registry.RegisterTool(def, handler)
 		}); err != nil {
-			mcpManager.Close()
 			return nil, fmt.Errorf("failed to register MCP servers: %w", err)
 		}
 	}

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -13,7 +13,7 @@ import (
 	"github.com/menny/cassandra/llm"
 )
 
-func registerLocalReadFile(r *Registry) {
+func registerLocalReadFile(r *Registry, root string) {
 	def := llm.ToolDef{
 		Name:        "read_file",
 		Description: "Read the contents of a local file. For large files, use line_start/line_end or tail_lines to save tokens.",
@@ -52,7 +52,19 @@ func registerLocalReadFile(r *Registry) {
 			return "", err
 		}
 
-		b, err := os.ReadFile(args.FilePath)
+		fullPath := args.FilePath
+		if root != "" {
+			if !filepath.IsAbs(fullPath) {
+				fullPath = filepath.Join(root, fullPath)
+			}
+			// Security: Ensure the path is within the root directory.
+			rel, err := filepath.Rel(root, fullPath)
+			if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+				return "", fmt.Errorf("read_file failed: path %q is outside the workspace root", args.FilePath)
+			}
+		}
+
+		b, err := os.ReadFile(fullPath)
 		if err != nil {
 			return "", fmt.Errorf("read_file failed: %w", err)
 		}
@@ -105,7 +117,7 @@ func registerLocalReadFile(r *Registry) {
 	})
 }
 
-func registerLocalGlobFiles(r *Registry) {
+func registerLocalGlobFiles(r *Registry, root string) {
 	def := llm.ToolDef{
 		Name:        "glob_files",
 		Description: "Search for files within a directory matching an exact substring or simple glob suffix.",
@@ -138,6 +150,16 @@ func registerLocalGlobFiles(r *Registry) {
 		if dir == "" {
 			dir = "."
 		}
+		if root != "" {
+			if !filepath.IsAbs(dir) {
+				dir = filepath.Join(root, dir)
+			}
+			// Security: Ensure the path is within the root directory.
+			rel, err := filepath.Rel(root, dir)
+			if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+				return "", fmt.Errorf("glob_files failed: path %q is outside the workspace root", args.Directory)
+			}
+		}
 
 		var matches []string
 		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
@@ -147,7 +169,13 @@ func registerLocalGlobFiles(r *Registry) {
 			if !d.IsDir() {
 				// Simple substring match allows catching things like ".go" or "BUILD"
 				if strings.Contains(filepath.Base(path), args.Query) || strings.Contains(path, args.Query) {
-					matches = append(matches, path)
+					relPath := path
+					if root != "" {
+						if rel, err := filepath.Rel(root, path); err == nil {
+							relPath = rel
+						}
+					}
+					matches = append(matches, relPath)
 				}
 			}
 			return nil
@@ -163,7 +191,7 @@ func registerLocalGlobFiles(r *Registry) {
 	})
 }
 
-func registerLocalGrepFiles(r *Registry, ignoredLockFiles []string) {
+func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string) {
 	def := llm.ToolDef{
 		Name:        "grep_files",
 		Description: "Search for a pattern in the repository using git grep. This includes unstaged changes.",
@@ -221,7 +249,7 @@ func registerLocalGrepFiles(r *Registry, ignoredLockFiles []string) {
 		// Note: git grep already searches the working tree (unstaged changes) by default.
 		// We've also added --untracked to include newly created files.
 
-		out, err := runGit(ctx, "", cmdArgs...)
+		out, err := runGit(ctx, root, cmdArgs...)
 		if err != nil {
 			// git grep returns exit code 1 if no matches are found.
 			var exitErr *exec.ExitError

--- a/tools/local_tools_test.go
+++ b/tools/local_tools_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestLocalReadFile(t *testing.T) {
 	r := NewRegistry()
-	registerLocalReadFile(r)
+	registerLocalReadFile(r, "")
 
 	// Create a temp file with multiple lines
 	tmpDir := t.TempDir()
@@ -130,10 +130,10 @@ func TestLocalReadFile(t *testing.T) {
 }
 
 func TestLocalGlobFiles(t *testing.T) {
-	r := NewRegistry()
-	registerLocalGlobFiles(r)
-
 	tmpDir := t.TempDir()
+	r := NewRegistry()
+	registerLocalGlobFiles(r, tmpDir)
+
 	err := os.WriteFile(filepath.Join(tmpDir, "file1.go"), []byte(""), 0o644)
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +143,7 @@ func TestLocalGlobFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	args, _ := json.Marshal(map[string]any{"directory": tmpDir, "query": ".go"})
+	args, _ := json.Marshal(map[string]any{"directory": ".", "query": ".go"})
 	result, err := r.HandleCall(context.Background(), llm.ToolCall{
 		Name:      "glob_files",
 		Arguments: string(args),
@@ -162,7 +162,7 @@ func TestLocalGlobFiles(t *testing.T) {
 
 func TestLocalReadFile_Errors(t *testing.T) {
 	r := NewRegistry()
-	registerLocalReadFile(r)
+	registerLocalReadFile(r, "")
 
 	t.Run("missing file", func(t *testing.T) {
 		_, err := r.HandleCall(context.Background(), llm.ToolCall{
@@ -187,7 +187,7 @@ func TestLocalReadFile_Errors(t *testing.T) {
 
 func TestLocalGlobFiles_Errors(t *testing.T) {
 	r := NewRegistry()
-	registerLocalGlobFiles(r)
+	registerLocalGlobFiles(r, "")
 
 	t.Run("invalid directory", func(t *testing.T) {
 		// filepath.WalkDir doesn't necessarily error if the root doesn't exist depending on OS,
@@ -203,10 +203,10 @@ func TestLocalGlobFiles_Errors(t *testing.T) {
 }
 
 func TestLocalGrepFiles(t *testing.T) {
-	r := NewRegistry()
-	registerLocalGrepFiles(r, DefaultLockFiles)
-
 	tmpDir := t.TempDir()
+	r := NewRegistry()
+	registerLocalGrepFiles(r, tmpDir, DefaultLockFiles)
+
 	setupGitRepo(t, tmpDir)
 
 	// Create a file with some content
@@ -216,9 +216,6 @@ func TestLocalGrepFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	runGitCmd(t, tmpDir, "add", "grep_test.txt")
-
-	// We need to change the working directory for git grep to work in the temp repo
-	t.Chdir(tmpDir)
 
 	t.Run("basic grep", func(t *testing.T) {
 		args, _ := json.Marshal(map[string]any{"query": "Cassandra"})

--- a/tools/mcp/client.go
+++ b/tools/mcp/client.go
@@ -85,7 +85,9 @@ func (m *Manager) registerServer(ctx context.Context, serverName string, cfg Ser
 		// main application context is canceled.
 		cmd := exec.CommandContext(ctx, cfg.Command, cfg.Args...)
 		if cfg.Env != nil {
-			cmd.Env = os.Environ()
+			// Security: If Env is provided, ONLY use those variables.
+			// Do NOT inherit from os.Environ() to prevent secret leakage.
+			cmd.Env = make([]string, 0, len(cfg.Env))
 			for k, v := range cfg.Env {
 				cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 			}

--- a/tools/mcp/client.go
+++ b/tools/mcp/client.go
@@ -84,14 +84,15 @@ func (m *Manager) registerServer(ctx context.Context, serverName string, cfg Ser
 		// Use CommandContext to ensure that the subprocess is reaped if the
 		// main application context is canceled.
 		cmd := exec.CommandContext(ctx, cfg.Command, cfg.Args...)
-		if cfg.Env != nil {
-			// Security: If Env is provided, ONLY use those variables.
-			// Do NOT inherit from os.Environ() to prevent secret leakage.
-			cmd.Env = make([]string, 0, len(cfg.Env))
-			for k, v := range cfg.Env {
-				cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
-			}
+
+		// Security: Unconditionally initialize Env to an empty slice to prevent
+		// silent inheritance of the host's full process environment.
+		// If Env is provided, ONLY those variables will be used.
+		cmd.Env = make([]string, 0, len(cfg.Env))
+		for k, v := range cfg.Env {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 		}
+
 		transport = &mcp.CommandTransport{
 			Command: cmd,
 		}

--- a/tools/mcp/client.go
+++ b/tools/mcp/client.go
@@ -85,10 +85,21 @@ func (m *Manager) registerServer(ctx context.Context, serverName string, cfg Ser
 		// main application context is canceled.
 		cmd := exec.CommandContext(ctx, cfg.Command, cfg.Args...)
 
-		// Security: Unconditionally initialize Env to an empty slice to prevent
-		// silent inheritance of the host's full process environment.
-		// If Env is provided, ONLY those variables will be used.
-		cmd.Env = make([]string, 0, len(cfg.Env))
+		// Ensure the command runs in the workspace root or the process's current CWD.
+		if cwd, err := os.Getwd(); err == nil {
+			cmd.Dir = cwd
+		}
+
+		// Security: Prevent secret leakage by not inheriting the full host environment.
+		// However, we MUST inherit essential system variables for the command to execute.
+		essential := []string{"PATH", "HOME", "USER", "TMPDIR"}
+		for _, e := range essential {
+			if val, ok := os.LookupEnv(e); ok {
+				cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", e, val))
+			}
+		}
+
+		// Add explicitly configured environment variables.
 		for k, v := range cfg.Env {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 		}

--- a/tools/mcp_servers/godoc/BUILD.bazel
+++ b/tools/mcp_servers/godoc/BUILD.bazel
@@ -14,8 +14,5 @@ go_test(
     name = "godoc_test",
     srcs = ["server_test.go"],
     embed = [":godoc"],
-    deps = [
-        "@com_github_modelcontextprotocol_go_sdk//mcp",
-        "@com_github_stretchr_testify//assert",
-    ],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -37,8 +37,8 @@ func (r *Registry) HandleCall(ctx context.Context, tc llm.ToolCall) (string, err
 	return handler(ctx, tc)
 }
 
-func RegisterLocalTools(r *Registry, ignoredLockFiles []string) {
-	registerLocalReadFile(r)
-	registerLocalGlobFiles(r)
-	registerLocalGrepFiles(r, ignoredLockFiles)
+func RegisterLocalTools(r *Registry, root string, ignoredLockFiles []string) {
+	registerLocalReadFile(r, root)
+	registerLocalGlobFiles(r, root)
+	registerLocalGrepFiles(r, root, ignoredLockFiles)
 }


### PR DESCRIPTION
## Summary
Implemented a Go-native, provider-agnostic LLM-as-a-Judge evaluation mechanism to assess the quality of the `ai-reviewer` agent.

## Key Features
- **Data-Driven Evals**: Test cases are defined as filesystem fixtures (metadata + diff + base state).
- **Git-Backed Sandbox**: Each evaluation runs in a hermetic `git` environment, allowing tools like `grep_files` and `read_file` to operate realistically.
- **Structured Scoring**: Uses LLM-as-a-Judge to produce machine-readable scores (1-5), rationales, and specific findings.
- **Thread-Safe**: Designed for parallel execution by avoiding process-wide side effects like `os.Chdir`.
- **Security**: Built-in path traversal protection for filesystem tools.
- **CLI Tool**: New `cmd/eval` for batch processing results.

## Verification
- Unit tests for sandbox and tool isolation: `bazel test //core/eval:all //tools:all`.
- Manual verification of the evaluation loop using the included `simple-bug` fixture.