### PR TITLE
security: prevent workspace escape via symlinks in local tools (#76)

### DIFF
--- a/core/eval/BUILD.bazel
+++ b/core/eval/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//core/config",
         "//core/prompts",
         "//llm",
+        "//util",
     ],
 )
 

--- a/core/eval/sandbox.go
+++ b/core/eval/sandbox.go
@@ -206,7 +206,7 @@ func extractTarGz(gzipPath, dst string) error {
 			}
 
 			safeLinkname := header.Linkname
-			if !filepath.IsAbs(linkTarget) {
+			if !filepath.IsAbs(header.Linkname) {
 				// Recompute the relative linkname from the physical directory
 				// to neutralize any physical path traversal bypasses.
 				safeLinkname, err = filepath.Rel(physicalDir, safeAbsTarget)

--- a/core/eval/sandbox.go
+++ b/core/eval/sandbox.go
@@ -199,15 +199,26 @@ func extractTarGz(gzipPath, dst string) error {
 				linkTarget = filepath.Join(physicalDir, linkTarget)
 			}
 
-			// Validate the resolved target.
-			if _, err := util.ValidatePathInRoot(dst, linkTarget); err != nil {
+			// Validate the resolved target and capture the safe physical path.
+			safeAbsTarget, err := util.ValidatePathInRoot(dst, linkTarget)
+			if err != nil {
 				return fmt.Errorf("malicious symlink target detected: %w", err)
+			}
+
+			safeLinkname := header.Linkname
+			if !filepath.IsAbs(linkTarget) {
+				// Recompute the relative linkname from the physical directory
+				// to neutralize any physical path traversal bypasses.
+				safeLinkname, err = filepath.Rel(physicalDir, safeAbsTarget)
+				if err != nil {
+					return fmt.Errorf("failed to compute safe linkname: %w", err)
+				}
 			}
 
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return err
 			}
-			if err := os.Symlink(header.Linkname, target); err != nil {
+			if err := os.Symlink(safeLinkname, target); err != nil {
 				return err
 			}
 		}

--- a/core/eval/sandbox.go
+++ b/core/eval/sandbox.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/menny/cassandra/util"
 )
 
 // Sandbox provides a high-fidelity git environment for evaluating the agent.
@@ -157,10 +159,9 @@ func extractTarGz(gzipPath, dst string) error {
 
 		target := filepath.Join(dst, header.Name)
 
-		// Security: Prevent "Tar Slip" (directory traversal)
-		rel, err := filepath.Rel(dst, target)
-		if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
-			return fmt.Errorf("tar slip detected: %s", header.Name)
+		// Security: Prevent "Tar Slip" (directory traversal and symlink escape)
+		if _, err := util.ValidatePathInRoot(dst, header.Name); err != nil {
+			return fmt.Errorf("tar slip detected: %w", err)
 		}
 
 		switch header.Typeflag {
@@ -182,6 +183,25 @@ func extractTarGz(gzipPath, dst string) error {
 				return err
 			}
 			if err := f.Close(); err != nil {
+				return err
+			}
+		case tar.TypeSymlink:
+			// Security: Validate that the symlink target is also within the root.
+			linkTarget := header.Linkname
+			if !filepath.IsAbs(linkTarget) {
+				// Relative targets are relative to the symlink's location.
+				linkTarget = filepath.Join(filepath.Dir(header.Name), linkTarget)
+			}
+			// Use the logical check for the target since it doesn't have to exist yet.
+			// ValidatePathInRoot will handle the logic.
+			if _, err := util.ValidatePathInRoot(dst, linkTarget); err != nil {
+				return fmt.Errorf("malicious symlink target detected: %w", err)
+			}
+
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			if err := os.Symlink(header.Linkname, target); err != nil {
 				return err
 			}
 		}

--- a/core/eval/sandbox.go
+++ b/core/eval/sandbox.go
@@ -187,13 +187,19 @@ func extractTarGz(gzipPath, dst string) error {
 			}
 		case tar.TypeSymlink:
 			// Security: Validate that the symlink target is also within the root.
+			// Use the physical directory to resolve relative targets to prevent trampoline escapes.
+			physicalDir, err := util.ValidatePathInRoot(dst, filepath.Dir(header.Name))
+			if err != nil {
+				return fmt.Errorf("invalid symlink directory: %w", err)
+			}
+
 			linkTarget := header.Linkname
 			if !filepath.IsAbs(linkTarget) {
-				// Relative targets are relative to the symlink's location.
-				linkTarget = filepath.Join(filepath.Dir(header.Name), linkTarget)
+				// Relative targets are relative to the symlink's physical location.
+				linkTarget = filepath.Join(physicalDir, linkTarget)
 			}
-			// Use the logical check for the target since it doesn't have to exist yet.
-			// ValidatePathInRoot will handle the logic.
+
+			// Validate the resolved target.
 			if _, err := util.ValidatePathInRoot(dst, linkTarget); err != nil {
 				return fmt.Errorf("malicious symlink target detected: %w", err)
 			}

--- a/core/eval/sandbox_test.go
+++ b/core/eval/sandbox_test.go
@@ -174,6 +174,58 @@ func TestExtractTarGz_SymlinkSlip(t *testing.T) {
 	}
 }
 
+func TestExtractTarGz_BrokenSymlinkSlip(t *testing.T) {
+	// 1. Setup a clean destination and a parent directory we want to protect
+	parentDir := t.TempDir()
+	dstDir := filepath.Join(parentDir, "sandbox")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Create a broken symlink in the destination that points to a non-existent path outside
+	linkPath := filepath.Join(dstDir, "broken_link")
+	if err := os.Symlink(filepath.Join(parentDir, "nonexistent"), linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. Create a tarball that attempts to write through that broken symlink
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	content := "unauthorized access"
+	hdr := &tar.Header{
+		Name: "broken_link/evil.txt",
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+
+	tw.Close()
+	gw.Close()
+
+	tarPath := filepath.Join(parentDir, "broken_symlink.tar.gz")
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. Attempt extraction
+	err := extractTarGz(tarPath, dstDir)
+
+	// 5. Assert failure
+	if err == nil {
+		t.Error("Expected error for broken symlink escape tarball, but got nil")
+	}
+	if !strings.Contains(err.Error(), "broken symlink") {
+		t.Errorf("Expected 'broken symlink' error, got: %v", err)
+	}
+}
+
 func TestExtractTarGz_SymlinkTargetSlip(t *testing.T) {
 	// 1. Setup a clean destination and a parent directory we want to protect
 	parentDir := t.TempDir()

--- a/core/eval/sandbox_test.go
+++ b/core/eval/sandbox_test.go
@@ -108,6 +108,115 @@ func TestExtractTarGz_TarSlip(t *testing.T) {
 	}
 }
 
+func TestExtractTarGz_SymlinkSlip(t *testing.T) {
+	// 1. Setup a clean destination and a parent directory we want to protect
+	parentDir := t.TempDir()
+	dstDir := filepath.Join(parentDir, "sandbox")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resolve symlinks for base dirs because of macOS /var -> /private/var
+	if resolved, err := filepath.EvalSymlinks(parentDir); err == nil {
+		parentDir = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(dstDir); err == nil {
+		dstDir = resolved
+	}
+
+	// 2. Create a symlink in the destination that points outside
+	linkPath := filepath.Join(dstDir, "malicious_link")
+	if err := os.Symlink(parentDir, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. Create a tarball that attempts to write through that symlink
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	content := "unauthorized access"
+	hdr := &tar.Header{
+		Name: "malicious_link/evil.txt",
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+
+	tw.Close()
+	gw.Close()
+
+	tarPath := filepath.Join(parentDir, "malicious_symlink.tar.gz")
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. Attempt extraction
+	err := extractTarGz(tarPath, dstDir)
+
+	// 5. Assert failure
+	if err == nil {
+		t.Fatalf("Expected error for symlink escape tarball, but got nil")
+	}
+	if !strings.Contains(err.Error(), "tar slip detected") {
+		t.Errorf("Expected 'tar slip detected' error, got: %v", err)
+	}
+
+	// 6. Final safety check
+	evilFilePath := filepath.Join(parentDir, "evil.txt")
+	if _, err := os.Stat(evilFilePath); err == nil {
+		t.Errorf("CRITICAL SECURITY FAILURE: Malicious file was extracted to %s via symlink", evilFilePath)
+	}
+}
+
+func TestExtractTarGz_SymlinkTargetSlip(t *testing.T) {
+	// 1. Setup a clean destination and a parent directory we want to protect
+	parentDir := t.TempDir()
+	dstDir := filepath.Join(parentDir, "sandbox")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Create a tarball containing a symlink with a malicious target
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	hdr := &tar.Header{
+		Name:     "malicious_symlink",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "/etc/shadow", // Malicious absolute target
+		Mode:     0o644,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+
+	tw.Close()
+	gw.Close()
+
+	tarPath := filepath.Join(parentDir, "malicious_target.tar.gz")
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. Attempt extraction
+	err := extractTarGz(tarPath, dstDir)
+
+	// 4. Assert failure
+	if err == nil {
+		t.Error("Expected error for malicious symlink target, but got nil")
+	}
+	if !strings.Contains(err.Error(), "malicious symlink target detected") {
+		t.Errorf("Expected 'malicious symlink target detected' error, got: %v", err)
+	}
+}
+
 func TestExtractTarGz_Truncation(t *testing.T) {
 	tmpDir := t.TempDir()
 	dstDir := filepath.Join(tmpDir, "dst")

--- a/core/eval/sandbox_test.go
+++ b/core/eval/sandbox_test.go
@@ -269,6 +269,70 @@ func TestExtractTarGz_SymlinkTargetSlip(t *testing.T) {
 	}
 }
 
+func TestExtractTarGz_SymlinkTrampolineSlip(t *testing.T) {
+	// 1. Setup a clean destination and a parent directory we want to protect
+	parentDir := t.TempDir()
+	dstDir := filepath.Join(parentDir, "sandbox")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Create a tarball with a symlink trampoline exploit
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	// Entry 1: Symlink "a" -> "." (trampoline)
+	hdr := &tar.Header{
+		Name:     "a",
+		Typeflag: tar.TypeSymlink,
+		Linkname: ".",
+		Mode:     0o755,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+
+	// Entry 2: Symlink "a/b/c/evil" -> "../../../etc/passwd"
+	// Lexically: a/b/c/evil -> etc/passwd (Safe)
+	// Physically: a is root, so a/b/c/evil is actually ./b/c/evil.
+	// Going up 3 levels from ./b/c/evil reaches parentDir/../../etc/passwd (Escape!)
+	hdr = &tar.Header{
+		Name:     "a/b/c/evil",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "../../../etc/passwd",
+		Mode:     0o644,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+
+	tw.Close()
+	gw.Close()
+
+	tarPath := filepath.Join(parentDir, "trampoline.tar.gz")
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. Attempt extraction
+	err := extractTarGz(tarPath, dstDir)
+
+	// 4. Assert failure
+	if err == nil {
+		t.Fatalf("Expected error for trampoline symlink escape, but got nil")
+	}
+	if !strings.Contains(err.Error(), "malicious symlink target detected") {
+		t.Errorf("Expected 'malicious symlink target detected' error, got: %v", err)
+	}
+
+	// 5. Final safety check
+	evilFilePath := filepath.Join(parentDir, "etc/passwd")
+	if _, err := os.Stat(evilFilePath); err == nil {
+		t.Errorf("CRITICAL SECURITY FAILURE: Malicious file was pointed to outside sandbox via trampoline")
+	}
+}
+
 func TestExtractTarGz_Truncation(t *testing.T) {
 	tmpDir := t.TempDir()
 	dstDir := filepath.Join(tmpDir, "dst")

--- a/core/eval/sandbox_test.go
+++ b/core/eval/sandbox_test.go
@@ -219,7 +219,7 @@ func TestExtractTarGz_BrokenSymlinkSlip(t *testing.T) {
 
 	// 5. Assert failure
 	if err == nil {
-		t.Error("Expected error for broken symlink escape tarball, but got nil")
+		t.Fatalf("Expected error for broken symlink escape tarball, but got nil")
 	}
 	if !strings.Contains(err.Error(), "broken symlink") {
 		t.Errorf("Expected 'broken symlink' error, got: %v", err)
@@ -262,7 +262,7 @@ func TestExtractTarGz_SymlinkTargetSlip(t *testing.T) {
 
 	// 4. Assert failure
 	if err == nil {
-		t.Error("Expected error for malicious symlink target, but got nil")
+		t.Fatalf("Expected error for malicious symlink target, but got nil")
 	}
 	if !strings.Contains(err.Error(), "malicious symlink target detected") {
 		t.Errorf("Expected 'malicious symlink target detected' error, got: %v", err)

--- a/core/eval/sandbox_test.go
+++ b/core/eval/sandbox_test.go
@@ -333,6 +333,70 @@ func TestExtractTarGz_SymlinkTrampolineSlip(t *testing.T) {
 	}
 }
 
+func TestExtractTarGz_SymlinkTOCTOUSlip(t *testing.T) {
+	// 1. Setup a clean destination and a parent directory we want to protect
+	parentDir := t.TempDir()
+	dstDir := filepath.Join(parentDir, "sandbox")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Create a tarball with a TOCTOU symlink exploit
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	// Entry 1: Symlink "y" -> "." (inside root)
+	hdr := &tar.Header{
+		Name:     "y",
+		Typeflag: tar.TypeSymlink,
+		Linkname: ".",
+		Mode:     0o755,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+
+	// Entry 2: Symlink "evil" -> "y/../../etc/passwd"
+	// Lexical Join: y/../../etc/passwd -> ../etc/passwd (relative to dstDir) -> parentDir/etc/passwd (Escape!)
+	// BUT, filepath.Clean (inside Join/Validate) sees y/../../etc/passwd and makes it ../etc/passwd.
+	// If the original "y/../../etc/passwd" is used in os.Symlink, and "y" is physically ".",
+	// then "y/../../etc/passwd" physically resolves to "../../etc/passwd" from dstDir -> parentDir/../etc/passwd -> /etc/passwd (Escape!)
+	hdr = &tar.Header{
+		Name:     "evil",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "y/../../etc/passwd",
+		Mode:     0o644,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+
+	tw.Close()
+	gw.Close()
+
+	tarPath := filepath.Join(parentDir, "toctou.tar.gz")
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. Attempt extraction
+	err := extractTarGz(tarPath, dstDir)
+
+	// 4. Verify outcome
+	// The validation should fail because even after lexical cleaning, "y/../../etc/passwd" becomes "../etc/passwd"
+	// which is outside the root.
+	if err == nil {
+		t.Fatalf("Expected error for TOCTOU symlink escape, but got nil")
+	}
+	if !strings.Contains(err.Error(), "malicious symlink target detected") {
+		t.Errorf("Expected 'malicious symlink target detected' error, got: %v", err)
+	}
+
+	// Verify the symlink was NOT created or if it was, it doesn't escape.
+	// (Our current logic fails BEFORE creation).
+}
+
 func TestExtractTarGz_Truncation(t *testing.T) {
 	tmpDir := t.TempDir()
 	dstDir := filepath.Join(tmpDir, "dst")

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/menny/cassandra/llm"
+	"github.com/menny/cassandra/util"
 )
 
 func registerLocalReadFile(r *Registry, root string) {
@@ -73,12 +74,10 @@ func registerLocalReadFile(r *Registry, root string) {
 
 		fullPath := args.FilePath
 		if root != "" {
-			if !filepath.IsAbs(fullPath) {
-				fullPath = filepath.Join(root, fullPath)
-			}
-			rel, err := filepath.Rel(root, fullPath)
-			if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
-				return "", fmt.Errorf("read_file failed: path %q is outside the workspace root", args.FilePath)
+			var err error
+			fullPath, err = util.ValidatePathInRoot(root, args.FilePath)
+			if err != nil {
+				return "", fmt.Errorf("read_file failed: %w", err)
 			}
 		}
 
@@ -334,12 +333,10 @@ func registerLocalGlobFiles(r *Registry, root string) {
 			dir = "."
 		}
 		if root != "" {
-			if !filepath.IsAbs(dir) {
-				dir = filepath.Join(root, dir)
-			}
-			rel, err := filepath.Rel(root, dir)
-			if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
-				return "", fmt.Errorf("glob_files failed: path %q is outside the workspace root", args.Directory)
+			var err error
+			dir, err = util.ValidatePathInRoot(root, dir)
+			if err != nil {
+				return "", fmt.Errorf("glob_files failed: %w", err)
 			}
 		}
 
@@ -413,7 +410,15 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 		cmdArgs = append(cmdArgs, "-e", args.Query)
 
 		if args.Directory != "" {
-			cmdArgs = append(cmdArgs, "--", args.Directory)
+			dir := args.Directory
+			if root != "" {
+				var err error
+				dir, err = util.ValidatePathInRoot(root, args.Directory)
+				if err != nil {
+					return "", fmt.Errorf("grep_files failed: %w", err)
+				}
+			}
+			cmdArgs = append(cmdArgs, "--", dir)
 		} else {
 			cmdArgs = append(cmdArgs, "--", ".")
 		}

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -346,13 +346,13 @@ func registerLocalGlobFiles(r *Registry, root string) {
 				return nil
 			}
 			if !d.IsDir() {
-				if strings.Contains(filepath.Base(path), args.Query) || strings.Contains(path, args.Query) {
-					relPath := path
-					if root != "" {
-						if rel, err := filepath.Rel(root, path); err == nil {
-							relPath = rel
-						}
+				relPath := path
+				if root != "" {
+					if rel, err := filepath.Rel(root, path); err == nil {
+						relPath = rel
 					}
+				}
+				if strings.Contains(filepath.Base(relPath), args.Query) || strings.Contains(relPath, args.Query) {
 					matches = append(matches, relPath)
 				}
 			}
@@ -416,6 +416,14 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 				dir, err = util.ValidatePathInRoot(root, args.Directory)
 				if err != nil {
 					return "", fmt.Errorf("grep_files failed: %w", err)
+				}
+				// Convert back to relative path for Git consistency and relative output.
+				// We only use the relative path if it's clean and doesn't escape.
+				if rel, err := filepath.Rel(root, dir); err == nil && !strings.HasPrefix(rel, "..") {
+					dir = rel
+				} else if !filepath.IsAbs(args.Directory) {
+					// Fallback to original input if it was relative
+					dir = args.Directory
 				}
 			}
 			cmdArgs = append(cmdArgs, "--", dir)

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -342,6 +342,9 @@ func registerLocalGlobFiles(r *Registry, root string) {
 
 		var matches []string
 		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			if err != nil {
 				return nil
 			}

--- a/tools/local_tools_safety_test.go
+++ b/tools/local_tools_safety_test.go
@@ -178,3 +178,39 @@ func TestLocalReadFile_SafetyLimits(t *testing.T) {
 		}
 	})
 }
+
+func TestLocalReadFile_SymlinkEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	workspaceRoot := filepath.Join(tmpDir, "workspace")
+	if err := os.Mkdir(workspaceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry()
+	RegisterLocalTools(r, workspaceRoot, nil, "")
+
+	// Create a file OUTSIDE the workspace root
+	secretFile := filepath.Join(tmpDir, "secret.txt")
+	secretContent := "SENSITIVE SYSTEM DATA"
+	if err := os.WriteFile(secretFile, []byte(secretContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink INSIDE the workspace root pointing OUTSIDE
+	linkPath := filepath.Join(workspaceRoot, "malicious_link")
+	if err := os.Symlink(secretFile, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("symlink escape should be blocked", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"file_path": "malicious_link"})
+		_, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "read_file",
+			Arguments: string(args),
+		})
+
+		if err == nil {
+			t.Error("Security Vulnerability: read_file successfully read content through a symlink escaping the workspace root")
+		}
+	})
+}

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/menny/cassandra/llm"
 )
@@ -38,6 +39,11 @@ func (r *Registry) HandleCall(ctx context.Context, tc llm.ToolCall) (string, err
 }
 
 func RegisterLocalTools(r *Registry, root string, ignoredLockFiles []string, wishlistDir string) {
+	if root != "" {
+		if resolved, err := filepath.EvalSymlinks(root); err == nil {
+			root = resolved
+		}
+	}
 	registerLocalReadFile(r, root)
 	registerLocalGlobFiles(r, root)
 	registerLocalGrepFiles(r, root, ignoredLockFiles)

--- a/util/fs.go
+++ b/util/fs.go
@@ -98,6 +98,12 @@ func ValidatePathInRoot(root, path string) (string, error) {
 			return "", fmt.Errorf("failed to resolve symlinks for %q: %w", curr, err)
 		}
 
+		// Handle potential broken symlinks. EvalSymlinks fails with IsNotExist
+		// if a symlink exists but its target does not.
+		if info, lerr := os.Lstat(curr); lerr == nil && info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("path contains a broken symlink %q which cannot be safely validated", curr)
+		}
+
 		parent := filepath.Dir(curr)
 		if parent == curr {
 			// Reached the root of the filesystem without finding anything that exists.

--- a/util/fs.go
+++ b/util/fs.go
@@ -41,3 +41,67 @@ func SanitizeFileNameWithDefault(s, defaultName string) string {
 	}
 	return res
 }
+
+// ValidatePathInRoot ensures that the given path is within the root directory.
+// It resolves symlinks to prevent escaping the root, including cases where
+// multiple non-existent components follow a symlink.
+func ValidatePathInRoot(root, path string) (string, error) {
+	var err error
+	root, err = filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path for root: %w", err)
+	}
+	// Resolve symlinks for root too, because on some systems (like macOS)
+	// /var is a symlink to /private/var, which can cause Rel to fail.
+	if resolvedRoot, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolvedRoot
+	}
+
+	fullPath := path
+	if !filepath.IsAbs(fullPath) {
+		fullPath = filepath.Join(root, fullPath)
+	}
+	fullPath = filepath.Clean(fullPath)
+
+	// 1. Logical boundary check (preliminary)
+	rel, err := filepath.Rel(root, fullPath)
+	if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return "", fmt.Errorf("path %q is logically outside the root %q", path, root)
+	}
+
+	// 2. Physical boundary check (resolve symlinks)
+	// We iterate upwards until we find a component that exists, then validate its resolution.
+	curr := fullPath
+	for {
+		resolved, err := filepath.EvalSymlinks(curr)
+		if err == nil {
+			// Found an existing component. Check if its resolved path is within root.
+			rel, err = filepath.Rel(root, resolved)
+			if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+				return "", fmt.Errorf("resolved path %q (from %q) is outside the root %q", resolved, curr, root)
+			}
+
+			// If we resolved a prefix of the path, we should return the path constructed from the resolved prefix.
+			// This ensures that symlinks are resolved in the returned path.
+			if curr != fullPath {
+				relToCurr, _ := filepath.Rel(curr, fullPath)
+				return filepath.Join(resolved, relToCurr), nil
+			}
+			return resolved, nil
+		}
+
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("failed to resolve symlinks for %q: %w", curr, err)
+		}
+
+		parent := filepath.Dir(curr)
+		if parent == curr {
+			// Reached the root of the filesystem without finding anything that exists.
+			// This shouldn't happen if 'root' exists, but as a fallback, we've already done the logical check.
+			break
+		}
+		curr = parent
+	}
+
+	return fullPath, nil
+}

--- a/util/fs.go
+++ b/util/fs.go
@@ -64,7 +64,11 @@ func ValidatePathInRoot(root, path string) (string, error) {
 	fullPath = filepath.Clean(fullPath)
 
 	// 1. Logical boundary check (preliminary)
-	rel, err := filepath.Rel(root, fullPath)
+	absFullPath, err := filepath.Abs(fullPath)
+	if err != nil {
+		absFullPath = fullPath
+	}
+	rel, err := filepath.Rel(root, absFullPath)
 	if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
 		return "", fmt.Errorf("path %q is logically outside the root %q", path, root)
 	}

--- a/util/fs_test.go
+++ b/util/fs_test.go
@@ -62,3 +62,107 @@ func TestWriteFileWithDirs(t *testing.T) {
 		t.Errorf("expected 'hello', got %q", string(content))
 	}
 }
+
+func TestValidatePathInRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "root")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Resolve root to handle macOS /var symlink
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+
+	// Create a secret file outside root
+	secretFile := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(secretFile, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("valid path", func(t *testing.T) {
+		path := filepath.Join(root, "file.txt")
+		if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		got, err := ValidatePathInRoot(root, "file.txt")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		rel, _ := filepath.Rel(root, got)
+		if rel != "file.txt" {
+			t.Errorf("expected rel path 'file.txt', got %q", rel)
+		}
+	})
+
+	t.Run("traversal attempt", func(t *testing.T) {
+		_, err := ValidatePathInRoot(root, "../secret.txt")
+		if err == nil {
+			t.Error("expected error for traversal, got nil")
+		}
+	})
+
+	t.Run("symlink escape", func(t *testing.T) {
+		link := filepath.Join(root, "link")
+		if err := os.Symlink(secretFile, link); err != nil {
+			t.Fatal(err)
+		}
+		_, err := ValidatePathInRoot(root, "link")
+		if err == nil {
+			t.Error("expected error for symlink escape, got nil")
+		}
+	})
+
+	t.Run("nested symlink escape", func(t *testing.T) {
+		subdir := filepath.Join(tmpDir, "outside_dir")
+		if err := os.Mkdir(subdir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		outsideFile := filepath.Join(subdir, "file.txt")
+		if err := os.WriteFile(outsideFile, []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		link := filepath.Join(root, "dir_link")
+		if err := os.Symlink(subdir, link); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := ValidatePathInRoot(root, "dir_link/file.txt")
+		if err == nil {
+			t.Error("expected error for nested symlink escape, got nil")
+		}
+	})
+
+	t.Run("valid symlink within root", func(t *testing.T) {
+		target := filepath.Join(root, "target.txt")
+		if err := os.WriteFile(target, []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		link := filepath.Join(root, "valid_link")
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := ValidatePathInRoot(root, "valid_link")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		rel, _ := filepath.Rel(root, got)
+		if rel != "target.txt" {
+			t.Errorf("expected rel path 'target.txt', got %q", rel)
+		}
+	})
+
+	t.Run("nested non-existent symlink escape", func(t *testing.T) {
+		link := filepath.Join(root, "bad_link")
+		if err := os.Symlink(tmpDir, link); err != nil {
+			t.Fatal(err)
+		}
+		// This should fail even though 'a/b/c.txt' does not exist
+		_, err := ValidatePathInRoot(root, "bad_link/a/b/c.txt")
+		if err == nil {
+			t.Error("expected error for nested non-existent symlink escape, got nil")
+		}
+	})
+}


### PR DESCRIPTION
This PR fixes a security vulnerability where local tools (read_file, glob_files, grep_files) and the evaluation sandbox could be tricked into reading or writing files outside the workspace root using symbolic links.

### Key Changes:
- Introduced 'util.ValidatePathInRoot' to securely validate paths by resolving all intermediate symlinks, even for non-existent paths.
- Hardened 'read_file', 'glob_files', and 'grep_files' with robust path validation.
- Improved 'extractTarGz' in the sandbox to prevent 'Tar Slip' attacks via symlinks and validate symlink targets.
- Added comprehensive security tests for symlink escapes and malicious tarballs.

Fixes #76