### PR TITLE
feat: add evaluation documentation system and fix corrupt diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ bazel-testlogs
 
 # temp stuff
 scratch/
+core/eval/results/
 
 # Conductor
 conductor/plan.md

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -84,18 +84,8 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	}
 
 	// 2. Setup Judge
-	// Default judge to subject if not specified
-	if judgeProvider == "" {
-		judgeProvider = subjectCfg.Provider
-	}
-	if judgeModel == "" {
-		judgeModel = subjectCfg.Model
-	}
-	if judgeAPIKey == "" {
-		judgeAPIKey = subjectCfg.ProviderAPIKey
-	}
-	if judgeURL == "" {
-		judgeURL = subjectCfg.ProviderURL
+	if judgeProvider == "" || judgeModel == "" || judgeAPIKey == "" {
+		return fmt.Errorf("judge configuration is incomplete (judge-provider, judge-model, and judge-api-key are required)")
 	}
 
 	judge, err := factory.New(ctx, judgeProvider, judgeModel, judgeAPIKey, judgeURL)

--- a/cmd/update_eval_docs/BUILD.bazel
+++ b/cmd/update_eval_docs/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "update_eval_docs_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/menny/cassandra/cmd/update_eval_docs",
+    visibility = ["//visibility:private"],
+    deps = ["//core/eval"],
+)
+
+go_binary(
+    name = "update_eval_docs",
+    embed = [":update_eval_docs_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/update_eval_docs/main.go
+++ b/cmd/update_eval_docs/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/menny/cassandra/core/eval"
+)
+
+func main() {
+	var (
+		resultsPath     string
+		configPath      string
+		suitePath       string
+		id              string
+		evaluationsFile string
+	)
+
+	flag.StringVar(&resultsPath, "results", "", "Path to the JSON results file")
+	flag.StringVar(&configPath, "config", "cassandra.toml", "Path to the subject's cassandra.toml")
+	flag.StringVar(&suitePath, "suite", "core/eval/testdata/evaluations.json", "Path to the evaluation suite manifest (JSON)")
+	flag.StringVar(&id, "id", "", "The ID of the injection site in EVALUATIONS.md")
+	flag.StringVar(&evaluationsFile, "md", "core/eval/EVALUATIONS.md", "Path to the EVALUATIONS.md file")
+	flag.Parse()
+
+	// Move to the intended working directory if executing via bazel
+	if workspaceDir := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); workspaceDir != "" {
+		if err := os.Chdir(workspaceDir); err != nil {
+			log.Fatalf("failed to change directory to %s: %v", workspaceDir, err)
+		}
+	}
+
+	if resultsPath == "" {
+		log.Fatal("--results is required")
+	}
+	if id == "" {
+		log.Fatal("--id is required")
+	}
+
+	// 1. Load results
+	resultsData, err := os.ReadFile(resultsPath)
+	if err != nil {
+		log.Fatalf("failed to read results: %v", err)
+	}
+
+	var results []eval.CaseResult
+	if err := json.Unmarshal(resultsData, &results); err != nil {
+		log.Fatalf("failed to parse results: %v", err)
+	}
+
+	// 2. Load suite to get rubrics
+	suite, err := eval.LoadSuite(suitePath)
+	if err != nil {
+		log.Fatalf("failed to load suite: %v", err)
+	}
+
+	rubrics := make(map[string]string)
+	for _, c := range suite.Cases {
+		rubrics[c.ID] = c.Rubric
+	}
+
+	// 3. Generate Markdown
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("**Config**: `%s`  \n\n", configPath))
+
+	sb.WriteString("| Eval ID | Eval Name | Judge Criteria | Score |\n")
+	sb.WriteString("| --- | --- | --- | --- |\n")
+
+	for _, res := range results {
+		rubric := rubrics[res.CaseID]
+		// Clean up rubric for table (no newlines, escape pipes)
+		rubric = strings.ReplaceAll(rubric, "\n", " ")
+		rubric = strings.ReplaceAll(rubric, "|", "\\|")
+
+		scoreStr := fmt.Sprintf("%d/5", res.Subject.Score)
+		if res.Error != "" {
+			scoreStr = "ERROR"
+		}
+
+		sb.WriteString(fmt.Sprintf("| `%s` | %s | %s | %s |\n", res.CaseID, res.CaseName, rubric, scoreStr))
+	}
+	sb.WriteString("\n")
+
+	newContent := sb.String()
+
+	// 4. Update EVALUATIONS.md
+	mdContent, err := os.ReadFile(evaluationsFile)
+	if err != nil {
+		log.Fatalf("failed to read evaluations file: %v", err)
+	}
+
+	startMarker := fmt.Sprintf("<!-- EVAL_RESULTS_START:%s -->", id)
+	endMarker := fmt.Sprintf("<!-- EVAL_RESULTS_END:%s -->", id)
+
+	content := string(mdContent)
+	startIndex := strings.Index(content, startMarker)
+	endIndex := strings.Index(content, endMarker)
+
+	if startIndex == -1 || endIndex == -1 {
+		log.Fatalf("could not find markers for ID %s in %s", id, evaluationsFile)
+	}
+
+	finalContent := content[:startIndex+len(startMarker)] + "\n" + newContent + content[endIndex:]
+
+	if err := os.WriteFile(evaluationsFile, []byte(finalContent), 0o644); err != nil {
+		log.Fatalf("failed to write evaluations file: %v", err)
+	}
+
+	fmt.Printf("Successfully updated %s section '%s' with results from %s\n", evaluationsFile, id, resultsPath)
+}

--- a/cmd/update_eval_docs/main.go
+++ b/cmd/update_eval_docs/main.go
@@ -101,7 +101,10 @@ func main() {
 	endIndex := strings.Index(content, endMarker)
 
 	if startIndex == -1 || endIndex == -1 {
-		log.Fatalf("could not find markers for ID %s in %s", id, evaluationsFile)
+		log.Fatalf("could not find markers for ID %s in %s. Please ensure both <!-- EVAL_RESULTS_START:%s --> and <!-- EVAL_RESULTS_END:%s --> are present.", id, evaluationsFile, id, id)
+	}
+	if startIndex >= endIndex {
+		log.Fatalf("invalid marker positions for ID %s in %s: start marker must appear before end marker", id, evaluationsFile)
 	}
 
 	finalContent := content[:startIndex+len(startMarker)] + "\n" + newContent + content[endIndex:]
@@ -110,5 +113,5 @@ func main() {
 		log.Fatalf("failed to write evaluations file: %v", err)
 	}
 
-	fmt.Printf("Successfully updated %s section '%s' with results from %s\n", evaluationsFile, id, resultsPath)
+	fmt.Fprintf(os.Stderr, "Successfully updated %s section '%s' with results from %s\n", evaluationsFile, id, resultsPath)
 }

--- a/core/eval/EVALUATIONS.md
+++ b/core/eval/EVALUATIONS.md
@@ -1,0 +1,41 @@
+# Cassandra Evaluation Results
+
+This document tracks the performance of various Cassandra configurations against our evaluation suite. It provides transparency into the agent's reasoning capabilities, tool usage, and adherence to security standards.
+
+## Baseline Evaluation
+
+This configuration uses the standard Cassandra settings without any supplemental guidelines or MCP servers. It represents the "out-of-the-box" experience.
+
+<!-- EVAL_RESULTS_START:baseline -->
+**Config**: `cassandra.toml`  
+
+| Eval ID | Eval Name | Judge Criteria | Score |
+| --- | --- | --- | --- |
+| `simple-bug` | Simple Bug Fix | The agent should identify that the `Divide` function does not check for division by zero. | 5/5 |
+| `interface-contract` | Interface Contract Violation | The agent MUST identify that `CreateAndSave` in `service.go` passes a potentially nil user to `SaveUser`, which explicitly requires a non-nil pointer in `repository.go`. | 5/5 |
+| `security-path-traversal` | Security: Path Traversal | The agent MUST identify the path traversal vulnerability in the `/file` handler and recommend using `filepath.Clean` or a boundary check. | 5/5 |
+| `local-agents-convention` | Local Agents Convention | The agent MUST identify that the new code uses raw `db.Query` instead of the mandated `SafeQuery` wrapper defined in `internal/db/AGENTS.md`. | 5/5 |
+| `library-godoc-verification` | Library API Verification | The agent MUST identify that `ExecuteAsync` is not a valid method on the `db.DB` type by inspecting the `lib/db/db.go` file or using godoc. | 5/5 |
+
+<!-- EVAL_RESULTS_END:baseline -->
+
+## MCP-Enhanced Evaluation
+
+In this run, we enabled the `godoc` MCP server to see if the agent can better verify library signatures and API contracts.
+
+<!-- EVAL_RESULTS_START:mcp-godoc -->
+<!-- EVAL_RESULTS_END:mcp-godoc -->
+
+## Evaluation Methodology
+
+The evaluations are performed using an **LLM-as-a-Judge** strategy. Each evaluation case consists of:
+1.  **A Base State**: A specific version of a repository.
+2.  **An Input Diff**: A set of changes the agent is asked to review.
+3.  **A Rubric**: Specific criteria the judge uses to score the review.
+
+### Scoring Rubric
+-   **5 (Excellent)**: Correctly identifies all issues, no false positives, professional and constructive.
+-   **4 (Good)**: Identifies major issues, might miss minor style points, constructive.
+-   **3 (Fair)**: Identifies the core issue but might miss nuances or include minor inaccuracies.
+-   **2 (Poor)**: Misses the core issue or provides significantly misleading feedback.
+-   **1 (Fail)**: Fails to identify the problem or produces harmful advice.

--- a/core/eval/testdata/cases/security-path-traversal/input.diff
+++ b/core/eval/testdata/cases/security-path-traversal/input.diff
@@ -1,15 +1,16 @@
 --- a/server.go
 +++ b/server.go
-@@ -1,6 +1,8 @@
+@@ -1,10 +1,23 @@
  package main
  
- import (
+-import "net/http"
++import (
++	"net/http"
 +	"os"
 +	"path/filepath"
- 	"net/http"
- )
++)
  
-@@ -8,5 +10,13 @@
+ func main() {
  	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
  		w.Write([]byte("OK"))
  	})

--- a/scripts/run_evals.sh
+++ b/scripts/run_evals.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+# Usage: ./scripts/run_evals.sh <ID> <config_path> <subject-api-key> <judge-provider> <judge-model> <judge-api-key>
+# Example: ./scripts/run_evals.sh baseline cassandra.toml $GOOGLE_API_KEY google gemini-1.5-pro $GOOGLE_API_KEY
+
+ID="$1"
+if [ -z "$ID" ]; then
+  echo "Usage: ./scripts/run_evals.sh <ID> <config_path> <subject-api-key> <judge-provider> <judge-model> <judge-api-key>"
+  exit 1
+fi
+shift
+
+CONFIG_PATH=${1}
+if [ -z "$CONFIG_PATH" ]; then
+  echo "Usage: ./scripts/run_evals.sh <ID> <config_path> <subject-api-key> <judge-provider> <judge-model> <judge-api-key>"
+  exit 1
+fi
+shift
+
+SUBJECT_API_KEY=${1}
+if [ -z "$SUBJECT_API_KEY" ]; then
+  echo "Usage: ./scripts/run_evals.sh <ID> <config_path> <subject-api-key> <judge-provider> <judge-model> <judge-api-key>"
+  exit 1
+fi
+shift
+
+JUDGE_PROVIDER=${1}
+if [ -z "$JUDGE_PROVIDER" ]; then
+  echo "Usage: ./scripts/run_evals.sh <ID> <config_path> <subject-api-key> <judge-provider> <judge-model> <judge-api-key>"
+  exit 1
+fi
+shift
+
+JUDGE_MODEL=${1}
+if [ -z "$JUDGE_MODEL" ]; then
+  echo "Usage: ./scripts/run_evals.sh <ID> <config_path> <subject-api-key> <judge-provider> <judge-model> <judge-api-key>"
+  exit 1
+fi
+shift
+
+JUDGE_API_KEY=${1}
+if [ -z "$JUDGE_API_KEY" ]; then
+  echo "Usage: ./scripts/run_evals.sh <ID> <config_path> <subject-api-key> <judge-provider> <judge-model> <judge-api-key>"
+  exit 1
+fi
+shift
+
+RESULTS_DIR="core/eval/results"
+CONFIG_NAME=$(basename "$CONFIG_PATH" .toml)
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+RESULTS_FILE="$RESULTS_DIR/${CONFIG_NAME}_${TIMESTAMP}.json"
+
+mkdir -p "$RESULTS_DIR"
+
+echo "===> Running evaluations for $CONFIG_PATH (ID: $ID)..."
+bazel run //cmd/eval -- \
+  --subject-config "$CONFIG_PATH" \
+  --subject-api-key "$SUBJECT_API_KEY" \
+  --judge-provider "$JUDGE_PROVIDER" \
+  --judge-model "$JUDGE_MODEL" \
+  --judge-api-key "$JUDGE_API_KEY" \
+  --output "$RESULTS_FILE"
+
+echo "===> Updating EVALUATIONS.md..."
+bazel run //cmd/update_eval_docs -- \
+  --results "$RESULTS_FILE" \
+  --config "$CONFIG_PATH" \
+  --id "$ID"
+
+echo "===> Done! Results written to $RESULTS_FILE and EVALUATIONS.md updated."


### PR DESCRIPTION
This PR introduces a robust reporting system for Cassandra evaluations and fixes a bug in the security-path-traversal evaluation case.

### Changes:
- **cmd/update_eval_docs**: New Go tool for ID-based Markdown injection in EVALUATIONS.md.
- **scripts/run_evals.sh**: Orchestration script for running evaluations and updating docs with independent judge/subject configs.
- **core/eval/EVALUATIONS.md**: Human-managed evaluation results template.
- **cmd/eval**: Enforce explicit judge configuration to prevent credential/config leakage.
- **Fix**: Corrected malformed hunk header in `security-path-traversal/input.diff`.
- **.gitignore**: Added `core/eval/results/`.