### PR TITLE
docs: streamline agent/reviewer guidelines and add codify-patterns supplemental

### DIFF
--- a/.cassandra/codify-patterns.md
+++ b/.cassandra/codify-patterns.md
@@ -1,0 +1,16 @@
+# Codify Repeating Patterns
+
+Watch for two signals that a rule is missing from the relevant AGENTS.md:
+
+1. **Recurrence** — the same root-cause mistake appears in two or more locations in this diff.
+2. **Surprise** — a problem that an agent following the current AGENTS.md files would not have been warned about.
+
+When either signal fires, use `read_file` to read the AGENTS.md in the affected directory. If that file has no match, walk up to the repo root. If the rule is absent, append a **"Codification Opportunities"** section to your review. Each entry must specify:
+
+- **Target**: the AGENTS.md path closest to where the pattern lives.
+- **Rule**: one imperative sentence stating what MUST or MUST NOT be done.
+- **Rationale**: one sentence naming the failure mode it prevents.
+
+If a short `// bad` / `// good` example would materially clarify the rule, include it — following the style of CODE_STYLE.md.
+
+Omit the section entirely if every issue you raised is already covered by existing AGENTS.md content.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Before introducing major changes or restructuring the review loop, please read t
 
 **[CODE_STYLE.md](CODE_STYLE.md)** captures recurring coding patterns with rule + example + rationale for each: error handling idioms (`errors.New`, `%w`, `errors.As`), helper extraction, sentinel handling, registries over switches, typed accessors for untyped maps, centralized `//nolint`, stdout/stderr discipline, test-double `ctx` forwarding, paired-edit documentation, and stdlib-idiom preferences.
 
-Consult it when writing new code or when a review comment cites an idiom you don't recognize. AGENTS.md states *what MUST be done*; CODE_STYLE.md shows *how to write it so it matches the rest of the codebase*.
+Consult it when writing new code or when a review comment cites an idiom you don't recognize. This file states *what MUST be done*; CODE_STYLE.md shows *how to write it so it matches the rest of the codebase*.
 
 ## Output Contract
 
@@ -55,19 +55,12 @@ When adding new logging or output anywhere in the codebase, apply this rule stri
 
 ## Engineering Guidelines
 
-### 1. Tool Implementation Pattern
-To maintain consistency and type safety, all new tools MUST follow the standardized argument handling pattern:
-- **Struct-based Arguments**: Define a local anonymous struct (or a named struct if reused) to represent tool parameters.
-- **Explicit Unmarshaling**: Use `tc.UnmarshalArguments(&args)` within the tool handler. Do not perform manual type assertions or "missing key" checks on a map.
-  - *Exception*: Tools that proxy to external systems with dynamic schemas (e.g., Model Context Protocol tools) may use `map[string]any` since their arguments are discovered at runtime and cannot be statically typed.
-- **Error Propagation**: Return errors from the handler; the `Agent` is responsible for formatting these as "error: ..." strings for the LLM to process.
-
-### 2. Diagnostic Reporting
+### 1. Diagnostic Reporting
 Progress reporting is abstracted via the `core.Reporter` interface.
 - **Interface Usage**: Do not write directly to `os.Stderr` within the ReAct loop logic. Use `a.reporter.ReportIteration(...)`, etc.
 - **Default Phrasing**: Use distinct phrasing for different stages (e.g., "Iteration X..." vs "Formulating final review...") to provide high-signal feedback to the user.
 
-### 3. Testing Standards
+### 2. Testing Standards
 - **Mock Isolation**: When using `mockLLM` or similar history-tracking doubles, you MUST perform a deep copy of the message slice and its internal slices (`ToolCalls`, `ToolResults`). Shallow copies will lead to state contamination across iterations.
 - **Avoid Goroutine Leaks**: When starting background tasks or mock servers in tests, ALWAYS use a cancelable `context.Context` (via `context.WithCancel`) and ensure it is canceled (via `defer cancel()`) when the test completes.
 - **Safer JSON Construction**: Avoid manual string concatenation for JSON arguments in tests. Use `json.Marshal` or existing helpers to ensure paths (especially in `t.TempDir()`) containing special characters do not break the test payload.
@@ -75,27 +68,22 @@ Progress reporting is abstracted via the `core.Reporter` interface.
 - **Test Doubles Must Forward `ctx` and Arguments**: A stub or mock implementing a `context.Context`-accepting interface MUST forward the received `ctx` and arguments to any internal delegate. Substituting `context.Background()` silently breaks cancellation tests. Every context-accepting method on a test double needs at least one cancellation-propagation test.
 - **Parallel Method Coverage**: When an interface has parallel methods that share a wrapper (e.g. `GenerateContent` / `GenerateStructuredContent` behind `RetryingModel`), behavioral tests (retries, cancellation, error propagation) MUST cover both methods. Generics or composition that unify them in production do not remove the need for independent test coverage.
 
-### 4. Performance Mindfulness
+### 3. Performance Mindfulness
 - **Redundant I/O**: When walking the directory tree for configuration or guidelines (like `REVIEWERS.md`), use directory-based caching to avoid redundant disk lookups. If a directory subtree has already been searched for a specific filename, terminate the walk-up early.
 
-### 5. Token Efficiency
+### 4. Token Efficiency
 - **Mindful Generation**: When designing LLM interactions (prompts, schemas, or post-processing), prioritize strategies that minimize output tokens. Avoid asking the model to echo large amounts of existing text; instead, prefer manual assembly or reference-based extraction to reduce latency and API costs.
 
-### 6. Prompt Engineering & Prefix Caching
+### 5. Prompt Engineering & Prefix Caching
 - **Zone ordering**: The system prompt is divided into three zones ordered from most- to least-stable (see `core/prompts/library/README.md` for the full Prompt Developer Guide). When editing `BuildSystemPrompt` or any prompt file, **never inject dynamic or per-request data (file paths, PR metadata, commit SHAs) into Zone 1 or Zone 2**. All such content belongs in Zone 3 (the dynamic suffix).
 - **Byte-for-byte stability**: Any change to `reviewer_prompt.md`, a library guideline file, or the `approval_evaluation_prompt.md` will invalidate the prefix cache for every subsequent review using that configuration. Review such changes carefully and keep them minimal.
 - **New sections**: If you add a new semi-static section to `BuildSystemPrompt`, insert it between the existing Zone 2 entries and before the Zone 3 block (AGENTS.md / REVIEWERS.md), maintaining the stable-prefix ordering described in the design.
 
-### 7. Lint Exceptions
+### 6. Lint Exceptions
 - **Centralize `//nolint` pragmas**: If a construct legitimately needs a lint exception (e.g. `int32` narrowing after a bounds check, an intentionally-unused receiver), wrap it in a named helper so the pragma lives in one place with a comment explaining the invariant. Do not sprinkle `//nolint:gosec` or similar pragmas at multiple call sites — the invariant becomes invisible and copy-paste drift accumulates. See `clampInt32` in `llm/google/provider.go` as the canonical example.
 
-### 8. Defensive Tool Implementation
-Tools that interact with external data (files, network, pipes) MUST be resilient to resource exhaustion and hangs.
-- **Hard Safety Limits**: Every tool MUST enforce an output size limit (e.g., 40KB) and a per-operation memory cap.
-- **Streaming over Loading**: Do NOT use `os.ReadFile` or `io.ReadAll` on potentially large sources. Use `io.LimitReader` and `bufio.Reader` to process data in chunks.
-- **Pseudo-file Protection**: Never trust `os.Stat().Size()` for OOM prevention (it returns 0 for pseudo-files like `/dev/zero`). Always use `io.LimitReader` with a hard cap.
-- **Cancellation Checks**: Every loop that performs I/O or intensive computation (including filesystem traversals like `filepath.WalkDir`) MUST check `ctx.Err()` in each iteration to ensure the tool can be interrupted by the ReAct loop timeout.
-- **Workspace Isolation**: Tools MUST NEVER read or write outside the designated workspace root. Use `util.ValidatePathInRoot` to securely resolve and validate paths, ensuring protection against directory traversal and symbolic link escapes.
+### 7. Defensive Tool Implementation
+Tools that interact with external data (files, network, pipes) MUST be resilient to resource exhaustion and hangs. See [`tools/AGENTS.md`](tools/AGENTS.md) for the full requirements and security test mandates.
 
 ## Security Standards
 
@@ -104,12 +92,6 @@ To prevent command injection vulnerabilities, you MUST NOT interpolate user-cont
 - **Use Environment Variables**: Map user-controlled inputs to environment variables in the `env:` block of the step.
 - **Reference Safely**: Use the environment variable within the script (e.g., `run: my-tool --arg "$VAL"`). This ensures the shell treats the input as literal data.
 - **Exceptions**: System-provided variables that are not user-controlled and follow a strict format (e.g., `${{ github.repository }}`, `${{ github.action_path }}`, `${{ github.workspace }}`, `${{ runner.temp }}`) can be used directly if it improves readability and doesn't introduce risk.
-
-### 2. Tool Workspace Isolation
-To prevent sensitive data leaks and host system compromise, all local tools MUST enforce strict directory isolation:
-- **Root Validation**: Always validate user-provided paths against the workspace root using `util.ValidatePathInRoot`.
-- **Symlink Hardening**: Do not trust lexical path cleaning (e.g., `filepath.Clean`). Validation must resolve physical paths to detect symlink trampolines or broken symlink escapes.
-- **TOCTOU Protection**: When creating symlinks (e.g., in sandboxes), re-compute the relative target from validated physical paths to neutralize parsing differentials.
 
 ## Git Commit Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,8 @@ Tools that interact with external data (files, network, pipes) MUST be resilient
 - **Hard Safety Limits**: Every tool MUST enforce an output size limit (e.g., 40KB) and a per-operation memory cap.
 - **Streaming over Loading**: Do NOT use `os.ReadFile` or `io.ReadAll` on potentially large sources. Use `io.LimitReader` and `bufio.Reader` to process data in chunks.
 - **Pseudo-file Protection**: Never trust `os.Stat().Size()` for OOM prevention (it returns 0 for pseudo-files like `/dev/zero`). Always use `io.LimitReader` with a hard cap.
-- **Cancellation Checks**: Every loop that performs I/O or intensive computation MUST check `ctx.Err()` in each iteration to ensure the tool can be interrupted by the ReAct loop timeout.
+- **Cancellation Checks**: Every loop that performs I/O or intensive computation (including filesystem traversals like `filepath.WalkDir`) MUST check `ctx.Err()` in each iteration to ensure the tool can be interrupted by the ReAct loop timeout.
+- **Workspace Isolation**: Tools MUST NEVER read or write outside the designated workspace root. Use `util.ValidatePathInRoot` to securely resolve and validate paths, ensuring protection against directory traversal and symbolic link escapes.
 
 ## Security Standards
 
@@ -103,6 +104,12 @@ To prevent command injection vulnerabilities, you MUST NOT interpolate user-cont
 - **Use Environment Variables**: Map user-controlled inputs to environment variables in the `env:` block of the step.
 - **Reference Safely**: Use the environment variable within the script (e.g., `run: my-tool --arg "$VAL"`). This ensures the shell treats the input as literal data.
 - **Exceptions**: System-provided variables that are not user-controlled and follow a strict format (e.g., `${{ github.repository }}`, `${{ github.action_path }}`, `${{ github.workspace }}`, `${{ runner.temp }}`) can be used directly if it improves readability and doesn't introduce risk.
+
+### 2. Tool Workspace Isolation
+To prevent sensitive data leaks and host system compromise, all local tools MUST enforce strict directory isolation:
+- **Root Validation**: Always validate user-provided paths against the workspace root using `util.ValidatePathInRoot`.
+- **Symlink Hardening**: Do not trust lexical path cleaning (e.g., `filepath.Clean`). Validation must resolve physical paths to detect symlink trampolines or broken symlink escapes.
+- **TOCTOU Protection**: When creating symlinks (e.g., in sandboxes), re-compute the relative target from validated physical paths to neutralize parsing differentials.
 
 ## Git Commit Guidelines
 

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -169,7 +169,7 @@ under the relevant scope.
 
 ```
 # llm/REVIEWERS.md
-- `submitReviewToolName` ↔ `DESIGN.md §Technical Decisions 4`.
+- `submitReviewToolName` ↔ `DESIGN.md — Structured Feedback Extraction`.
 - `DefaultMaxTokens` ↔ CLI `--max-tokens` default in `cmd/ai_reviewer`.
 ```
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -41,7 +41,7 @@ The system is designed as a CLI-driven, autonomous AI worker. It acts essentiall
 ### 4. Tool Registry (`tools/`)
 - **Interface**: The `ToolDispatcher` interface (defined in `core/agent.go`) is the minimal set of methods the Agent needs: one to enumerate available tools and one to dispatch a tool call by name with its context and arguments. Read `core/agent.go` for the authoritative signature.
 - **Implementation**: `tools.Registry` (in `tools/registry.go`) implements this interface. It stores a list of `llm.ToolDef` and a map of `ToolHandler` functions.
-- **Local Tools**: High-level tools implemented in `tools/local_tools.go` and registered via `tools.RegisterLocalTools`:
+- **Local Tools**: High-level tools implemented under `tools/` and registered via `tools.RegisterLocalTools`:
   - `read_file`: Reads file content from the local disk.
   - `glob_files`: Finds files matching a pattern or extension.
   - `grep_files`: Searches for patterns in the repository using `git grep`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -39,27 +39,16 @@ The system is designed as a CLI-driven, autonomous AI worker. It acts essentiall
   6. **Cap Reached**: If the cap is reached, the agent forces a final review call by appending a system message and stripping tool definitions from the next LLM call.
 
 ### 4. Tool Registry (`tools/`)
-- **Interface**: The `ToolDispatcher` interface (defined in `core/agent.go`) is the minimal set of methods the Agent needs:
-  ```go
-  type ToolDispatcher interface {
-      ToTools() []llm.ToolDef
-      HandleCall(tc llm.ToolCall) (string, error)
-  }
-  ```
+- **Interface**: The `ToolDispatcher` interface (defined in `core/agent.go`) is the minimal set of methods the Agent needs: one to enumerate available tools and one to dispatch a tool call by name with its context and arguments. Read `core/agent.go` for the authoritative signature.
 - **Implementation**: `tools.Registry` (in `tools/registry.go`) implements this interface. It stores a list of `llm.ToolDef` and a map of `ToolHandler` functions.
-- **Local Tools**: High-level tools implemented in `tools/local_tools.go`:
+- **Local Tools**: High-level tools implemented in `tools/local_tools.go` and registered via `tools.RegisterLocalTools`:
   - `read_file`: Reads file content from the local disk.
   - `glob_files`: Finds files matching a pattern or extension.
   - `grep_files`: Searches for patterns in the repository using `git grep`.
+  - `wishlist_tool`: Reads developer wishlist/guidance files from a configurable directory.
 
 ### 5. LLM Abstraction (`llm/`)
-- **Interface**: `llm.Model` (in `llm/llm.go`) is the provider-agnostic interface:
-  ```go
-  type Model interface {
-      GenerateContent(ctx context.Context, messages []Message, tools []ToolDef, maxTokens int) (*Response, error)
-      GenerateStructuredContent(ctx context.Context, messages []Message, schema map[string]any, config StructuredConfig) (*Response, error)
-  }
-  ```
+- **Interface**: `llm.Model` (in `llm/llm.go`) is the provider-agnostic interface. It exposes two generation methods: `GenerateContent` for free-form responses with optional tool use, and `GenerateStructuredContent` for schema-constrained output. Read `llm/llm.go` for the authoritative signatures.
 - **Shared Types**: Standardizes `Message`, `ToolDef`, `ToolCall`, `ToolResult`, and `Response` across all providers.
 - **Provider Implementations**:
   - `llm/anthropic`: Uses `github.com/anthropics/anthropic-sdk-go`.
@@ -111,8 +100,7 @@ the companion implementation rules.
 
 ## Output Contract
 
-- **Stderr**: All diagnostic and progress output (configuration summary, iteration progress, tool calls).
-- **Stdout**: The final review text (markdown). This allows for easy redirection: `cassandra ... > review.md`.
+See [AGENTS.md — Output Contract](AGENTS.md#output-contract). All diagnostic and progress output goes to stderr; the final review text goes to stdout only.
 
 ## Structured Output JSON (`--output-json`)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -45,7 +45,7 @@ The system is designed as a CLI-driven, autonomous AI worker. It acts essentiall
   - `read_file`: Reads file content from the local disk.
   - `glob_files`: Finds files matching a pattern or extension.
   - `grep_files`: Searches for patterns in the repository using `git grep`.
-  - `wishlist_tool`: Reads developer wishlist/guidance files from a configurable directory.
+  - `wishlist_tool`: Records a capability gap the LLM encountered during a review into a configurable directory for future tool development.
 
 ### 5. LLM Abstraction (`llm/`)
 - **Interface**: `llm.Model` (in `llm/llm.go`) is the provider-agnostic interface. It exposes two generation methods: `GenerateContent` for free-form responses with optional tool use, and `GenerateStructuredContent` for schema-constrained output. Read `llm/llm.go` for the authoritative signatures.

--- a/REVIEWERS.md
+++ b/REVIEWERS.md
@@ -5,8 +5,10 @@ Reviewer lens for the whole repo. Assumes [AGENTS.md](AGENTS.md) and [DESIGN.md]
 ## Paired edits (block if one is missing)
 
 - New `os.Stdout` write ↔ justification that it is final review output.
-- `BuildSystemPrompt` addition ↔ placement between Zone 2 and Zone 3 (AGENTS.md §6).
-- GitHub Action input added ↔ `env:` mapping per AGENTS.md §Security 1.
+- `BuildSystemPrompt` addition ↔ placement between Zone 2 and Zone 3 (AGENTS.md — Prompt Engineering & Prefix Caching).
+- GitHub Action input added ↔ `env:` mapping per AGENTS.md — GitHub Action Input Safety.
+- `llm.Model` interface signature change ↔ all test doubles under `llm/` (see also [llm/REVIEWERS.md — Paired edits](llm/REVIEWERS.md)).
+- New local tool ↔ security negative tests (traversal, valid symlink, broken symlink, trampoline symlink); see [tools/REVIEWERS.md](tools/REVIEWERS.md).
 
 ## Safety & Liveness (block if missing)
 

--- a/REVIEWERS.md
+++ b/REVIEWERS.md
@@ -7,7 +7,7 @@ Reviewer lens for the whole repo. Assumes [AGENTS.md](AGENTS.md) and [DESIGN.md]
 - New `os.Stdout` write ↔ justification that it is final review output.
 - `BuildSystemPrompt` addition ↔ placement between Zone 2 and Zone 3 (AGENTS.md — Prompt Engineering & Prefix Caching).
 - GitHub Action input added ↔ `env:` mapping per AGENTS.md — GitHub Action Input Safety.
-- `llm.Model` interface signature change ↔ all test doubles under `llm/` (see also [llm/REVIEWERS.md — Paired edits](llm/REVIEWERS.md)).
+- `llm.Model` interface signature change ↔ all test doubles under `llm/` (see also [llm/REVIEWERS.md — Paired edits](llm/REVIEWERS.md#paired-edits-block-if-one-is-missing)).
 - New local tool ↔ security negative tests (traversal, valid symlink, broken symlink, trampoline symlink); see [tools/REVIEWERS.md](tools/REVIEWERS.md).
 
 ## Safety & Liveness (block if missing)

--- a/llm/AGENTS.md
+++ b/llm/AGENTS.md
@@ -2,7 +2,7 @@
 
 Scoped guidance for code under `llm/`. These rules complement the repo-level
 [AGENTS.md](../AGENTS.md); follow both. See also the architectural contract
-in [DESIGN.md §5 LLM Abstraction](../DESIGN.md#5-llm-abstraction-llm).
+in [DESIGN.md — LLM Abstraction](../DESIGN.md#5-llm-abstraction-llm).
 
 ## Provider Implementation Pattern
 

--- a/llm/REVIEWERS.md
+++ b/llm/REVIEWERS.md
@@ -13,13 +13,13 @@ Behavioral divergence between `llm/anthropic` and `llm/google` is a defect unles
 
 - `RetryingModel` retries on all errors, including 4xx. Error-class filtering was rejected.
 - `llm.UnknownUsage()` is value-typed with `-1/-1` sentinels. Callers depend on this; do not suggest pointers or an `Ok` field.
-- `clampInt32` carries the package `//nolint:gosec`; it is the centralization point (root AGENTS.md §7).
+- `clampInt32` carries the package `//nolint:gosec`; it is the centralization point (root AGENTS.md — Lint Exceptions).
 - `llm/internal/util` is the intentional shared conversion layer.
 - `llm.retry[T]` is tested via both `RetryingModel` methods; do not request direct unit tests.
 
 ## Paired edits (block if one is missing)
 
-- `submitReviewToolName` ↔ `DESIGN.md §Technical Decisions 4`.
+- `submitReviewToolName` ↔ `DESIGN.md — Structured Feedback Extraction`.
 - `DefaultMaxTokens` ↔ CLI `--max-tokens` default in `cmd/ai_reviewer`.
-- New provider ↔ `factory.providers` map + `README.md` §Supported Models.
+- New provider ↔ `factory.providers` map + `README.md` — Supported Models.
 - `llm.Model` signature change ↔ test doubles under `llm/`.

--- a/llm/anthropic/provider.go
+++ b/llm/anthropic/provider.go
@@ -16,8 +16,8 @@ import (
 
 // submitReviewToolName is the synthetic tool the Anthropic provider forces
 // the model to call to deliver structured output. The name is a documented
-// contract — see DESIGN.md §Technical Decisions 4 ("Structured Feedback
-// Extraction"). Keep it stable; downstream consumers may match on it.
+// contract — see DESIGN.md — Structured Feedback Extraction.
+// Keep it stable; downstream consumers may match on it.
 const submitReviewToolName = "submit_review"
 
 // Provider implements llm.Model backed by the Anthropic Messages API.

--- a/llm/openai/provider.go
+++ b/llm/openai/provider.go
@@ -13,8 +13,8 @@ import (
 
 // submitReviewToolName is the synthetic tool the OpenAI provider forces the
 // model to call to deliver structured output. The name is a documented
-// contract — see DESIGN.md §Technical Decisions 4 ("Structured Feedback
-// Extraction"). Keep it stable; downstream consumers may match on it.
+// contract — see DESIGN.md — Structured Feedback Extraction.
+// Keep it stable; downstream consumers may match on it.
 const submitReviewToolName = "submit_review"
 
 // Provider implements llm.Model backed by the OpenAI Chat Completions API.

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -15,6 +15,13 @@ Tools that invoke external CLIs MUST:
 - **Bounded Buffers**: If a tool uses a buffer to collect data (e.g., a circular buffer for `tail_lines`), it MUST have both an entry count limit AND a strict byte-based memory cap (e.g., 1MB).
 - **Graceful Truncation**: When a tool hits an output limit, it should return as much valid data as possible followed by a clear truncation notice (e.g., `... (truncated)`), rather than failing with an error.
 
+### 4. Path Validation & Security
+Tools that accept file or directory paths as arguments MUST:
+- **Use `util.ValidatePathInRoot(root, path)`**: This helper ensures the path is physically within the root by resolving all intermediate symlinks.
+- **Check for Broken Symlinks**: Broken symlinks committed to a repo can be used to bypass lexical checks. `ValidatePathInRoot` handles this by rejecting paths that cannot be safely resolved.
+- **Consistent Relative Output**: Tools (like `grep` or `glob`) SHOULD return paths relative to the workspace root. If a tool resolves a path to an absolute location during validation, it MUST convert it back to a relative path before passing it to external CLIs or returning it to the LLM.
+- **Context Awareness**: Long-running filesystem operations (e.g., `WalkDir`) MUST propagate the tool's context and check `ctx.Err()` to prevent "context holes" during large repository scans.
+
 ## Model Context Protocol (MCP) Servers
 
 MCP servers allow Cassandra to extend its capabilities without increasing the main binary's complexity or dependency footprint.
@@ -54,4 +61,8 @@ The command should also include a trailing `--` to separate Bazel flags from app
 ## Testing Standards
 
 - **Local Tools**: Use `t.TempDir()` and file-based fixtures to test tools that interact with the filesystem.
+- **Security Negative Tests**: Any tool interacting with the filesystem MUST include test cases for:
+  - Directory traversal attempts (`../etc/passwd`).
+  - Symlinks pointing outside the workspace (valid, broken, and "trampoline" symlinks).
+  - TOCTOU bypasses (relative targets with hidden physical traversals).
 - **MCP Servers**: Unit tests for MCP server logic should verify the execution of underlying commands (e.g., by checking for expected output strings or error conditions).

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -20,6 +20,8 @@ Tools that invoke external CLIs MUST:
 ### 3. Resource Management
 - **Bounded Buffers**: If a tool uses a buffer to collect data (e.g., the `tail_lines` parameter of `read_file`), it MUST have both an entry count limit AND a strict byte-based memory cap (e.g., 1 MB). This cap covers in-process buffer allocation.
 - **Output Size Limit**: Every tool MUST cap the bytes it returns to the LLM at 40 KB. Return as much valid data as possible and append a clear truncation notice (e.g., `... (truncated)`) rather than failing.
+- **Streaming over Loading**: Do NOT use `os.ReadFile` or `io.ReadAll` on potentially large sources. Use `io.LimitReader` and `bufio.Reader` to process data in chunks.
+- **Pseudo-file Protection**: Never trust `os.Stat().Size()` for OOM prevention — it returns 0 for pseudo-files like `/dev/zero`. Always enforce limits via `io.LimitReader`, not by checking the reported file size.
 
 ### 4. Path Validation & Security
 Tools that accept file or directory paths as arguments MUST:

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -18,8 +18,8 @@ Tools that invoke external CLIs MUST:
 - On failure, include the `stderr` output in the returned error string so the LLM can diagnose the issue (e.g., "command failed: <stderr>").
 
 ### 3. Resource Management
-- **Bounded Buffers**: If a tool uses a buffer to collect data (e.g., the `tail_lines` parameter of `read_file`), it MUST have both an entry count limit AND a strict byte-based memory cap (e.g., 1 MB). This cap covers in-process buffer allocation; the separate 40 KB output limit (root AGENTS.md — Defensive Tool Implementation) caps bytes returned to the LLM.
-- **Graceful Truncation**: When a tool hits an output limit, it should return as much valid data as possible followed by a clear truncation notice (e.g., `... (truncated)`), rather than failing with an error.
+- **Bounded Buffers**: If a tool uses a buffer to collect data (e.g., the `tail_lines` parameter of `read_file`), it MUST have both an entry count limit AND a strict byte-based memory cap (e.g., 1 MB). This cap covers in-process buffer allocation.
+- **Output Size Limit**: Every tool MUST cap the bytes it returns to the LLM at 40 KB. Return as much valid data as possible and append a clear truncation notice (e.g., `... (truncated)`) rather than failing.
 
 ### 4. Path Validation & Security
 Tools that accept file or directory paths as arguments MUST:

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -2,8 +2,14 @@
 
 ## Tool Implementation Pattern
 
-### 1. Registration
-Local tools (compiled into the binary) MUST be registered in `tools/registry.go`. Each tool implementation should reside in its own file (e.g., `tools/diff.go`) and follow the struct-based argument pattern defined in the root `AGENTS.md`.
+### 1. Registration & Argument Handling
+Local tools (compiled into the binary) MUST be registered in `tools/registry.go` via `RegisterLocalTools`. Each tool implementation should reside in its own file (e.g., `tools/diff.go`).
+
+All tools MUST follow this argument-handling pattern:
+- **Struct-based Arguments**: Define a local anonymous struct (or a named struct if reused) to represent the tool's parameters.
+- **Explicit Unmarshaling**: Use `tc.UnmarshalArguments(&args)` within the handler. Do not perform manual type assertions or "missing key" checks on a raw map.
+  - *Exception*: MCP tools that proxy external systems with dynamic schemas may use `map[string]any` since their arguments are discovered at runtime and cannot be statically typed.
+- **Error Propagation**: Return errors from the handler; the `Agent` is responsible for formatting these as "error: ..." strings for the LLM.
 
 ### 2. Execution Context
 Tools that invoke external CLIs MUST:
@@ -12,13 +18,14 @@ Tools that invoke external CLIs MUST:
 - On failure, include the `stderr` output in the returned error string so the LLM can diagnose the issue (e.g., "command failed: <stderr>").
 
 ### 3. Resource Management
-- **Bounded Buffers**: If a tool uses a buffer to collect data (e.g., a circular buffer for `tail_lines`), it MUST have both an entry count limit AND a strict byte-based memory cap (e.g., 1MB).
+- **Bounded Buffers**: If a tool uses a buffer to collect data (e.g., the `tail_lines` parameter of `read_file`), it MUST have both an entry count limit AND a strict byte-based memory cap (e.g., 1 MB). This cap covers in-process buffer allocation; the separate 40 KB output limit (root AGENTS.md — Defensive Tool Implementation) caps bytes returned to the LLM.
 - **Graceful Truncation**: When a tool hits an output limit, it should return as much valid data as possible followed by a clear truncation notice (e.g., `... (truncated)`), rather than failing with an error.
 
 ### 4. Path Validation & Security
 Tools that accept file or directory paths as arguments MUST:
 - **Use `util.ValidatePathInRoot(root, path)`**: This helper ensures the path is physically within the root by resolving all intermediate symlinks.
 - **Check for Broken Symlinks**: Broken symlinks committed to a repo can be used to bypass lexical checks. `ValidatePathInRoot` handles this by rejecting paths that cannot be safely resolved.
+- **TOCTOU Protection**: When creating symlinks (e.g., in sandboxes), re-compute the relative target from validated physical paths to neutralize parsing differentials between lexical and physical resolution.
 - **Consistent Relative Output**: Tools (like `grep` or `glob`) SHOULD return paths relative to the workspace root. If a tool resolves a path to an absolute location during validation, it MUST convert it back to a relative path before passing it to external CLIs or returning it to the LLM.
 - **Context Awareness**: Long-running filesystem operations (e.g., `WalkDir`) MUST propagate the tool's context and check `ctx.Err()` to prevent "context holes" during large repository scans.
 

--- a/tools/REVIEWERS.md
+++ b/tools/REVIEWERS.md
@@ -1,0 +1,24 @@
+# Tools Package Review Guidelines
+
+Reviewer lens. Complements [AGENTS.md](AGENTS.md) and [../AGENTS.md](../AGENTS.md); does not restate them.
+
+## Do not flag
+
+- Truncation at the 40 KB output limit is intentional — tools return a truncation notice rather than failing.
+- The 40 KB LLM-output cap and the 1 MB buffer cap are separate limits (wire vs. in-process); both are required.
+- `util.ValidatePathInRoot` re-resolving symlinks on every call is intentional (TOCTOU prevention, not redundancy).
+- `exec.CommandContext` stderr included in the returned error string is intentional — it gives the LLM diagnostic context.
+
+## Safety (block if missing)
+
+- Tools accepting file or directory paths MUST call `util.ValidatePathInRoot`; lexical path cleaning (`filepath.Clean`) alone is not sufficient.
+- Long-running loops (`WalkDir`, streaming reads) MUST check `ctx.Err()` in each iteration.
+- Tools invoking external CLIs MUST use `exec.CommandContext(ctx, ...)`.
+- Streaming tools MUST use `io.LimitReader` — do not rely on `os.Stat().Size()` for OOM prevention.
+
+## Paired edits (block if one is missing)
+
+- New local tool ↔ registered in `tools/registry.go` via `RegisterLocalTools`.
+- New local tool ↔ security negative tests: directory traversal (`../`), valid symlink, broken symlink, trampoline symlink.
+- New MCP server ↔ `VERIFICATION MANDATE` in tool `Description` + noise-suppression flags (`--noshow_progress`, `--ui_event_filters`) in `mcp.json`.
+- New MCP server ↔ binary entry point under `cmd/mcp_<name>/`.


### PR DESCRIPTION
## Summary

- **Consolidate tool rules**: Remove duplicated tool implementation and workspace-isolation rules from root `AGENTS.md`; `tools/AGENTS.md` is now the single owner of argument handling, path validation, defensive I/O, and security test requirements
- **Fix stale DESIGN.md**: Replace copy-pasted interface code blocks (`ToolDispatcher`, `llm.Model`) with prose pointing at the source files — eliminates the drift vector that caused the missing `ctx` parameter
- **Add `tools/REVIEWERS.md`**: New reviewer checklist for the tools package covering do-not-flag items, safety blockers, and paired-edit requirements
- **Strengthen root `REVIEWERS.md`**: Add missing paired-edit entries for `llm.Model` signature changes and new-tool security test requirements
- **Add `codify-patterns` supplemental**: Guides the AI reviewer to identify AGENTS.md gaps when it sees recurring mistakes (recurrence signal) or problems an agent following current docs would not have been warned about (surprise signal)
- **Replace §-number references with section titles**: All cross-references now use the section name so renumbering never silently breaks a pointer
- **Fix `wishlist_tool` omission**: DESIGN.md tool registry list was missing this registered tool
- **Clarify 40 KB / 1 MB limits**: Defined explicitly in `tools/AGENTS.md` as the authoritative source, with clear separation between the LLM-output cap (40 KB) and the in-process buffer cap (1 MB)

## Test plan

- [ ] Verify `tools/AGENTS.md` standalone covers all tool implementation requirements (argument handling, resource limits, path validation, security tests) without needing to cross-reference root
- [ ] Verify no `§`-number references remain in any docs file
- [ ] Verify `DESIGN.md` no longer contains interface code blocks that can drift from source
- [ ] Verify `tools/REVIEWERS.md` paired-edit entries align with `tools/AGENTS.md` rules