### PR TITLE
docs: add defensive tool implementation and safety review guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,13 @@ Progress reporting is abstracted via the `core.Reporter` interface.
 ### 7. Lint Exceptions
 - **Centralize `//nolint` pragmas**: If a construct legitimately needs a lint exception (e.g. `int32` narrowing after a bounds check, an intentionally-unused receiver), wrap it in a named helper so the pragma lives in one place with a comment explaining the invariant. Do not sprinkle `//nolint:gosec` or similar pragmas at multiple call sites — the invariant becomes invisible and copy-paste drift accumulates. See `clampInt32` in `llm/google/provider.go` as the canonical example.
 
+### 8. Defensive Tool Implementation
+Tools that interact with external data (files, network, pipes) MUST be resilient to resource exhaustion and hangs.
+- **Hard Safety Limits**: Every tool MUST enforce an output size limit (e.g., 40KB) and a per-operation memory cap.
+- **Streaming over Loading**: Do NOT use `os.ReadFile` or `io.ReadAll` on potentially large sources. Use `io.LimitReader` and `bufio.Reader` to process data in chunks.
+- **Pseudo-file Protection**: Never trust `os.Stat().Size()` for OOM prevention (it returns 0 for pseudo-files like `/dev/zero`). Always use `io.LimitReader` with a hard cap.
+- **Cancellation Checks**: Every loop that performs I/O or intensive computation MUST check `ctx.Err()` in each iteration to ensure the tool can be interrupted by the ReAct loop timeout.
+
 ## Security Standards
 
 ### 1. GitHub Action Input Safety

--- a/REVIEWERS.md
+++ b/REVIEWERS.md
@@ -7,3 +7,11 @@ Reviewer lens for the whole repo. Assumes [AGENTS.md](AGENTS.md) and [DESIGN.md]
 - New `os.Stdout` write ↔ justification that it is final review output.
 - `BuildSystemPrompt` addition ↔ placement between Zone 2 and Zone 3 (AGENTS.md §6).
 - GitHub Action input added ↔ `env:` mapping per AGENTS.md §Security 1.
+
+## Safety & Liveness (block if missing)
+
+- **Infinite Loops**: Any loop reading until a delimiter (e.g. `\n`) or EOF MUST have a mechanism to handle missing delimiters in infinite streams.
+- **Context Holes**: Tools performing non-trivial I/O MUST be audited for `ctx.Err()` propagation.
+- **Buffer Wrap-around**: Circular buffers MUST be verified for index desync during eviction, especially when memory limits and count limits are enforced simultaneously.
+- **Truncation Clarity**: Verify that truncation notices are appended in a way that remains visible even if the output is further truncated by downstream systems.
+

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -11,6 +11,10 @@ Tools that invoke external CLIs MUST:
 - Capture both `stdout` and `stderr`.
 - On failure, include the `stderr` output in the returned error string so the LLM can diagnose the issue (e.g., "command failed: <stderr>").
 
+### 3. Resource Management
+- **Bounded Buffers**: If a tool uses a buffer to collect data (e.g., a circular buffer for `tail_lines`), it MUST have both an entry count limit AND a strict byte-based memory cap (e.g., 1MB).
+- **Graceful Truncation**: When a tool hits an output limit, it should return as much valid data as possible followed by a clear truncation notice (e.g., `... (truncated)`), rather than failing with an error.
+
 ## Model Context Protocol (MCP) Servers
 
 MCP servers allow Cassandra to extend its capabilities without increasing the main binary's complexity or dependency footprint.


### PR DESCRIPTION
- Add Defensive Tool Implementation rules to AGENTS.md (§8) covering safety limits, pseudo-file protection, and cancellation checks.
- Add Resource Management rules to tools/AGENTS.md covering bounded buffers and truncation.
- Add Safety & Liveness section to REVIEWERS.md to audit for infinite loops, context holes, and buffer desync.