### PR TITLE
Fix: Implement read_file safety limits and streaming (#77)

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
     name = "tools_test",
     srcs = [
         "diff_test.go",
+        "local_tools_safety_test.go",
         "local_tools_test.go",
     ],
     embed = [":tools"],

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -63,7 +62,8 @@ func registerLocalReadFile(r *Registry, root string) {
 		const defaultMaxReadLength = 40000
 		const absoluteMaxReadLength = 40000
 		const absoluteMaxTailLines = 10000
-		const maxLineLength = 65536 // 64KB per line safety limit
+		const maxLineLength = 65536           // 64KB per line safety limit
+		const maxTailBufferBytes = 1024 * 1024 // 1MB limit for the circular buffer storage
 
 		maxOutput := args.MaxReadLength
 		if maxOutput <= 0 {
@@ -118,12 +118,8 @@ func registerLocalReadFile(r *Registry, root string) {
 			if tailLines > absoluteMaxTailLines {
 				tailLines = absoluteMaxTailLines
 			}
-			// Circular buffer for tail lines.
-			buffer := make([][]byte, tailLines)
-			count := 0
-			totalBufferBytes := 0
-			const maxTailBufferBytes = 1024 * 1024 // 1MB limit for the circular buffer storage
 
+			tb := newTailBuffer(tailLines, maxTailBufferBytes)
 			for {
 				line, err := readLimitedLine(reader, maxLineLength)
 				if len(line) == 0 && err != nil {
@@ -133,59 +129,23 @@ func registerLocalReadFile(r *Registry, root string) {
 					return "", fmt.Errorf("read_file failed while reading: %w", err)
 				}
 
-				idx := count % tailLines
-				// Subtract old line size from total
-				if buffer[idx] != nil {
-					totalBufferBytes -= len(buffer[idx])
-				}
-
-				buffer[idx] = line
-				totalBufferBytes += len(line)
-				count++
-
-				// If we exceed 1MB, we must keep memory bounded.
-				// If the TOTAL bytes in the buffer exceeds 1MB, we'll start setting older entries to nil
-				// to reclaim memory until we are under the limit again.
-				for totalBufferBytes > maxTailBufferBytes {
-					oldestIdx := (count - tailLines)
-					if oldestIdx < 0 {
-						oldestIdx = 0
-					} else {
-						oldestIdx = oldestIdx % tailLines
-					}
-
-					if buffer[oldestIdx] != nil {
-						totalBufferBytes -= len(buffer[oldestIdx])
-						buffer[oldestIdx] = nil
-					} else {
-						break
-					}
-				}
+				tb.Add(line)
 
 				if err == io.EOF {
 					break
 				}
 			}
 
-			startIdx := 0
-			numToPrint := count
-			if count > tailLines {
-				startIdx = count % tailLines
-				numToPrint = tailLines
-			}
-
-			for i := 0; i < numToPrint; i++ {
-				line := buffer[(startIdx+i)%tailLines]
-				if line == nil {
-					continue
-				}
-				if sb.Len() > 0 {
+			lines := tb.Lines()
+			for i, line := range lines {
+				if i > 0 {
 					if sb.Len()+1+len(line) > maxOutput {
 						sb.WriteString("\n... (truncated)")
 						break
 					}
 					sb.WriteString("\n")
 				} else if len(line) > maxOutput {
+					// Handle case where even the first line is too long
 					sb.Write(line[:maxOutput])
 					sb.WriteString("\n... (truncated)")
 					break
@@ -224,6 +184,7 @@ func registerLocalReadFile(r *Registry, root string) {
 				} else {
 					started = true
 					if len(line) > maxOutput {
+						// Handle case where even the first line is too long
 						sb.Write(line[:maxOutput])
 						sb.WriteString("\n... (truncated)")
 						break
@@ -247,26 +208,94 @@ func registerLocalReadFile(r *Registry, root string) {
 	})
 }
 
+type tailBuffer struct {
+	lines    [][]byte
+	limit    int
+	maxBytes int
+	curBytes int
+	count    int
+}
+
+func newTailBuffer(limit, maxBytes int) *tailBuffer {
+	return &tailBuffer{
+		lines:    make([][]byte, limit),
+		limit:    limit,
+		maxBytes: maxBytes,
+	}
+}
+
+func (b *tailBuffer) Add(line []byte) {
+	idx := b.count % b.limit
+	if b.lines[idx] != nil {
+		b.curBytes -= len(b.lines[idx])
+	}
+	b.lines[idx] = line
+	b.curBytes += len(line)
+	b.count++
+
+	// Enforce maxBytes limit by purging oldest lines
+	for b.curBytes > b.maxBytes {
+		found := false
+		for i := 0; i < b.limit; i++ {
+			testIdx := (b.count + i) % b.limit
+			if b.lines[testIdx] != nil {
+				b.curBytes -= len(b.lines[testIdx])
+				b.lines[testIdx] = nil
+				found = true
+				break
+			}
+		}
+		if !found {
+			break
+		}
+	}
+}
+
+func (b *tailBuffer) Lines() [][]byte {
+	res := make([][]byte, 0, b.limit)
+	for i := 0; i < b.limit; i++ {
+		idx := (b.count + i) % b.limit
+		if b.lines[idx] != nil {
+			res = append(res, b.lines[idx])
+		}
+	}
+	return res
+}
+
 // readLimitedLine reads up to maxLineLength bytes or until a newline.
-// It trims the trailing newline.
+// It trims the trailing newline and ensures the returned slice is a copy.
 func readLimitedLine(r *bufio.Reader, limit int) ([]byte, error) {
-	line, err := r.ReadBytes('\n')
-	if len(line) > limit {
-		line = line[:limit]
-		// If we truncated, we need to skip the rest of the line until the next \n
-		if err == nil {
-			for {
-				b, err2 := r.ReadByte()
-				if err2 != nil {
-					return line, err2
-				}
-				if b == '\n' {
-					break
-				}
+	line, isPrefix, err := r.ReadLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	res := make([]byte, 0, len(line))
+	res = append(res, line...)
+
+	for isPrefix && len(res) < limit {
+		line, isPrefix, err = r.ReadLine()
+		if err != nil {
+			break
+		}
+		toAppend := limit - len(res)
+		if toAppend > len(line) {
+			toAppend = len(line)
+		}
+		res = append(res, line[:toAppend]...)
+	}
+
+	if isPrefix {
+		// Line is longer than the limit. Consume the rest.
+		for isPrefix {
+			_, isPrefix, err = r.ReadLine()
+			if err != nil {
+				break
 			}
 		}
 	}
-	return bytes.TrimRight(line, "\r\n"), err
+
+	return res, err
 }
 
 func registerLocalGlobFiles(r *Registry, root string) {

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -2,9 +2,11 @@ package tools
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -110,7 +112,7 @@ func registerLocalReadFile(r *Registry, root string) {
 		defer f.Close()
 
 		var sb strings.Builder
-		scanner := bufio.NewScanner(f)
+		reader := bufio.NewReader(f)
 
 		if args.TailLines > 0 {
 			tailLines := args.TailLines
@@ -118,14 +120,41 @@ func registerLocalReadFile(r *Registry, root string) {
 				tailLines = absoluteMaxTailLines
 			}
 			// Circular buffer for tail lines.
-			buffer := make([]string, tailLines)
+			// To reduce GC pressure, we'll try to be efficient, though ReadBytes still allocates.
+			buffer := make([][]byte, tailLines)
 			count := 0
-			for scanner.Scan() {
-				buffer[count%tailLines] = scanner.Text()
+			totalBufferBytes := 0
+			const maxTailBufferBytes = 1024 * 1024 // 1MB limit for the circular buffer storage
+
+			for {
+				line, err := reader.ReadBytes('\n')
+				if len(line) == 0 && err != nil {
+					if err == io.EOF {
+						break
+					}
+					return "", fmt.Errorf("read_file failed while reading: %w", err)
+				}
+
+				// Remove trailing newline for consistent storage.
+				line = bytes.TrimRight(line, "\r\n")
+
+				idx := count % tailLines
+				// Subtract old line size from total
+				if buffer[idx] != nil {
+					totalBufferBytes -= len(buffer[idx])
+				}
+
+				buffer[idx] = line
+				totalBufferBytes += len(line)
 				count++
-			}
-			if err := scanner.Err(); err != nil {
-				return "", fmt.Errorf("read_file failed while scanning: %w", err)
+
+				if totalBufferBytes > maxTailBufferBytes {
+					return "", fmt.Errorf("read_file failed: tail collection exceeded 1MB limit. Use a smaller tail_lines or line ranges")
+				}
+
+				if err == io.EOF {
+					break
+				}
 			}
 
 			startIdx := 0
@@ -137,14 +166,19 @@ func registerLocalReadFile(r *Registry, root string) {
 
 			for i := 0; i < numToPrint; i++ {
 				line := buffer[(startIdx+i)%tailLines]
-				if sb.Len()+len(line)+1 > maxOutput {
+				if i > 0 {
+					if sb.Len()+1+len(line) > maxOutput {
+						sb.WriteString("\n... (truncated)")
+						break
+					}
+					sb.WriteString("\n")
+				} else if len(line) > maxOutput {
+					// Handle case where even the first line is too long
+					sb.Write(line[:maxOutput])
 					sb.WriteString("\n... (truncated)")
 					break
 				}
-				if i > 0 {
-					sb.WriteString("\n")
-				}
-				sb.WriteString(line)
+				sb.Write(line)
 			}
 			return sb.String(), nil
 		}
@@ -157,27 +191,46 @@ func registerLocalReadFile(r *Registry, root string) {
 		end := args.LineEnd
 
 		currentLine := 0
-		for scanner.Scan() {
-			currentLine++
-			if currentLine < start {
-				continue
-			}
-			if end > 0 && currentLine > end {
-				break
+		started := false
+		for {
+			line, err := reader.ReadBytes('\n')
+			if len(line) == 0 && err != nil {
+				if err == io.EOF {
+					break
+				}
+				return "", fmt.Errorf("read_file failed while reading: %w", err)
 			}
 
-			line := scanner.Text()
-			if sb.Len()+len(line)+1 > maxOutput {
-				sb.WriteString("\n... (truncated)")
+			currentLine++
+			if currentLine >= start && (end <= 0 || currentLine <= end) {
+				line = bytes.TrimRight(line, "\r\n")
+				if started {
+					if sb.Len()+1+len(line) > maxOutput {
+						sb.WriteString("\n... (truncated)")
+						break
+					}
+					sb.WriteString("\n")
+				} else {
+					started = true
+					if len(line) > maxOutput {
+						// Handle case where even the first line is too long
+						sb.Write(line[:maxOutput])
+						sb.WriteString("\n... (truncated)")
+						break
+					}
+				}
+				sb.Write(line)
+			}
+
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return "", fmt.Errorf("read_file failed while reading: %w", err)
+			}
+			if end > 0 && currentLine >= end {
 				break
 			}
-			if sb.Len() > 0 {
-				sb.WriteString("\n")
-			}
-			sb.WriteString(line)
-		}
-		if err := scanner.Err(); err != nil {
-			return "", fmt.Errorf("read_file failed while scanning: %w", err)
 		}
 
 		return sb.String(), nil

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -36,6 +37,10 @@ func registerLocalReadFile(r *Registry, root string) {
 					"type":        "integer",
 					"description": "Read this many lines from the end of the file. If specified, line_start and line_end are ignored.",
 				},
+				"max_read_length": map[string]any{
+					"type":        "integer",
+					"description": "The maximum number of bytes to read. Defaults to 40,000. Maximum allowed is 40,000.",
+				},
 			},
 			"required": []string{"file_path"},
 		},
@@ -43,13 +48,26 @@ func registerLocalReadFile(r *Registry, root string) {
 
 	r.RegisterTool(def, func(ctx context.Context, tc llm.ToolCall) (string, error) {
 		var args struct {
-			FilePath  string `json:"file_path"`
-			LineStart int    `json:"line_start"`
-			LineEnd   int    `json:"line_end"`
-			TailLines int    `json:"tail_lines"`
+			FilePath      string `json:"file_path"`
+			LineStart     int    `json:"line_start"`
+			LineEnd       int    `json:"line_end"`
+			TailLines     int    `json:"tail_lines"`
+			MaxReadLength int    `json:"max_read_length"`
 		}
 		if err := tc.UnmarshalArguments(&args); err != nil {
 			return "", err
+		}
+
+		const defaultMaxReadLength = 40000
+		const absoluteMaxReadLength = 40000
+		const absoluteMaxTailLines = 10000
+
+		maxOutput := args.MaxReadLength
+		if maxOutput <= 0 {
+			maxOutput = defaultMaxReadLength
+		}
+		if maxOutput > absoluteMaxReadLength {
+			maxOutput = absoluteMaxReadLength
 		}
 
 		fullPath := args.FilePath
@@ -64,56 +82,105 @@ func registerLocalReadFile(r *Registry, root string) {
 			}
 		}
 
-		b, err := os.ReadFile(fullPath)
+		info, err := os.Stat(fullPath)
 		if err != nil {
 			return "", fmt.Errorf("read_file failed: %w", err)
 		}
 
-		// If no line-limiting arguments are provided, return the whole file.
+		// If no line-limiting arguments are provided, return the whole file but only if it's small.
 		if args.LineStart <= 0 && args.LineEnd <= 0 && args.TailLines <= 0 {
-			return string(b), nil
-		}
-
-		lines := strings.Split(string(b), "\n")
-		numLines := len(lines)
-
-		// Handle tail_lines first as it takes precedence.
-		if args.TailLines > 0 {
-			start := numLines - args.TailLines
-			if start < 0 {
-				start = 0
+			if info.Size() > int64(absoluteMaxReadLength) {
+				return "", fmt.Errorf("read_file failed: file is too large (%d bytes) to read entirely. Use line_start/line_end or tail_lines", info.Size())
 			}
-			return strings.Join(lines[start:], "\n"), nil
+			b, err := os.ReadFile(fullPath)
+			if err != nil {
+				return "", fmt.Errorf("read_file failed: %w", err)
+			}
+			content := string(b)
+			if len(content) > maxOutput {
+				return content[:maxOutput] + "\n... (truncated)", nil
+			}
+			return content, nil
 		}
 
-		// Handle line range.
+		f, err := os.Open(fullPath)
+		if err != nil {
+			return "", fmt.Errorf("read_file failed: %w", err)
+		}
+		defer f.Close()
+
+		var sb strings.Builder
+		scanner := bufio.NewScanner(f)
+
+		if args.TailLines > 0 {
+			tailLines := args.TailLines
+			if tailLines > absoluteMaxTailLines {
+				tailLines = absoluteMaxTailLines
+			}
+			// Circular buffer for tail lines.
+			buffer := make([]string, tailLines)
+			count := 0
+			for scanner.Scan() {
+				buffer[count%tailLines] = scanner.Text()
+				count++
+			}
+			if err := scanner.Err(); err != nil {
+				return "", fmt.Errorf("read_file failed while scanning: %w", err)
+			}
+
+			startIdx := 0
+			numToPrint := count
+			if count > tailLines {
+				startIdx = count % tailLines
+				numToPrint = tailLines
+			}
+
+			for i := 0; i < numToPrint; i++ {
+				line := buffer[(startIdx+i)%tailLines]
+				if sb.Len()+len(line)+1 > maxOutput {
+					sb.WriteString("\n... (truncated)")
+					break
+				}
+				if i > 0 {
+					sb.WriteString("\n")
+				}
+				sb.WriteString(line)
+			}
+			return sb.String(), nil
+		}
+
+		// Line range.
 		start := args.LineStart
 		if start <= 0 {
 			start = 1
 		}
 		end := args.LineEnd
-		if end <= 0 || end > numLines {
-			end = numLines
+
+		currentLine := 0
+		for scanner.Scan() {
+			currentLine++
+			if currentLine < start {
+				continue
+			}
+			if end > 0 && currentLine > end {
+				break
+			}
+
+			line := scanner.Text()
+			if sb.Len()+len(line)+1 > maxOutput {
+				sb.WriteString("\n... (truncated)")
+				break
+			}
+			if sb.Len() > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString(line)
+		}
+		if err := scanner.Err(); err != nil {
+			return "", fmt.Errorf("read_file failed while scanning: %w", err)
 		}
 
-		// Adjust to 0-based indexing for slicing.
-		startIdx := start - 1
-		if startIdx < 0 {
-			startIdx = 0
-		}
-		if startIdx >= numLines {
-			return "", nil
-		}
-
-		endIdx := end
-		if endIdx > numLines {
-			endIdx = numLines
-		}
-		if endIdx < startIdx {
-			return "", nil
-		}
-
-		return strings.Join(lines[startIdx:endIdx], "\n"), nil
+		return sb.String(), nil
 	})
 }
 

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -117,7 +117,11 @@ func registerLocalReadFile(r *Registry, root string) {
 
 			tb := newTailBuffer(limit, maxTailBufferBytes)
 			for {
-				line, err := readLimitedLine(reader, maxLineLength)
+				if err := ctx.Err(); err != nil {
+					return "", err
+				}
+
+				line, err := readLimitedLine(ctx, reader, maxLineLength)
 				if len(line) == 0 && err != nil {
 					if err == io.EOF {
 						break
@@ -147,7 +151,11 @@ func registerLocalReadFile(r *Registry, root string) {
 		currentLine := 0
 		started := false
 		for {
-			line, err := readLimitedLine(reader, maxLineLength)
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+
+			line, err := readLimitedLine(ctx, reader, maxLineLength)
 			if len(line) == 0 && err != nil {
 				if err == io.EOF {
 					break
@@ -187,7 +195,6 @@ func writeLine(sb *strings.Builder, line []byte, started bool, maxOutput int) bo
 	}
 
 	if sb.Len()+len(prefix)+len(line) > maxOutput {
-		// Calculate how much of the line (if any) we can still fit.
 		remain := maxOutput - sb.Len() - len(prefix)
 		if remain > 0 {
 			sb.WriteString(prefix)
@@ -208,7 +215,7 @@ type tailBuffer struct {
 	maxBytes  int
 	curBytes  int
 	count     int
-	oldestIdx int // Points to the oldest non-nil line
+	oldestIdx int
 }
 
 func newTailBuffer(limit, maxBytes int) *tailBuffer {
@@ -223,13 +230,12 @@ func (b *tailBuffer) Add(line []byte) {
 	idx := b.count % b.limit
 	if b.lines[idx] != nil {
 		b.curBytes -= len(b.lines[idx])
+		b.oldestIdx = (idx + 1) % b.limit
 	}
 	b.lines[idx] = line
 	b.curBytes += len(line)
 	b.count++
 
-	// Reclaim memory if we exceed maxBytes by purging the oldest non-nil lines.
-	// Since we add at b.count%limit, the oldest is usually near oldestIdx.
 	for b.curBytes > b.maxBytes {
 		if b.lines[b.oldestIdx] != nil {
 			b.curBytes -= len(b.lines[b.oldestIdx])
@@ -237,7 +243,6 @@ func (b *tailBuffer) Add(line []byte) {
 		}
 		b.oldestIdx = (b.oldestIdx + 1) % b.limit
 
-		// Safety: if we've purged everything and still over, break.
 		if b.curBytes <= 0 {
 			b.curBytes = 0
 			break
@@ -248,7 +253,7 @@ func (b *tailBuffer) Add(line []byte) {
 func (b *tailBuffer) Lines() [][]byte {
 	res := make([][]byte, 0, b.limit)
 	for i := 0; i < b.limit; i++ {
-		idx := (b.count + i) % b.limit
+		idx := (b.oldestIdx + i) % b.limit
 		if b.lines[idx] != nil {
 			res = append(res, b.lines[idx])
 		}
@@ -256,9 +261,7 @@ func (b *tailBuffer) Lines() [][]byte {
 	return res
 }
 
-// readLimitedLine reads up to maxLineLength bytes or until a newline.
-// It trims the trailing newline and ensures the returned slice is a copy.
-func readLimitedLine(r *bufio.Reader, limit int) ([]byte, error) {
+func readLimitedLine(ctx context.Context, r *bufio.Reader, limit int) ([]byte, error) {
 	line, isPrefix, err := r.ReadLine()
 	if err != nil && err != io.EOF {
 		return nil, err
@@ -268,6 +271,9 @@ func readLimitedLine(r *bufio.Reader, limit int) ([]byte, error) {
 	res = append(res, line...)
 
 	for isPrefix && len(res) < limit {
+		if errCtx := ctx.Err(); errCtx != nil {
+			return res, errCtx
+		}
 		line, isPrefix, err = r.ReadLine()
 		if err != nil {
 			break
@@ -280,8 +286,10 @@ func readLimitedLine(r *bufio.Reader, limit int) ([]byte, error) {
 	}
 
 	if isPrefix {
-		// Line is longer than the limit. Consume the rest.
 		for isPrefix {
+			if errCtx := ctx.Err(); errCtx != nil {
+				return res, errCtx
+			}
 			_, isPrefix, err = r.ReadLine()
 			if err != nil {
 				break
@@ -329,7 +337,6 @@ func registerLocalGlobFiles(r *Registry, root string) {
 			if !filepath.IsAbs(dir) {
 				dir = filepath.Join(root, dir)
 			}
-			// Security: Ensure the path is within the root directory.
 			rel, err := filepath.Rel(root, dir)
 			if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
 				return "", fmt.Errorf("glob_files failed: path %q is outside the workspace root", args.Directory)
@@ -339,10 +346,9 @@ func registerLocalGlobFiles(r *Registry, root string) {
 		var matches []string
 		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
-				return nil // Skip errors reading specific files
+				return nil
 			}
 			if !d.IsDir() {
-				// Simple substring match allows catching things like ".go" or "BUILD"
 				if strings.Contains(filepath.Base(path), args.Query) || strings.Contains(path, args.Query) {
 					relPath := path
 					if root != "" {
@@ -400,12 +406,6 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 			return "", err
 		}
 
-		// git grep options:
-		// --line-number: show line numbers
-		// --column: show column numbers
-		// --extended-regexp: use extended regex
-		// --untracked: search untracked files as well
-		// -e: treat the next argument as the pattern, even if it starts with a hyphen
 		cmdArgs := []string{"grep", "--line-number", "--column", "--extended-regexp", "--untracked"}
 		if args.CaseInsensitive {
 			cmdArgs = append(cmdArgs, "-i")
@@ -418,15 +418,10 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 			cmdArgs = append(cmdArgs, "--", ".")
 		}
 
-		// Filter out lock files as they are usually not relevant and can be huge.
 		cmdArgs = appendLockFileExcludes(cmdArgs, ignoredLockFiles)
-
-		// Note: git grep already searches the working tree (unstaged changes) by default.
-		// We've also added --untracked to include newly created files.
 
 		out, err := runGit(ctx, root, cmdArgs...)
 		if err != nil {
-			// git grep returns exit code 1 if no matches are found.
 			var exitErr *exec.ExitError
 			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && len(out) == 0 {
 				return "No matches found.", nil

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -181,27 +181,34 @@ func registerLocalReadFile(r *Registry, root string) {
 // writeLine appends a line to sb, adding a newline if started is true.
 // Returns true if the output was truncated and no more lines should be written.
 func writeLine(sb *strings.Builder, line []byte, started bool, maxOutput int) bool {
+	prefix := ""
 	if started {
-		if sb.Len()+1+len(line) > maxOutput {
-			sb.WriteString("\n... (truncated)")
-			return true
+		prefix = "\n"
+	}
+
+	if sb.Len()+len(prefix)+len(line) > maxOutput {
+		// Calculate how much of the line (if any) we can still fit.
+		remain := maxOutput - sb.Len() - len(prefix)
+		if remain > 0 {
+			sb.WriteString(prefix)
+			sb.Write(line[:remain])
 		}
-		sb.WriteString("\n")
-	} else if len(line) > maxOutput {
-		sb.Write(line[:maxOutput])
 		sb.WriteString("\n... (truncated)")
 		return true
 	}
+
+	sb.WriteString(prefix)
 	sb.Write(line)
 	return false
 }
 
 type tailBuffer struct {
-	lines    [][]byte
-	limit    int
-	maxBytes int
-	curBytes int
-	count    int
+	lines     [][]byte
+	limit     int
+	maxBytes  int
+	curBytes  int
+	count     int
+	oldestIdx int // Points to the oldest non-nil line
 }
 
 func newTailBuffer(limit, maxBytes int) *tailBuffer {
@@ -221,19 +228,18 @@ func (b *tailBuffer) Add(line []byte) {
 	b.curBytes += len(line)
 	b.count++
 
-	// Reclaim memory if we exceed maxBytes by purging oldest lines
+	// Reclaim memory if we exceed maxBytes by purging the oldest non-nil lines.
+	// Since we add at b.count%limit, the oldest is usually near oldestIdx.
 	for b.curBytes > b.maxBytes {
-		purged := false
-		for i := 0; i < b.limit; i++ {
-			testIdx := (b.count + i) % b.limit
-			if b.lines[testIdx] != nil {
-				b.curBytes -= len(b.lines[testIdx])
-				b.lines[testIdx] = nil
-				purged = true
-				break
-			}
+		if b.lines[b.oldestIdx] != nil {
+			b.curBytes -= len(b.lines[b.oldestIdx])
+			b.lines[b.oldestIdx] = nil
 		}
-		if !purged {
+		b.oldestIdx = (b.oldestIdx + 1) % b.limit
+
+		// Safety: if we've purged everything and still over, break.
+		if b.curBytes <= 0 {
+			b.curBytes = 0
 			break
 		}
 	}

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -59,17 +59,15 @@ func registerLocalReadFile(r *Registry, root string) {
 			return "", err
 		}
 
-		const defaultMaxReadLength = 40000
-		const absoluteMaxReadLength = 40000
-		const absoluteMaxTailLines = 10000
-		const maxLineLength = 65536           // 64KB per line safety limit
-		const maxTailBufferBytes = 1024 * 1024 // 1MB limit for the circular buffer storage
+		const (
+			absoluteMaxReadLength = 40000
+			absoluteMaxTailLines  = 10000
+			maxLineLength         = 65536
+			maxTailBufferBytes    = 1024 * 1024
+		)
 
 		maxOutput := args.MaxReadLength
-		if maxOutput <= 0 {
-			maxOutput = defaultMaxReadLength
-		}
-		if maxOutput > absoluteMaxReadLength {
+		if maxOutput <= 0 || maxOutput > absoluteMaxReadLength {
 			maxOutput = absoluteMaxReadLength
 		}
 
@@ -78,7 +76,6 @@ func registerLocalReadFile(r *Registry, root string) {
 			if !filepath.IsAbs(fullPath) {
 				fullPath = filepath.Join(root, fullPath)
 			}
-			// Security: Ensure the path is within the root directory.
 			rel, err := filepath.Rel(root, fullPath)
 			if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
 				return "", fmt.Errorf("read_file failed: path %q is outside the workspace root", args.FilePath)
@@ -91,17 +88,16 @@ func registerLocalReadFile(r *Registry, root string) {
 		}
 		defer f.Close()
 
-		// If no line-limiting arguments are provided, return the whole file but only if it's small.
+		// If no line limits, read up to absoluteMaxReadLength.
+		// Use LimitReader to protect against infinite pseudo-files (e.g. /dev/zero).
 		if args.LineStart <= 0 && args.LineEnd <= 0 && args.TailLines <= 0 {
-			// Security: info.Size() is 0 for pseudo-files (e.g. /dev/zero).
-			// We use io.LimitReader to enforce a hard limit regardless of what Stat reports.
 			lr := io.LimitReader(f, int64(absoluteMaxReadLength)+1)
 			b, err := io.ReadAll(lr)
 			if err != nil {
 				return "", fmt.Errorf("read_file failed: %w", err)
 			}
 			if len(b) > absoluteMaxReadLength {
-				return "", fmt.Errorf("read_file failed: file is too large to read entirely. Use line_start/line_end or tail_lines")
+				return "", fmt.Errorf("read_file failed: file too large for whole-file read. Use line limits")
 			}
 			content := string(b)
 			if len(content) > maxOutput {
@@ -114,12 +110,12 @@ func registerLocalReadFile(r *Registry, root string) {
 		reader := bufio.NewReader(f)
 
 		if args.TailLines > 0 {
-			tailLines := args.TailLines
-			if tailLines > absoluteMaxTailLines {
-				tailLines = absoluteMaxTailLines
+			limit := args.TailLines
+			if limit > absoluteMaxTailLines {
+				limit = absoluteMaxTailLines
 			}
 
-			tb := newTailBuffer(tailLines, maxTailBufferBytes)
+			tb := newTailBuffer(limit, maxTailBufferBytes)
 			for {
 				line, err := readLimitedLine(reader, maxLineLength)
 				if len(line) == 0 && err != nil {
@@ -128,34 +124,20 @@ func registerLocalReadFile(r *Registry, root string) {
 					}
 					return "", fmt.Errorf("read_file failed while reading: %w", err)
 				}
-
 				tb.Add(line)
-
 				if err == io.EOF {
 					break
 				}
 			}
 
-			lines := tb.Lines()
-			for i, line := range lines {
-				if i > 0 {
-					if sb.Len()+1+len(line) > maxOutput {
-						sb.WriteString("\n... (truncated)")
-						break
-					}
-					sb.WriteString("\n")
-				} else if len(line) > maxOutput {
-					// Handle case where even the first line is too long
-					sb.Write(line[:maxOutput])
-					sb.WriteString("\n... (truncated)")
+			for i, line := range tb.Lines() {
+				if stop := writeLine(&sb, line, i > 0, maxOutput); stop {
 					break
 				}
-				sb.Write(line)
 			}
 			return sb.String(), nil
 		}
 
-		// Line range.
 		start := args.LineStart
 		if start <= 0 {
 			start = 1
@@ -175,22 +157,10 @@ func registerLocalReadFile(r *Registry, root string) {
 
 			currentLine++
 			if currentLine >= start && (end <= 0 || currentLine <= end) {
-				if started {
-					if sb.Len()+1+len(line) > maxOutput {
-						sb.WriteString("\n... (truncated)")
-						break
-					}
-					sb.WriteString("\n")
-				} else {
-					started = true
-					if len(line) > maxOutput {
-						// Handle case where even the first line is too long
-						sb.Write(line[:maxOutput])
-						sb.WriteString("\n... (truncated)")
-						break
-					}
+				if stop := writeLine(&sb, line, started, maxOutput); stop {
+					break
 				}
-				sb.Write(line)
+				started = true
 			}
 
 			if err != nil {
@@ -206,6 +176,24 @@ func registerLocalReadFile(r *Registry, root string) {
 
 		return sb.String(), nil
 	})
+}
+
+// writeLine appends a line to sb, adding a newline if started is true.
+// Returns true if the output was truncated and no more lines should be written.
+func writeLine(sb *strings.Builder, line []byte, started bool, maxOutput int) bool {
+	if started {
+		if sb.Len()+1+len(line) > maxOutput {
+			sb.WriteString("\n... (truncated)")
+			return true
+		}
+		sb.WriteString("\n")
+	} else if len(line) > maxOutput {
+		sb.Write(line[:maxOutput])
+		sb.WriteString("\n... (truncated)")
+		return true
+	}
+	sb.Write(line)
+	return false
 }
 
 type tailBuffer struct {
@@ -233,19 +221,19 @@ func (b *tailBuffer) Add(line []byte) {
 	b.curBytes += len(line)
 	b.count++
 
-	// Enforce maxBytes limit by purging oldest lines
+	// Reclaim memory if we exceed maxBytes by purging oldest lines
 	for b.curBytes > b.maxBytes {
-		found := false
+		purged := false
 		for i := 0; i < b.limit; i++ {
 			testIdx := (b.count + i) % b.limit
 			if b.lines[testIdx] != nil {
 				b.curBytes -= len(b.lines[testIdx])
 				b.lines[testIdx] = nil
-				found = true
+				purged = true
 				break
 			}
 		}
-		if !found {
+		if !purged {
 			break
 		}
 	}

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -63,6 +63,7 @@ func registerLocalReadFile(r *Registry, root string) {
 		const defaultMaxReadLength = 40000
 		const absoluteMaxReadLength = 40000
 		const absoluteMaxTailLines = 10000
+		const maxLineLength = 65536 // 64KB per line safety limit
 
 		maxOutput := args.MaxReadLength
 		if maxOutput <= 0 {
@@ -84,19 +85,23 @@ func registerLocalReadFile(r *Registry, root string) {
 			}
 		}
 
-		info, err := os.Stat(fullPath)
+		f, err := os.Open(fullPath)
 		if err != nil {
 			return "", fmt.Errorf("read_file failed: %w", err)
 		}
+		defer f.Close()
 
 		// If no line-limiting arguments are provided, return the whole file but only if it's small.
 		if args.LineStart <= 0 && args.LineEnd <= 0 && args.TailLines <= 0 {
-			if info.Size() > int64(absoluteMaxReadLength) {
-				return "", fmt.Errorf("read_file failed: file is too large (%d bytes) to read entirely. Use line_start/line_end or tail_lines", info.Size())
-			}
-			b, err := os.ReadFile(fullPath)
+			// Security: info.Size() is 0 for pseudo-files (e.g. /dev/zero).
+			// We use io.LimitReader to enforce a hard limit regardless of what Stat reports.
+			lr := io.LimitReader(f, int64(absoluteMaxReadLength)+1)
+			b, err := io.ReadAll(lr)
 			if err != nil {
 				return "", fmt.Errorf("read_file failed: %w", err)
+			}
+			if len(b) > absoluteMaxReadLength {
+				return "", fmt.Errorf("read_file failed: file is too large to read entirely. Use line_start/line_end or tail_lines")
 			}
 			content := string(b)
 			if len(content) > maxOutput {
@@ -104,12 +109,6 @@ func registerLocalReadFile(r *Registry, root string) {
 			}
 			return content, nil
 		}
-
-		f, err := os.Open(fullPath)
-		if err != nil {
-			return "", fmt.Errorf("read_file failed: %w", err)
-		}
-		defer f.Close()
 
 		var sb strings.Builder
 		reader := bufio.NewReader(f)
@@ -120,23 +119,19 @@ func registerLocalReadFile(r *Registry, root string) {
 				tailLines = absoluteMaxTailLines
 			}
 			// Circular buffer for tail lines.
-			// To reduce GC pressure, we'll try to be efficient, though ReadBytes still allocates.
 			buffer := make([][]byte, tailLines)
 			count := 0
 			totalBufferBytes := 0
 			const maxTailBufferBytes = 1024 * 1024 // 1MB limit for the circular buffer storage
 
 			for {
-				line, err := reader.ReadBytes('\n')
+				line, err := readLimitedLine(reader, maxLineLength)
 				if len(line) == 0 && err != nil {
 					if err == io.EOF {
 						break
 					}
 					return "", fmt.Errorf("read_file failed while reading: %w", err)
 				}
-
-				// Remove trailing newline for consistent storage.
-				line = bytes.TrimRight(line, "\r\n")
 
 				idx := count % tailLines
 				// Subtract old line size from total
@@ -148,8 +143,23 @@ func registerLocalReadFile(r *Registry, root string) {
 				totalBufferBytes += len(line)
 				count++
 
-				if totalBufferBytes > maxTailBufferBytes {
-					return "", fmt.Errorf("read_file failed: tail collection exceeded 1MB limit. Use a smaller tail_lines or line ranges")
+				// If we exceed 1MB, we must keep memory bounded.
+				// If the TOTAL bytes in the buffer exceeds 1MB, we'll start setting older entries to nil
+				// to reclaim memory until we are under the limit again.
+				for totalBufferBytes > maxTailBufferBytes {
+					oldestIdx := (count - tailLines)
+					if oldestIdx < 0 {
+						oldestIdx = 0
+					} else {
+						oldestIdx = oldestIdx % tailLines
+					}
+
+					if buffer[oldestIdx] != nil {
+						totalBufferBytes -= len(buffer[oldestIdx])
+						buffer[oldestIdx] = nil
+					} else {
+						break
+					}
 				}
 
 				if err == io.EOF {
@@ -166,14 +176,16 @@ func registerLocalReadFile(r *Registry, root string) {
 
 			for i := 0; i < numToPrint; i++ {
 				line := buffer[(startIdx+i)%tailLines]
-				if i > 0 {
+				if line == nil {
+					continue
+				}
+				if sb.Len() > 0 {
 					if sb.Len()+1+len(line) > maxOutput {
 						sb.WriteString("\n... (truncated)")
 						break
 					}
 					sb.WriteString("\n")
 				} else if len(line) > maxOutput {
-					// Handle case where even the first line is too long
 					sb.Write(line[:maxOutput])
 					sb.WriteString("\n... (truncated)")
 					break
@@ -193,7 +205,7 @@ func registerLocalReadFile(r *Registry, root string) {
 		currentLine := 0
 		started := false
 		for {
-			line, err := reader.ReadBytes('\n')
+			line, err := readLimitedLine(reader, maxLineLength)
 			if len(line) == 0 && err != nil {
 				if err == io.EOF {
 					break
@@ -203,7 +215,6 @@ func registerLocalReadFile(r *Registry, root string) {
 
 			currentLine++
 			if currentLine >= start && (end <= 0 || currentLine <= end) {
-				line = bytes.TrimRight(line, "\r\n")
 				if started {
 					if sb.Len()+1+len(line) > maxOutput {
 						sb.WriteString("\n... (truncated)")
@@ -213,7 +224,6 @@ func registerLocalReadFile(r *Registry, root string) {
 				} else {
 					started = true
 					if len(line) > maxOutput {
-						// Handle case where even the first line is too long
 						sb.Write(line[:maxOutput])
 						sb.WriteString("\n... (truncated)")
 						break
@@ -235,6 +245,28 @@ func registerLocalReadFile(r *Registry, root string) {
 
 		return sb.String(), nil
 	})
+}
+
+// readLimitedLine reads up to maxLineLength bytes or until a newline.
+// It trims the trailing newline.
+func readLimitedLine(r *bufio.Reader, limit int) ([]byte, error) {
+	line, err := r.ReadBytes('\n')
+	if len(line) > limit {
+		line = line[:limit]
+		// If we truncated, we need to skip the rest of the line until the next \n
+		if err == nil {
+			for {
+				b, err2 := r.ReadByte()
+				if err2 != nil {
+					return line, err2
+				}
+				if b == '\n' {
+					break
+				}
+			}
+		}
+	}
+	return bytes.TrimRight(line, "\r\n"), err
 }
 
 func registerLocalGlobFiles(r *Registry, root string) {

--- a/tools/local_tools_safety_test.go
+++ b/tools/local_tools_safety_test.go
@@ -63,7 +63,9 @@ func TestLocalReadFile_SafetyLimits(t *testing.T) {
 			t.Fatal(err)
 		}
 		for i := 0; i < 20000; i++ {
-			f.WriteString("line\n")
+			if _, err := f.WriteString("line\n"); err != nil {
+				t.Fatal(err)
+			}
 		}
 		f.Close()
 

--- a/tools/local_tools_safety_test.go
+++ b/tools/local_tools_safety_test.go
@@ -1,0 +1,151 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/menny/cassandra/llm"
+)
+
+func TestLocalReadFile_SafetyLimits(t *testing.T) {
+	r := NewRegistry()
+	registerLocalReadFile(r, "")
+
+	tmpDir := t.TempDir()
+
+	t.Run("read whole file > 40000 bytes fails", func(t *testing.T) {
+		largeFile := filepath.Join(tmpDir, "large_whole.txt")
+		content := strings.Repeat("a", 40001)
+		if err := os.WriteFile(largeFile, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		args, _ := json.Marshal(map[string]any{"file_path": largeFile})
+		_, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err == nil {
+			t.Error("expected error when reading file > 40000 bytes without line limits, but got nil")
+		} else if !strings.Contains(err.Error(), "too large") {
+			t.Errorf("expected 'too large' error, got: %v", err)
+		}
+	})
+
+	t.Run("read whole file <= 40000 bytes succeeds", func(t *testing.T) {
+		smallFile := filepath.Join(tmpDir, "small_whole.txt")
+		content := strings.Repeat("a", 40000)
+		if err := os.WriteFile(smallFile, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		args, _ := json.Marshal(map[string]any{"file_path": smallFile})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+		if len(result) != 40000 {
+			t.Errorf("expected 40000 bytes, got %d", len(result))
+		}
+	})
+
+	t.Run("tail_lines is clamped to 10000", func(t *testing.T) {
+		largeTailFile := filepath.Join(tmpDir, "large_tail.txt")
+		f, err := os.Create(largeTailFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 20000; i++ {
+			f.WriteString("line\n")
+		}
+		f.Close()
+
+		args, _ := json.Marshal(map[string]any{"file_path": largeTailFile, "tail_lines": 1000000})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// The result should have at most 10000 lines.
+		// 10000 lines + possibly a truncation message if it hit byte limit too, 
+		// but here 10000 lines * 5 bytes ("line\n") = 50KB, which is > 40KB.
+		// So it should be limited by 40KB.
+		if len(result) > 41000 {
+			t.Errorf("result too large: %d", len(result))
+		}
+	})
+
+	t.Run("handles very long lines gracefully", func(t *testing.T) {
+		longLineFile := filepath.Join(tmpDir, "long_line.txt")
+		// Scanner default limit is 64KB. Let's create a line longer than that.
+		content := strings.Repeat("a", 70000) + "\n"
+		if err := os.WriteFile(longLineFile, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		args, _ := json.Marshal(map[string]any{"file_path": longLineFile, "line_start": 1})
+		_, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		// It might fail with "token too long" or it might succeed if Scanner is configured differently.
+		if err != nil && !strings.Contains(err.Error(), "token too long") {
+			t.Errorf("expected 'token too long' error, got: %v", err)
+		}
+	})
+
+	t.Run("output truncated at 40000 bytes", func(t *testing.T) {
+		overflowFile := filepath.Join(tmpDir, "overflow.txt")
+		content := strings.Repeat("a\n", 30000) // 60,000 bytes
+		if err := os.WriteFile(overflowFile, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		args, _ := json.Marshal(map[string]any{"file_path": overflowFile, "line_start": 1})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result) > 41000 {
+			t.Errorf("output too large: %d bytes", len(result))
+		}
+		if !strings.Contains(result, "truncated") {
+			t.Error("expected truncation message in output")
+		}
+	})
+
+	t.Run("respects max_read_length", func(t *testing.T) {
+		smallFile := filepath.Join(tmpDir, "max_len.txt")
+		content := "1234567890"
+		if err := os.WriteFile(smallFile, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		args, _ := json.Marshal(map[string]any{"file_path": smallFile, "max_read_length": 5})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasPrefix(result, "12345") {
+			t.Errorf("expected prefix 12345, got %q", result)
+		}
+		if !strings.Contains(result, "truncated") {
+			t.Error("expected truncation message in output")
+		}
+	})
+}

--- a/tools/local_tools_safety_test.go
+++ b/tools/local_tools_safety_test.go
@@ -20,7 +20,7 @@ func TestLocalReadFile_SafetyLimits(t *testing.T) {
 	t.Run("read whole file > 40000 bytes fails", func(t *testing.T) {
 		largeFile := filepath.Join(tmpDir, "large_whole.txt")
 		content := strings.Repeat("a", 40001)
-		if err := os.WriteFile(largeFile, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(largeFile, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -39,7 +39,7 @@ func TestLocalReadFile_SafetyLimits(t *testing.T) {
 	t.Run("read whole file <= 40000 bytes succeeds", func(t *testing.T) {
 		smallFile := filepath.Join(tmpDir, "small_whole.txt")
 		content := strings.Repeat("a", 40000)
-		if err := os.WriteFile(smallFile, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(smallFile, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -76,7 +76,7 @@ func TestLocalReadFile_SafetyLimits(t *testing.T) {
 			t.Fatal(err)
 		}
 		// The result should have at most 10000 lines.
-		// 10000 lines + possibly a truncation message if it hit byte limit too, 
+		// 10000 lines + possibly a truncation message if it hit byte limit too,
 		// but here 10000 lines * 5 bytes ("line\n") = 50KB, which is > 40KB.
 		// So it should be limited by 40KB.
 		if len(result) > 41000 {
@@ -86,27 +86,54 @@ func TestLocalReadFile_SafetyLimits(t *testing.T) {
 
 	t.Run("handles very long lines gracefully", func(t *testing.T) {
 		longLineFile := filepath.Join(tmpDir, "long_line.txt")
-		// Scanner default limit is 64KB. Let's create a line longer than that.
+		// Create a line longer than the previous 64KB Scanner limit.
 		content := strings.Repeat("a", 70000) + "\n"
-		if err := os.WriteFile(longLineFile, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(longLineFile, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
 		args, _ := json.Marshal(map[string]any{"file_path": longLineFile, "line_start": 1})
-		_, err := r.HandleCall(context.Background(), llm.ToolCall{
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
 			Name:      "read_file",
 			Arguments: string(args),
 		})
-		// It might fail with "token too long" or it might succeed if Scanner is configured differently.
-		if err != nil && !strings.Contains(err.Error(), "token too long") {
-			t.Errorf("expected 'token too long' error, got: %v", err)
+		if err != nil {
+			t.Fatalf("expected success with long line, got: %v", err)
+		}
+		// It should be truncated to maxOutput (40000).
+		if len(result) > 41000 {
+			t.Errorf("result too large: %d", len(result))
+		}
+		if !strings.Contains(result, "truncated") {
+			t.Error("expected truncation message")
+		}
+	})
+
+	t.Run("preserves empty lines in range", func(t *testing.T) {
+		emptyLinesFile := filepath.Join(tmpDir, "empty_lines.txt")
+		content := "\nline 2\n\nline 4\n"
+		if err := os.WriteFile(emptyLinesFile, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		args, _ := json.Marshal(map[string]any{"file_path": emptyLinesFile, "line_start": 1})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := "\nline 2\n\nline 4"
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
 		}
 	})
 
 	t.Run("output truncated at 40000 bytes", func(t *testing.T) {
 		overflowFile := filepath.Join(tmpDir, "overflow.txt")
 		content := strings.Repeat("a\n", 30000) // 60,000 bytes
-		if err := os.WriteFile(overflowFile, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(overflowFile, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -129,7 +156,7 @@ func TestLocalReadFile_SafetyLimits(t *testing.T) {
 	t.Run("respects max_read_length", func(t *testing.T) {
 		smallFile := filepath.Join(tmpDir, "max_len.txt")
 		content := "1234567890"
-		if err := os.WriteFile(smallFile, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(smallFile, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
This PR addresses the OOM vulnerability in the read_file tool (issue #77) by implementing safety limits and a memory-efficient streaming approach.

### Key Changes:
- Safety Limits:
    - Unified the whole-file and output limit to 40KB.
    - Added a max_read_length argument for adjustable output sizing.
    - Clamped tail_lines to a maximum of 10,000 lines.
- Memory Efficiency:
    - Switched from os.ReadFile to bufio.Reader for all line-based reads, enabling support for arbitrarily long lines.
    - Implemented a circular buffer for tail_lines with a 1MB memory cap to ensure O(1) memory usage during collection.
- Robustness:
    - Fixed range-based reading to correctly preserve leading and intermediate empty lines.
    - Improved truncation logic to handle edge cases like very long first lines.
- Testing:
    - Added comprehensive safety regression tests in tools/local_tools_safety_test.go.
    - Updated tools/BUILD.bazel to include the new tests.

Verified with bazel test //tools:tools_test.