### PR TITLE
refactor: reduce file IO boilerplate and centralize path validation (#93)

### DIFF
--- a/core/prompts/BUILD.bazel
+++ b/core/prompts/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     ],
     importpath = "github.com/menny/cassandra/core/prompts",
     visibility = ["//visibility:public"],
+    deps = ["//util"],
 )
 
 filegroup(

--- a/core/prompts/prompts.go
+++ b/core/prompts/prompts.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+
+	"github.com/menny/cassandra/util"
 )
 
 //go:embed reviewer_prompt.md
@@ -101,10 +103,7 @@ func BuildSystemPrompt(workspaceRoot string, changedFiles []string, mainGuidelin
 	personalPath := filepath.Join(workspaceRoot, "personal.ai_code_review_guidelines.md")
 	if personalBytes, err := os.ReadFile(personalPath); err == nil {
 		stable += fmt.Sprintf("\n<personal_review_guidelines>\n%s\n</personal_review_guidelines>\n", string(personalBytes))
-		relPersonal, relErr := filepath.Rel(workspaceRoot, personalPath)
-		if relErr != nil {
-			relPersonal = personalPath
-		}
+		relPersonal := util.SafeRel(workspaceRoot, personalPath)
 		summary.LoadedFiles = append(summary.LoadedFiles, FileSource{Path: relPersonal, Type: "personal"})
 	}
 
@@ -169,10 +168,7 @@ func findRepoFiles(workspaceRoot string, changedFiles []string, filename string)
 		dir := filepath.Dir(absPath)
 
 		for {
-			relDir, err := filepath.Rel(workspaceRoot, dir)
-			if err != nil {
-				relDir = dir
-			}
+			relDir := util.SafeRel(workspaceRoot, dir)
 			if relDir == "." {
 				relDir = "/"
 			}

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -72,16 +71,7 @@ func registerLocalReadFile(r *Registry, root string) {
 			maxOutput = absoluteMaxReadLength
 		}
 
-		fullPath := args.FilePath
-		if root != "" {
-			var err error
-			fullPath, err = util.ValidatePathInRoot(root, args.FilePath)
-			if err != nil {
-				return "", fmt.Errorf("read_file failed: %w", err)
-			}
-		}
-
-		f, err := os.Open(fullPath)
+		f, err := util.OpenInRoot(root, args.FilePath)
 		if err != nil {
 			return "", fmt.Errorf("read_file failed: %w", err)
 		}
@@ -349,12 +339,7 @@ func registerLocalGlobFiles(r *Registry, root string) {
 				return nil
 			}
 			if !d.IsDir() {
-				relPath := path
-				if root != "" {
-					if rel, err := filepath.Rel(root, path); err == nil {
-						relPath = rel
-					}
-				}
+				relPath := util.SafeRel(root, path)
 				if strings.Contains(filepath.Base(relPath), args.Query) || strings.Contains(relPath, args.Query) {
 					matches = append(matches, relPath)
 				}
@@ -416,17 +401,9 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 			dir := args.Directory
 			if root != "" {
 				var err error
-				dir, err = util.ValidatePathInRoot(root, args.Directory)
+				dir, err = util.ValidateAndRel(root, args.Directory)
 				if err != nil {
 					return "", fmt.Errorf("grep_files failed: %w", err)
-				}
-				// Convert back to relative path for Git consistency and relative output.
-				// We only use the relative path if it's clean and doesn't escape.
-				if rel, err := filepath.Rel(root, dir); err == nil && !strings.HasPrefix(rel, "..") {
-					dir = rel
-				} else if !filepath.IsAbs(args.Directory) {
-					// Fallback to original input if it was relative
-					dir = args.Directory
 				}
 			}
 			cmdArgs = append(cmdArgs, "--", dir)

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -330,6 +330,15 @@ func registerLocalGlobFiles(r *Registry, root string) {
 			}
 		}
 
+		resolvedRoot := root
+		if root != "" {
+			// Resolve root once to handle symlinks (e.g. macOS /var) so that
+			// util.SafeRel produces consistent relative paths during the walk.
+			if r, err := util.ValidatePathInRoot(root, ""); err == nil {
+				resolvedRoot = r
+			}
+		}
+
 		var matches []string
 		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 			if ctx.Err() != nil {
@@ -339,7 +348,7 @@ func registerLocalGlobFiles(r *Registry, root string) {
 				return nil
 			}
 			if !d.IsDir() {
-				relPath := util.SafeRel(root, path)
+				relPath := util.SafeRel(resolvedRoot, path)
 				if strings.Contains(filepath.Base(relPath), args.Query) || strings.Contains(relPath, args.Query) {
 					matches = append(matches, relPath)
 				}

--- a/util/fs.go
+++ b/util/fs.go
@@ -115,3 +115,39 @@ func ValidatePathInRoot(root, path string) (string, error) {
 
 	return fullPath, nil
 }
+
+// OpenInRoot validates the path is within the root (if root is not empty) and opens the file.
+func OpenInRoot(root, path string) (*os.File, error) {
+	fullPath := path
+	if root != "" {
+		var err error
+		fullPath, err = ValidatePathInRoot(root, path)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return os.Open(fullPath)
+}
+
+// SafeRel returns the relative path from base to target. If an error occurs,
+// it returns the original target path.
+func SafeRel(base, target string) string {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return target
+	}
+	return rel
+}
+
+// ValidateAndRel validates that target is within root and returns its relative path from root.
+func ValidateAndRel(root, target string) (string, error) {
+	resolvedTarget, err := ValidatePathInRoot(root, target)
+	if err != nil {
+		return "", err
+	}
+	resolvedRoot, err := ValidatePathInRoot(root, "")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Rel(resolvedRoot, resolvedTarget)
+}

--- a/util/fs_test.go
+++ b/util/fs_test.go
@@ -166,3 +166,81 @@ func TestValidatePathInRoot(t *testing.T) {
 		}
 	})
 }
+
+func TestOpenInRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "root")
+	os.Mkdir(root, 0o755)
+	filePath := filepath.Join(root, "test.txt")
+	os.WriteFile(filePath, []byte("hello"), 0o644)
+
+	t.Run("valid path", func(t *testing.T) {
+		f, err := OpenInRoot(root, "test.txt")
+		if err != nil {
+			t.Fatalf("OpenInRoot failed: %v", err)
+		}
+		f.Close()
+	})
+
+	t.Run("invalid path", func(t *testing.T) {
+		_, err := OpenInRoot(root, "../secret.txt")
+		if err == nil {
+			t.Fatal("expected error for invalid path, got nil")
+		}
+	})
+
+	t.Run("no root", func(t *testing.T) {
+		f, err := OpenInRoot("", filePath)
+		if err != nil {
+			t.Fatalf("OpenInRoot failed with no root: %v", err)
+		}
+		f.Close()
+	})
+}
+
+func TestSafeRel(t *testing.T) {
+	t.Run("valid rel", func(t *testing.T) {
+		got := SafeRel("/a/b", "/a/b/c")
+		if got != "c" {
+			t.Errorf("expected 'c', got %q", got)
+		}
+	})
+
+	t.Run("invalid rel", func(t *testing.T) {
+		// On windows this might fail if they are on different drives,
+		// but on unix it usually works. To force an error, maybe empty base?
+		// Actually filepath.Rel("", "a") might error.
+		got := SafeRel("", "a")
+		if got != "a" {
+			t.Errorf("expected 'a' on error, got %q", got)
+		}
+	})
+}
+
+func TestValidateAndRel(t *testing.T) {
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "root")
+	os.Mkdir(root, 0o755)
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+	filePath := filepath.Join(root, "test.txt")
+	os.WriteFile(filePath, []byte("hello"), 0o644)
+
+	t.Run("valid path", func(t *testing.T) {
+		got, err := ValidateAndRel(root, "test.txt")
+		if err != nil {
+			t.Fatalf("ValidateAndRel failed: %v", err)
+		}
+		if got != "test.txt" {
+			t.Errorf("expected 'test.txt', got %q", got)
+		}
+	})
+
+	t.Run("invalid path", func(t *testing.T) {
+		_, err := ValidateAndRel(root, "../secret.txt")
+		if err == nil {
+			t.Fatal("expected error for invalid path, got nil")
+		}
+	})
+}

--- a/util/fs_test.go
+++ b/util/fs_test.go
@@ -170,9 +170,13 @@ func TestValidatePathInRoot(t *testing.T) {
 func TestOpenInRoot(t *testing.T) {
 	tmpDir := t.TempDir()
 	root := filepath.Join(tmpDir, "root")
-	os.Mkdir(root, 0o755)
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	filePath := filepath.Join(root, "test.txt")
-	os.WriteFile(filePath, []byte("hello"), 0o644)
+	if err := os.WriteFile(filePath, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Run("valid path", func(t *testing.T) {
 		f, err := OpenInRoot(root, "test.txt")
@@ -220,12 +224,16 @@ func TestSafeRel(t *testing.T) {
 func TestValidateAndRel(t *testing.T) {
 	tmpDir := t.TempDir()
 	root := filepath.Join(tmpDir, "root")
-	os.Mkdir(root, 0o755)
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if resolved, err := filepath.EvalSymlinks(root); err == nil {
 		root = resolved
 	}
 	filePath := filepath.Join(root, "test.txt")
-	os.WriteFile(filePath, []byte("hello"), 0o644)
+	if err := os.WriteFile(filePath, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Run("valid path", func(t *testing.T) {
 		got, err := ValidateAndRel(root, "test.txt")

--- a/util/fs_test.go
+++ b/util/fs_test.go
@@ -211,12 +211,10 @@ func TestSafeRel(t *testing.T) {
 	})
 
 	t.Run("invalid rel", func(t *testing.T) {
-		// On windows this might fail if they are on different drives,
-		// but on unix it usually works. To force an error, maybe empty base?
-		// Actually filepath.Rel("", "a") might error.
-		got := SafeRel("", "a")
-		if got != "a" {
-			t.Errorf("expected 'a' on error, got %q", got)
+		// Combining absolute and relative paths forces filepath.Rel to fail on Unix.
+		got := SafeRel("/a", "b")
+		if got != "b" {
+			t.Errorf("expected 'b' on error, got %q", got)
 		}
 	})
 }


### PR DESCRIPTION
Address #93 by refactoring repetitive file path normalization and basic file IO into common helper functions in `util/fs.go`.

### Changes

1. **New Utilities in `util/fs.go`**:
   - `OpenInRoot(root, path)`: Validates that a path is within a root directory and opens it.
   - `ValidateAndRel(root, target)`: Combines path validation with relative path generation, ensuring consistent relative output.
   - `SafeRel(base, target)`: A robust wrapper around `filepath.Rel` that falls back to the original path on error.

2. **Refactored `tools/local_tools.go`**:
   - Simplified `read_file`, `glob_files`, and `grep_files` by using the new helpers.
   - Removed redundant path validation and error handling logic.

3. **Refactored `core/prompts/prompts.go`**:
   - Simplified relative path generation for system prompts using `util.SafeRel`.
   - Updated `core/prompts/BUILD.bazel` with necessary dependencies.

4. **Security & Robustness**:
   - Ensured robust handling of symlinked roots (e.g., macOS `/var`) by using `ValidatePathInRoot` for base resolution in `ValidateAndRel`.
   - Added comprehensive unit tests in `util/fs_test.go` for all new helpers.