### PR TITLE
feat: show MCP initialization progress

### DIFF
--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -169,7 +169,8 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	stderr.Println("===============================")
 
 	// Initialize Reviewer
-	reviewer, err := core.NewReviewer(ctx, cfg, targetDir)
+	reporter := core.NewDefaultReporter(stderr.Writer())
+	reviewer, err := core.NewReviewer(ctx, cfg, targetDir, reporter)
 	if err != nil {
 		return fmt.Errorf("failed to initialize reviewer: %w", err)
 	}
@@ -181,15 +182,15 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 			metrics := reviewer.Agent.GetMetrics()
 			jsonBytes, err := json.MarshalIndent(map[string]any{"metrics": metrics}, "", "  ")
 			if err != nil {
-				stderr.Printf("Warning: failed to marshal metrics: %v\n", err)
+				stderr.Printf("⚠️  Failed to marshal metrics: %v\n", err)
 				return
 			}
 
 			if err := core.WriteFileWithDirs(cfg.MetricsJSONFile, jsonBytes); err != nil {
-				stderr.Printf("Warning: failed to write metrics to %s: %v\n", cfg.MetricsJSONFile, err)
+				stderr.Printf("⚠️  Failed to write metrics to %s: %v\n", cfg.MetricsJSONFile, err)
 				return
 			}
-			stderr.Printf("Session metrics written to %s\n", cfg.MetricsJSONFile)
+			stderr.Printf("📈 Metrics written to %s\n", cfg.MetricsJSONFile)
 		}()
 	}
 
@@ -219,7 +220,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 			}
 		}
 	} else {
-		stderr.Println("Fetching git diff locally...")
+		stderr.Println("🌿 Fetching git diff...")
 		var err error
 		diffOutput, changedFiles, err = tools.FetchGitDiff(ctx, targetDir, cfg.Base, cfg.Head, cfg.IgnoredLockFiles)
 		if err != nil {
@@ -234,17 +235,17 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		}
 		commitsOutput = string(commitsBytes)
 	} else {
-		stderr.Println("Fetching git commits locally...")
+		stderr.Println("🌿 Fetching git commits...")
 		commits, err := tools.FetchGitCommits(ctx, targetDir, cfg.Base, cfg.Head)
 		if err != nil {
-			stderr.Printf("Warning: failed to fetch git commits: %v\n", err)
+			stderr.Printf("⚠️  Failed to fetch git commits: %v\n", err)
 		} else {
 			commitsOutput = commits
 		}
 	}
 
 	if len(changedFiles) == 0 {
-		stderr.Println("No changes found to review.")
+		stderr.Println("⚪ No changes found.")
 		return nil
 	}
 
@@ -262,11 +263,11 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	if cfg.MetadataJSONFile != "" {
 		metadataBytes, err := os.ReadFile(cfg.MetadataJSONFile)
 		if err != nil {
-			stderr.Printf("Warning: failed to read metadata JSON: %v. Proceeding without metadata.\n", err)
+			stderr.Printf("⚠️  Failed to read metadata JSON: %v. Proceeding without metadata.\n", err)
 		} else {
 			var metadata core.PRMetadata
 			if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
-				stderr.Printf("Warning: failed to parse metadata JSON: %v. Proceeding without metadata.\n", err)
+				stderr.Printf("⚠️  Failed to parse metadata JSON: %v. Proceeding without metadata.\n", err)
 			} else {
 				requestText = formatMetadata(metadata) + "\n\n" + requestText
 			}
@@ -278,6 +279,8 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return fmt.Errorf("review failed: %w", err)
 	}
 
+	reviewer.Agent.Reporter().ReportReviewHeader(len(changedFiles), cfg.MainGuidelines, cfg.Model)
+
 	// Final review goes to stdout so it can be captured cleanly.
 	fmt.Println(result)
 
@@ -285,7 +288,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		if err := core.WriteFileWithDirs(cfg.ReviewOutputFile, []byte(result)); err != nil {
 			return fmt.Errorf("failed to write review to %s: %w", cfg.ReviewOutputFile, err)
 		}
-		stderr.Printf("Review written to %s\n", cfg.ReviewOutputFile)
+		stderr.Printf("📝 Review written to %s\n", cfg.ReviewOutputFile)
 	}
 
 	if cfg.OutputJSONFile != "" {
@@ -308,7 +311,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		if err := core.WriteFileWithDirs(cfg.OutputJSONFile, jsonBytes); err != nil {
 			return fmt.Errorf("failed to write structured review to %s: %w", cfg.OutputJSONFile, err)
 		}
-		stderr.Printf("Structured review written to %s\n", cfg.OutputJSONFile)
+		stderr.Printf("📦 Structured review written to %s\n", cfg.OutputJSONFile)
 	}
 
 	return nil

--- a/core/agent.go
+++ b/core/agent.go
@@ -48,6 +48,13 @@ type Reporter interface {
 	ReportEmptyResponseRetry(attempt int)
 	ReportCapReached(maxIterations int)
 	ReportTruncated(maxTokens int)
+	ReportMCPStatus(name string, status string, err error)
+	ReportReviewHeader(files int, guidelines string, model string)
+}
+
+// NewDefaultReporter creates a reporter that writes to the provided writer.
+func NewDefaultReporter(w io.Writer) Reporter {
+	return &defaultReporter{w: w}
 }
 
 // defaultReporter writes progress to an io.Writer.
@@ -56,16 +63,16 @@ type defaultReporter struct {
 }
 
 func (r *defaultReporter) ReportIteration(iter int) {
-	fmt.Fprintf(r.w, "Iteration %d: Cassandra is reviewing the code...\n", iter)
+	fmt.Fprintf(r.w, "🔍 [Iter %d] Reviewing...\n", iter)
 }
 
 func (r *defaultReporter) ReportToolCall(tc llm.ToolCall) {
-	fmt.Fprintf(r.w, "Cassandra asked to run tool %q (%s)\n", tc.Name, compactToolCallArgs(tc))
+	fmt.Fprintf(r.w, "🛠️  [Tool] %s(%s)\n", tc.Name, compactToolCallArgs(tc))
 }
 
 func (r *defaultReporter) ReportUsage(usage llm.Usage) {
 	if usage.PromptTokens >= 0 && usage.OutputTokens >= 0 {
-		msg := fmt.Sprintf("  [Tokens: %d input, %d output]", usage.TotalInput(), usage.TotalOutput())
+		msg := fmt.Sprintf("📊 %d in, %d out", usage.TotalInput(), usage.TotalOutput())
 		var breakdown []string
 		if usage.CachedTokens > 0 {
 			breakdown = append(breakdown, fmt.Sprintf("%d cached", usage.CachedTokens))
@@ -82,32 +89,44 @@ func (r *defaultReporter) ReportUsage(usage llm.Usage) {
 
 func (r *defaultReporter) ReportUsageSummary(total llm.Usage) {
 	if total.PromptTokens > 0 || total.OutputTokens > 0 {
-		fmt.Fprintf(r.w, "Total session tokens: %d input, %d output\n", total.TotalInput(), total.TotalOutput())
+		fmt.Fprintf(r.w, "📈 %d in, %d out (total)\n", total.TotalInput(), total.TotalOutput())
 	}
 }
 
 func (r *defaultReporter) ReportFinalReview() {
-	fmt.Fprintln(r.w, "Cassandra is formulating the final review...")
+	fmt.Fprintln(r.w, "📝 Formulating final review...")
 }
 
 func (r *defaultReporter) ReportExtraction() {
-	fmt.Fprintln(r.w, "Cassandra is extracting structured JSON findings...")
+	fmt.Fprintln(r.w, "📦 Extracting findings...")
 }
 
 func (r *defaultReporter) ReportExtractionRetry(attempt int) {
-	fmt.Fprintf(r.w, "Extraction attempt %d failed; retrying...\n", attempt)
+	fmt.Fprintf(r.w, "🔄 [Retry] Extraction attempt %d failed; retrying...\n", attempt)
 }
 
 func (r *defaultReporter) ReportEmptyResponseRetry(attempt int) {
-	fmt.Fprintf(r.w, "LLM returned empty response (attempt %d); retrying...\n", attempt)
+	fmt.Fprintf(r.w, "🔄 [Retry] LLM returned empty response (attempt %d); retrying...\n", attempt)
 }
 
 func (r *defaultReporter) ReportCapReached(maxIterations int) {
-	fmt.Fprintf(r.w, "Warning: reached maximum ReAct iterations (%d). Forcing final review.\n", maxIterations)
+	fmt.Fprintf(r.w, "⚠️  Reached maximum ReAct iterations (%d). Forcing final review.\n", maxIterations)
 }
 
 func (r *defaultReporter) ReportTruncated(maxTokens int) {
-	fmt.Fprintf(r.w, "Warning: LLM response truncated (hit max-tokens limit of %d). The review may be incomplete.\n", maxTokens)
+	fmt.Fprintf(r.w, "⚠️  LLM response truncated (hit max-tokens limit of %d). The review may be incomplete.\n", maxTokens)
+}
+
+func (r *defaultReporter) ReportMCPStatus(name string, status string, err error) {
+	if err != nil {
+		fmt.Fprintf(r.w, "🔌 [MCP] %s: %s: %v\n", name, status, err)
+	} else {
+		fmt.Fprintf(r.w, "🔌 [MCP] %s: %s\n", name, status)
+	}
+}
+
+func (r *defaultReporter) ReportReviewHeader(files int, guidelines string, model string) {
+	fmt.Fprintf(r.w, "\n✅ Review generated successfully.\n\n\n# 📝 Review for %d files using %s (%s)\n\n", files, guidelines, model)
 }
 
 // AgentOption configures an Agent.
@@ -121,7 +140,11 @@ func WithStderr(w io.Writer) AgentOption {
 
 // WithReporter sets a custom reporter for the Agent.
 func WithReporter(r Reporter) AgentOption {
-	return func(a *Agent) { a.reporter = r }
+	return func(a *Agent) {
+		if r != nil {
+			a.reporter = r
+		}
+	}
 }
 
 // Agent orchestrates the ReAct (Reason + Act) loop between the LLM and the tool registry.
@@ -148,6 +171,11 @@ func NewAgent(model llm.Model, registry ToolDispatcher, opts ...AgentOption) *Ag
 		o(a)
 	}
 	return a
+}
+
+// Reporter returns the Agent's reporter.
+func (a *Agent) Reporter() Reporter {
+	return a.reporter
 }
 
 // GetMetrics returns the collected usage and execution metrics for the session.

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -118,6 +118,20 @@ type spyReporter struct {
 	emptyResponseRetries []int
 	capsReached          []int
 	truncated            []int
+	mcpStatuses          []mcpStatus
+	reviewHeaders        []reviewHeaderInfo
+}
+
+type mcpStatus struct {
+	name   string
+	status string
+	err    error
+}
+
+type reviewHeaderInfo struct {
+	files      int
+	guidelines string
+	model      string
 }
 
 func (s *spyReporter) ReportIteration(iter int) {
@@ -140,6 +154,14 @@ func (s *spyReporter) ReportEmptyResponseRetry(attempt int) {
 func (s *spyReporter) ReportCapReached(max int) { s.capsReached = append(s.capsReached, max) }
 func (s *spyReporter) ReportTruncated(maxTokens int) {
 	s.truncated = append(s.truncated, maxTokens)
+}
+
+func (s *spyReporter) ReportMCPStatus(name string, status string, err error) {
+	s.mcpStatuses = append(s.mcpStatuses, mcpStatus{name: name, status: status, err: err})
+}
+
+func (s *spyReporter) ReportReviewHeader(files int, guidelines string, model string) {
+	s.reviewHeaders = append(s.reviewHeaders, reviewHeaderInfo{files: files, guidelines: guidelines, model: model})
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/core/eval/runner.go
+++ b/core/eval/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,7 +31,7 @@ func (r *Runner) RunCase(ctx context.Context, c EvalCase) (*CaseResult, error) {
 	defer sandbox.Cleanup()
 
 	// 2. Setup Reviewer (Subject)
-	reviewer, err := core.NewReviewer(ctx, r.SubjectConfig, sandbox.RootDir)
+	reviewer, err := core.NewReviewer(ctx, r.SubjectConfig, sandbox.RootDir, core.NewDefaultReporter(io.Discard))
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup reviewer: %w", err)
 	}

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -28,7 +28,11 @@ type Reviewer struct {
 
 // NewReviewer instantiates a Reviewer based on the provided configuration.
 // targetDir is the directory where local tools (like grep) will operate.
-func NewReviewer(ctx context.Context, cfg *config.Config, targetDir string) (r *Reviewer, err error) {
+func NewReviewer(ctx context.Context, cfg *config.Config, targetDir string, reporter Reporter) (r *Reviewer, err error) {
+	if reporter == nil {
+		reporter = NewDefaultReporter(os.Stderr)
+	}
+
 	client, err := factory.New(ctx, cfg.Provider, cfg.Model, cfg.ProviderAPIKey, cfg.ProviderURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize LLM: %w", err)
@@ -69,7 +73,7 @@ func NewReviewer(ctx context.Context, cfg *config.Config, targetDir string) (r *
 	if len(mcpConfig.MCPServers) > 0 {
 		mcpConfig.ExpandEnv()
 		mcpManager = mcp.NewManager()
-		if err := mcpManager.RegisterServers(ctx, mcpConfig, func(def llm.ToolDef, handler func(context.Context, llm.ToolCall) (string, error)) {
+		if err := mcpManager.RegisterServers(ctx, mcpConfig, reporter.ReportMCPStatus, func(def llm.ToolDef, handler func(context.Context, llm.ToolCall) (string, error)) {
 			registry.RegisterTool(def, handler)
 		}); err != nil {
 			return nil, fmt.Errorf("failed to register MCP servers: %w", err)
@@ -105,7 +109,7 @@ func NewReviewer(ctx context.Context, cfg *config.Config, targetDir string) (r *
 	}
 
 	return &Reviewer{
-		Agent:                    NewAgent(client, registry),
+		Agent:                    NewAgent(client, registry, WithReporter(reporter)),
 		Config:                   cfg,
 		RootDir:                  targetDir,
 		StablePrompt:             stable,

--- a/tools/mcp/client.go
+++ b/tools/mcp/client.go
@@ -42,15 +42,16 @@ func (m *Manager) Close() error {
 	return nil
 }
 
-func (m *Manager) RegisterServers(ctx context.Context, config Config, register func(llm.ToolDef, func(context.Context, llm.ToolCall) (string, error))) error {
+func (m *Manager) RegisterServers(ctx context.Context, config Config, report func(name, status string, err error), register func(llm.ToolDef, func(context.Context, llm.ToolCall) (string, error))) error {
 	var lastErr error
 	var successCount int
 	for name, server := range config.MCPServers {
-		if err := m.registerServer(ctx, name, server, register); err != nil {
-			// Per output contract, we report errors to stderr but continue if possible
-			fmt.Fprintf(os.Stderr, "Warning: failed to register MCP server %q: %v\n", name, err)
+		report(name, "started", nil)
+		if err := m.registerServer(ctx, name, server, report, register); err != nil {
+			report(name, "failed to load", err)
 			lastErr = err
 		} else {
+			report(name, "loaded", nil)
 			successCount++
 		}
 	}
@@ -77,7 +78,7 @@ func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	return h.base.RoundTrip(out)
 }
 
-func (m *Manager) registerServer(ctx context.Context, serverName string, cfg ServerConfig, register func(llm.ToolDef, func(context.Context, llm.ToolCall) (string, error))) error {
+func (m *Manager) registerServer(ctx context.Context, serverName string, cfg ServerConfig, report func(name, status string, err error), register func(llm.ToolDef, func(context.Context, llm.ToolCall) (string, error))) error {
 	var transport mcp.Transport
 
 	if cfg.Command != "" {
@@ -125,10 +126,10 @@ func (m *Manager) registerServer(ctx context.Context, serverName string, cfg Ser
 		return fmt.Errorf("invalid server config: neither command nor url specified")
 	}
 
-	return m.registerServerWithTransport(ctx, serverName, transport, cfg, register)
+	return m.registerServerWithTransport(ctx, serverName, transport, cfg, report, register)
 }
 
-func (m *Manager) registerServerWithTransport(ctx context.Context, serverName string, transport mcp.Transport, cfg ServerConfig, register func(llm.ToolDef, func(context.Context, llm.ToolCall) (string, error))) error {
+func (m *Manager) registerServerWithTransport(ctx context.Context, serverName string, transport mcp.Transport, cfg ServerConfig, report func(name, status string, err error), register func(llm.ToolDef, func(context.Context, llm.ToolCall) (string, error))) error {
 	client := mcp.NewClient(&mcp.Implementation{
 		Name:    "cassandra-reviewer",
 		Version: "0.0.1",
@@ -161,11 +162,11 @@ func (m *Manager) registerServerWithTransport(ctx context.Context, serverName st
 				// Fallback to unmarshaling if it's not a map
 				data, err := json.Marshal(t.InputSchema)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: failed to marshal input schema for tool %q: %v. Skipping tool registration.\n", t.Name, err)
+					report(serverName, fmt.Sprintf("failed to marshal input schema for tool %q", t.Name), err)
 					continue
 				}
 				if err := json.Unmarshal(data, &parameters); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: failed to unmarshal input schema for tool %q: %v. Skipping tool registration.\n", t.Name, err)
+					report(serverName, fmt.Sprintf("failed to unmarshal input schema for tool %q", t.Name), err)
 					continue
 				}
 			}

--- a/tools/mcp/client_test.go
+++ b/tools/mcp/client_test.go
@@ -64,7 +64,7 @@ func TestManager_RegisterServers_Mock(t *testing.T) {
 	}
 
 	cfg := ServerConfig{TimeoutSeconds: 30}
-	err := manager.registerServerWithTransport(ctx, "myserver", clientTransport, cfg, register)
+	err := manager.registerServerWithTransport(ctx, "myserver", clientTransport, cfg, func(string, string, error) {}, register)
 	require.NoError(t, err)
 
 	assert.Len(t, registeredTools, 2)
@@ -84,4 +84,53 @@ func TestManager_RegisterServers_Mock(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "MCP tool error: error details")
+}
+
+func TestManager_RegisterServers_Reporting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager := NewManager()
+	defer manager.Close()
+
+	// 1. Success case
+	serverTransport, _ := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	go func() { _ = server.Run(ctx, serverTransport) }()
+
+	// We'll mock registerServer by temporarily overriding the transport creation logic if it were possible,
+	// but since RegisterServers uses registerServer which creates transports based on config,
+	// we'll just test the reporting flow by providing a config that will fail and one that will (hypothetically) succeed if we could mock the transport.
+	// Actually, let's just test that it reports "started" and then "failed to load" for an invalid config.
+
+	cfg := Config{
+		MCPServers: map[string]ServerConfig{
+			"invalid": {
+				Command: "",
+				URL:     "",
+			},
+		},
+	}
+
+	var reports []struct {
+		name   string
+		status string
+		err    error
+	}
+	report := func(name, status string, err error) {
+		reports = append(reports, struct {
+			name   string
+			status string
+			err    error
+		}{name, status, err})
+	}
+
+	err := manager.RegisterServers(ctx, cfg, report, func(llm.ToolDef, func(context.Context, llm.ToolCall) (string, error)) {})
+	assert.Error(t, err)
+	assert.Len(t, reports, 2)
+	assert.Equal(t, "invalid", reports[0].name)
+	assert.Equal(t, "started", reports[0].status)
+	assert.Equal(t, "invalid", reports[1].name)
+	assert.Equal(t, "failed to load", reports[1].status)
+	assert.Error(t, reports[1].err)
+	assert.Contains(t, reports[1].err.Error(), "invalid server config")
 }


### PR DESCRIPTION
## Summary
This PR implements MCP initialization progress reporting and standardizes CLI diagnostic messages as requested in #78.

### Key Changes
- **MCP Progress**: Added `ReportMCPStatus` to the `Reporter` interface. The MCP manager now reports 'started', 'loaded', and 'failed' states during initialization.
- **Emoji-First Diagnostics**: Standardized all CLI progress messages (git fetching, tool calls, token usage, etc.) with emojis and concise text for better scannability.
- **Review Header**: Added a standardized header (e.g., `✅ Review generated successfully...`) that is printed to stderr just before the stdout review result.
- **Architectural Improvements**:
    - Refactored `NewReviewer` to accept a `Reporter` interface, allowing for better testability and consistency with the caller's logging setup.
    - Added nil-safety guards for the reporter in `NewReviewer` and `WithReporter`.
- **Testing**: Updated `spyReporter` to record all new reporting events and added unit tests for MCP initialization reporting.

### Output Example
```text
🔌 [MCP] mcp-server-fetch: started
🔌 [MCP] mcp-server-fetch: loaded
🌿 Fetching git diff...
🔍 [Iter 1] Reviewing...
🛠️  [Tool] grep_search(...)
📊 1240 in, 150 out (800 cached)
✅ Review generated successfully.
# 📝 Review for 5 files using asana-do-try-consider (gemini-1.5-pro)
```

Closes #78