### PR TITLE
refactor: consolidate lockfile ignore logic and identification into util package

### DIFF
--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -121,9 +121,11 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return fmt.Errorf("failed to unmarshal configuration: %w", err)
 	}
 
+	trimmed := make([]string, len(cfg.IgnoredLockFiles))
 	for i, lf := range cfg.IgnoredLockFiles {
-		cfg.IgnoredLockFiles[i] = strings.TrimSpace(lf)
+		trimmed[i] = strings.TrimSpace(lf)
 	}
+	cfg.IgnoredLockFiles = trimmed
 
 	var missing []string
 	if cfg.Provider == "" {

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -121,6 +121,10 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return fmt.Errorf("failed to unmarshal configuration: %w", err)
 	}
 
+	for i, lf := range cfg.IgnoredLockFiles {
+		cfg.IgnoredLockFiles[i] = strings.TrimSpace(lf)
+	}
+
 	var missing []string
 	if cfg.Provider == "" {
 		missing = append(missing, "--provider")

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -51,7 +51,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	fs.StringVar(&cfg.CommitsFile, "commits-file", "", "Path to a file containing the commit messages")
 	fs.StringVar(&cfg.MCPConfigFile, "mcp-config", "", "Path to an mcp.json file configuring custom tools for the reviewer")
 	fs.BoolVar(&cfg.AllowURLFetch, "allow-url-fetch", false, "Enable the mcp-server-fetch tool (requires uvx to be installed)")
-	fs.StringSliceVar(&cfg.IgnoredLockFiles, "ignored-lock-files", tools.DefaultLockFiles, "Comma-separated list of lock files to ignore in diffs (overrides default)")
+	fs.StringSliceVar(&cfg.IgnoredLockFiles, "ignored-lock-files", util.DefaultLockFiles, "Comma-separated list of lock files to ignore in diffs (overrides default)")
 	fs.StringVar(&cfg.ConfigFile, "config", "", "Path to a configuration file (toml)")
 	fs.StringVar(&cfg.WishlistDir, "wishlist-dir", "", "Path to a directory where AI-Reviewer feedback/wishlist will be stored")
 
@@ -88,7 +88,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	v.SetDefault("base", "main")
 	v.SetDefault("head", "HEAD")
 	v.SetDefault("max-tokens", llm.DefaultMaxTokens)
-	v.SetDefault("ignored-lock-files", tools.DefaultLockFiles)
+	v.SetDefault("ignored-lock-files", util.DefaultLockFiles)
 	v.SetDefault("allow-url-fetch", false)
 
 	fs.VisitAll(func(f *flag.Flag) {

--- a/cmd/github/BUILD.bazel
+++ b/cmd/github/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//core",
-        "//tools",
+        "//util",
         "@com_github_google_go_github_v69//github",
         "@com_github_spf13_pflag//:pflag",
     ],

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/go-github/v69/github"
 	"github.com/menny/cassandra/core"
-	"github.com/menny/cassandra/tools"
+	"github.com/menny/cassandra/util"
 	flag "github.com/spf13/pflag"
 )
 
@@ -45,7 +45,7 @@ func main() {
 	flag.StringVar(&metadataFile, "metadata-file", "", "Path to the metadata file (for post-structured-review)")
 	flag.BoolVar(&allowReviewAction, "allow-review-action", false, "Whether to allow the AI's suggested review action (APPROVE/REQUEST_CHANGES). If false, forces COMMENT.")
 	flag.BoolVar(&deleteOldComments, "delete-old-comments", true, "Whether to delete previous bot-authored inline comments before posting a new review.")
-	flag.StringSliceVar(&ignoredLockFiles, "ignored-lock-files", tools.DefaultLockFiles, "Comma-separated list of lock files to ignore (overrides default)")
+	flag.StringSliceVar(&ignoredLockFiles, "ignored-lock-files", util.DefaultLockFiles, "Comma-separated list of lock files to ignore (overrides default)")
 
 	flag.Parse()
 
@@ -654,7 +654,7 @@ func getDiff(ctx context.Context, client *github.Client, owner, repo string, prN
 			// split on " b/" from the right to correctly isolate the destination path.
 			skipping = false
 			if idx := strings.LastIndex(line, " b/"); idx != -1 {
-				skipping = tools.IsLockFile(line[idx+3:], ignoredLockFiles)
+				skipping = util.IsLockFile(line[idx+3:], ignoredLockFiles)
 			}
 		}
 
@@ -678,7 +678,7 @@ func getFiles(ctx context.Context, client *github.Client, owner, repo string, pr
 			return nil, err
 		}
 		for _, f := range files {
-			if path := f.GetFilename(); !tools.IsLockFile(path, ignoredLockFiles) {
+			if path := f.GetFilename(); !util.IsLockFile(path, ignoredLockFiles) {
 				allFiles = append(allFiles, path)
 			}
 		}

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -49,6 +49,10 @@ func main() {
 
 	flag.Parse()
 
+	for i, lf := range ignoredLockFiles {
+		ignoredLockFiles[i] = strings.TrimSpace(lf)
+	}
+
 	if repoFullName == "" {
 		log.Fatal("--repo-full-name is required")
 	}

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -49,9 +49,11 @@ func main() {
 
 	flag.Parse()
 
+	trimmed := make([]string, len(ignoredLockFiles))
 	for i, lf := range ignoredLockFiles {
-		ignoredLockFiles[i] = strings.TrimSpace(lf)
+		trimmed[i] = strings.TrimSpace(lf)
 	}
+	ignoredLockFiles = trimmed
 
 	if repoFullName == "" {
 		log.Fatal("--repo-full-name is required")

--- a/core/config/BUILD.bazel
+++ b/core/config/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//core/prompts",
         "//llm",
-        "//tools",
+        "//util",
         "@com_github_spf13_viper//:viper",
     ],
 )

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/menny/cassandra/core/prompts"
 	"github.com/menny/cassandra/llm"
-	"github.com/menny/cassandra/tools"
+	"github.com/menny/cassandra/util"
 )
 
 // Config represents the complete configuration for a Cassandra reviewer.
@@ -47,7 +47,7 @@ func NewDefaultConfig() *Config {
 		Head:             "HEAD",
 		MainGuidelines:   "general",
 		MaxTokens:        llm.DefaultMaxTokens,
-		IgnoredLockFiles: tools.DefaultLockFiles,
+		IgnoredLockFiles: util.DefaultLockFiles,
 	}
 }
 
@@ -60,7 +60,7 @@ func Load(configFile string) (*Config, error) {
 	v.SetDefault("base", "main")
 	v.SetDefault("head", "HEAD")
 	v.SetDefault("max-tokens", llm.DefaultMaxTokens)
-	v.SetDefault("ignored-lock-files", tools.DefaultLockFiles)
+	v.SetDefault("ignored-lock-files", util.DefaultLockFiles)
 	v.SetDefault("allow-url-fetch", false)
 
 	if configFile != "" {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -87,9 +87,11 @@ func Load(configFile string) (*Config, error) {
 		return nil, fmt.Errorf("failed to unmarshal configuration: %w", err)
 	}
 
+	trimmed := make([]string, len(cfg.IgnoredLockFiles))
 	for i, lf := range cfg.IgnoredLockFiles {
-		cfg.IgnoredLockFiles[i] = strings.TrimSpace(lf)
+		trimmed[i] = strings.TrimSpace(lf)
 	}
+	cfg.IgnoredLockFiles = trimmed
 
 	return cfg, nil
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/viper"
 
@@ -84,6 +85,10 @@ func Load(configFile string) (*Config, error) {
 	cfg := &Config{}
 	if err := v.Unmarshal(cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal configuration: %w", err)
+	}
+
+	for i, lf := range cfg.IgnoredLockFiles {
+		cfg.IgnoredLockFiles[i] = strings.TrimSpace(lf)
 	}
 
 	return cfg, nil

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -49,4 +49,30 @@ model = "gemini-3.1-pro-preview"
 			t.Errorf("expected AllowURLFetch to be false, got true")
 		}
 	})
+
+	t.Run("trims ignored-lock-files", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "cassandra.toml")
+		content := `
+ignored-lock-files = [" go.sum ", " package-lock.json\t"]
+`
+		if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("failed to load config: %v", err)
+		}
+
+		expected := []string{"go.sum", "package-lock.json"}
+		if len(cfg.IgnoredLockFiles) != len(expected) {
+			t.Fatalf("expected %d ignored lock files, got %d", len(expected), len(cfg.IgnoredLockFiles))
+		}
+		for i, v := range expected {
+			if cfg.IgnoredLockFiles[i] != v {
+				t.Errorf("expected IgnoredLockFiles[%d] to be %q, got %q", i, v, cfg.IgnoredLockFiles[i])
+			}
+		}
+	})
 }

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -25,5 +25,8 @@ go_test(
         "wishlist_test.go",
     ],
     embed = [":tools"],
-    deps = ["//llm"],
+    deps = [
+        "//llm",
+        "//util",
+    ],
 )

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -34,7 +34,7 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 	cmdArgs := []string{"diff", diffRange}
 
 	cmdArgs = append(cmdArgs, "--", ".")
-	cmdArgs = append(cmdArgs, util.GitExcludeArgs(ignoredLockFiles)...)
+	cmdArgs = util.AppendGitExcludeArgs(cmdArgs, ignoredLockFiles)
 
 	out, err := runGit(ctx, workingDir, cmdArgs...)
 	if err != nil {
@@ -47,7 +47,8 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 	}
 
 	// Get file list
-	nameOnlyArgs := append([]string{"diff", "--name-only", diffRange, "--", "."}, util.GitExcludeArgs(ignoredLockFiles)...)
+	nameOnlyArgs := []string{"diff", "--name-only", diffRange, "--", "."}
+	nameOnlyArgs = util.AppendGitExcludeArgs(nameOnlyArgs, ignoredLockFiles)
 	nameOnlyOut, err := runGit(ctx, workingDir, nameOnlyArgs...)
 	if err != nil {
 		return diffText, nil, nil // Fallback if name-only fails

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -5,54 +5,9 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/menny/cassandra/util"
 )
-
-var DefaultLockFiles = []string{
-	"go.sum",
-	"package-lock.json",
-	"yarn.lock",
-	"pnpm-lock.yaml",
-	"bun.lockb",
-	"deno.lock",
-	"Cargo.lock",
-	"poetry.lock",
-	"uv.lock",
-	"Gemfile.lock",
-	"composer.lock",
-	"pubspec.lock",
-	"mix.lock",
-	"flake.lock",
-	"MODULE.bazel.lock",
-}
-
-// appendLockFileExcludes appends a git pathspec ":(exclude)*<name>" for each
-// entry in ignoredLockFiles to args, returning the grown slice. Used to suppress
-// noisy lockfile churn in diff and grep output.
-func appendLockFileExcludes(args []string, ignoredLockFiles []string) []string {
-	for _, lf := range ignoredLockFiles {
-		if strings.TrimSpace(lf) == "" {
-			continue
-		}
-		args = append(args, fmt.Sprintf(":(exclude)*%s", lf))
-	}
-	return args
-}
-
-// IsLockFile reports whether path names one of the ignored lockfiles —
-// either at the repository root (path == name) or in any subdirectory
-// (path ends in "/name"). Used by callers that operate on pre-computed
-// paths (e.g. PR file lists) rather than via git pathspec excludes.
-func IsLockFile(path string, ignoredLockFiles []string) bool {
-	for _, lf := range ignoredLockFiles {
-		if strings.TrimSpace(lf) == "" {
-			continue
-		}
-		if path == lf || strings.HasSuffix(path, "/"+lf) {
-			return true
-		}
-	}
-	return false
-}
 
 // runGit invokes `git <args>` in the given working directory (or the current
 // directory when dir is empty) and returns combined stdout+stderr. Callers
@@ -79,7 +34,7 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 	cmdArgs := []string{"diff", diffRange}
 
 	cmdArgs = append(cmdArgs, "--", ".")
-	cmdArgs = appendLockFileExcludes(cmdArgs, ignoredLockFiles)
+	cmdArgs = append(cmdArgs, util.GitExcludeArgs(ignoredLockFiles)...)
 
 	out, err := runGit(ctx, workingDir, cmdArgs...)
 	if err != nil {
@@ -92,7 +47,7 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 	}
 
 	// Get file list
-	nameOnlyArgs := appendLockFileExcludes([]string{"diff", "--name-only", diffRange, "--", "."}, ignoredLockFiles)
+	nameOnlyArgs := append([]string{"diff", "--name-only", diffRange, "--", "."}, util.GitExcludeArgs(ignoredLockFiles)...)
 	nameOnlyOut, err := runGit(ctx, workingDir, nameOnlyArgs...)
 	if err != nil {
 		return diffText, nil, nil // Fallback if name-only fails

--- a/tools/diff_test.go
+++ b/tools/diff_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/menny/cassandra/util"
 )
 
 func runGitCmd(t *testing.T, dir string, args ...string) {
@@ -57,7 +59,7 @@ func TestFetchGitDiff(t *testing.T) {
 	t.Run("Triple-dot diff", func(t *testing.T) {
 		// diff main...feature should ONLY show feature.txt
 		// NOT main_new.txt
-		diff, files, err := FetchGitDiff(context.Background(), tmpDir, "main", "feature", DefaultLockFiles)
+		diff, files, err := FetchGitDiff(context.Background(), tmpDir, "main", "feature", util.DefaultLockFiles)
 		if err != nil {
 			t.Fatalf("FetchGitDiff failed: %v", err)
 		}
@@ -98,7 +100,7 @@ func TestFetchGitDiff(t *testing.T) {
 		runGitCmd(t, tmpDir, "add", "go.sum")
 		runGitCmd(t, tmpDir, "commit", "-m", "add go.sum")
 
-		_, files, err := FetchGitDiff(context.Background(), tmpDir, "main", "feature", DefaultLockFiles)
+		_, files, err := FetchGitDiff(context.Background(), tmpDir, "main", "feature", util.DefaultLockFiles)
 		if err != nil {
 			t.Fatalf("FetchGitDiff failed: %v", err)
 		}
@@ -120,7 +122,7 @@ func TestFetchGitDiff(t *testing.T) {
 		runGitCmd(t, tmpDir, "add", "uncommitted.txt")
 
 		// head="HEAD" should include uncommitted changes
-		_, files, err := FetchGitDiff(context.Background(), tmpDir, "main", "HEAD", DefaultLockFiles)
+		_, files, err := FetchGitDiff(context.Background(), tmpDir, "main", "HEAD", util.DefaultLockFiles)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -136,7 +138,7 @@ func TestFetchGitDiff(t *testing.T) {
 		}
 
 		// head="feature" should NOT include uncommitted changes (uses triple-dot)
-		_, files, err = FetchGitDiff(context.Background(), tmpDir, "main", "feature", DefaultLockFiles)
+		_, files, err = FetchGitDiff(context.Background(), tmpDir, "main", "feature", util.DefaultLockFiles)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -146,29 +148,6 @@ func TestFetchGitDiff(t *testing.T) {
 			}
 		}
 	})
-}
-
-func TestIsLockFile(t *testing.T) {
-	cases := []struct {
-		path string
-		want bool
-	}{
-		{"go.sum", true},
-		{"backend/go.sum", true},
-		{"a/b/c/go.sum", true},
-		{"Cargo.lock", true},
-		{"main.go", false},
-		{"go.sum.bak", false},
-		{"my-go.sum", false}, // not a path-separated suffix
-		{"", false},
-	}
-	for _, c := range cases {
-		t.Run(c.path, func(t *testing.T) {
-			if got := IsLockFile(c.path, DefaultLockFiles); got != c.want {
-				t.Errorf("IsLockFile(%q) = %v, want %v", c.path, got, c.want)
-			}
-		})
-	}
 }
 
 func TestFetchGitDiff_CustomIgnore(t *testing.T) {

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -420,7 +420,7 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 			cmdArgs = append(cmdArgs, "--", ".")
 		}
 
-		cmdArgs = appendLockFileExcludes(cmdArgs, ignoredLockFiles)
+		cmdArgs = append(cmdArgs, util.GitExcludeArgs(ignoredLockFiles)...)
 
 		out, err := runGit(ctx, root, cmdArgs...)
 		if err != nil {

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -420,7 +420,7 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 			cmdArgs = append(cmdArgs, "--", ".")
 		}
 
-		cmdArgs = append(cmdArgs, util.GitExcludeArgs(ignoredLockFiles)...)
+		cmdArgs = util.AppendGitExcludeArgs(cmdArgs, ignoredLockFiles)
 
 		out, err := runGit(ctx, root, cmdArgs...)
 		if err != nil {

--- a/tools/local_tools_test.go
+++ b/tools/local_tools_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/menny/cassandra/llm"
+	"github.com/menny/cassandra/util"
 )
 
 func TestLocalReadFile(t *testing.T) {
@@ -205,7 +206,7 @@ func TestLocalGlobFiles_Errors(t *testing.T) {
 func TestLocalGrepFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	r := NewRegistry()
-	registerLocalGrepFiles(r, tmpDir, DefaultLockFiles)
+	registerLocalGrepFiles(r, tmpDir, util.DefaultLockFiles)
 
 	setupGitRepo(t, tmpDir)
 

--- a/util/AGENTS.md
+++ b/util/AGENTS.md
@@ -1,0 +1,5 @@
+# Utility Package Guidelines
+
+## Path Trimming
+
+- **Mandatory Trimming**: Configuration strings representing filenames, paths, or identifiers MUST be trimmed of whitespace before comparison or usage to prevent subtle match failures from trailing or leading whitespace in user input or configuration.

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -2,13 +2,19 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "util",
-    srcs = ["fs.go"],
+    srcs = [
+        "fs.go",
+        "lockfiles.go",
+    ],
     importpath = "github.com/menny/cassandra/util",
     visibility = ["//visibility:public"],
 )
 
 go_test(
     name = "util_test",
-    srcs = ["fs_test.go"],
+    srcs = [
+        "fs_test.go",
+        "lockfiles_test.go",
+    ],
     embed = [":util"],
 )

--- a/util/lockfiles.go
+++ b/util/lockfiles.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DefaultLockFiles is a list of common lockfile names used by various package
+// managers across different ecosystems.
+var DefaultLockFiles = []string{
+	"go.sum",
+	"package-lock.json",
+	"yarn.lock",
+	"pnpm-lock.yaml",
+	"bun.lockb",
+	"deno.lock",
+	"Cargo.lock",
+	"poetry.lock",
+	"uv.lock",
+	"Gemfile.lock",
+	"composer.lock",
+	"pubspec.lock",
+	"mix.lock",
+	"flake.lock",
+	"MODULE.bazel.lock",
+}
+
+// IsLockFile reports whether path names one of the ignored lockfiles —
+// either at the repository root (path == name) or in any subdirectory
+// (path ends in "/name").
+func IsLockFile(path string, ignoredLockFiles []string) bool {
+	for _, lf := range ignoredLockFiles {
+		lf = strings.TrimSpace(lf)
+		if lf == "" {
+			continue
+		}
+		// Efficiently check for exact match or suffix starting with a slash
+		if path == lf {
+			return true
+		}
+		if strings.HasSuffix(path, lf) && len(path) > len(lf) && path[len(path)-len(lf)-1] == '/' {
+			return true
+		}
+	}
+	return false
+}
+
+// GitExcludeArgs returns a slice of git pathspec exclude arguments for each
+// entry in ignoredLockFiles. For example, if "go.sum" is in the list, it
+// returns [":(exclude)*go.sum"].
+func GitExcludeArgs(ignoredLockFiles []string) []string {
+	args := make([]string, 0, len(ignoredLockFiles))
+	for _, lf := range ignoredLockFiles {
+		lf = strings.TrimSpace(lf)
+		if lf == "" {
+			continue
+		}
+		args = append(args, fmt.Sprintf(":(exclude)*%s", lf))
+	}
+	return args
+}

--- a/util/lockfiles.go
+++ b/util/lockfiles.go
@@ -30,11 +30,9 @@ var DefaultLockFiles = []string{
 // (path ends in "/name").
 func IsLockFile(path string, ignoredLockFiles []string) bool {
 	for _, lf := range ignoredLockFiles {
-		lf = strings.TrimSpace(lf)
 		if lf == "" {
 			continue
 		}
-		// Efficiently check for exact match or suffix starting with a slash
 		if path == lf {
 			return true
 		}
@@ -51,7 +49,6 @@ func IsLockFile(path string, ignoredLockFiles []string) bool {
 func GitExcludeArgs(ignoredLockFiles []string) []string {
 	args := make([]string, 0, len(ignoredLockFiles))
 	for _, lf := range ignoredLockFiles {
-		lf = strings.TrimSpace(lf)
 		if lf == "" {
 			continue
 		}

--- a/util/lockfiles.go
+++ b/util/lockfiles.go
@@ -43,11 +43,10 @@ func IsLockFile(path string, ignoredLockFiles []string) bool {
 	return false
 }
 
-// GitExcludeArgs returns a slice of git pathspec exclude arguments for each
-// entry in ignoredLockFiles. For example, if "go.sum" is in the list, it
-// returns [":(exclude)*go.sum"].
-func GitExcludeArgs(ignoredLockFiles []string) []string {
-	args := make([]string, 0, len(ignoredLockFiles))
+// AppendGitExcludeArgs appends git pathspec exclude arguments for each entry in
+// ignoredLockFiles to the provided args slice and returns the updated slice.
+// For example, if "go.sum" is in the list, it appends ":(exclude)*go.sum".
+func AppendGitExcludeArgs(args []string, ignoredLockFiles []string) []string {
 	for _, lf := range ignoredLockFiles {
 		if lf == "" {
 			continue

--- a/util/lockfiles_test.go
+++ b/util/lockfiles_test.go
@@ -1,6 +1,9 @@
 package util
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestIsLockFile(t *testing.T) {
 	cases := []struct {
@@ -20,6 +23,30 @@ func TestIsLockFile(t *testing.T) {
 		t.Run(c.path, func(t *testing.T) {
 			if got := IsLockFile(c.path, DefaultLockFiles); got != c.want {
 				t.Errorf("IsLockFile(%q) = %v, want %v", c.path, got, c.want)
+			}
+		})
+	}
+}
+
+func TestAppendGitExcludeArgs(t *testing.T) {
+	cases := []struct {
+		ignored []string
+		want    []string
+	}{
+		{[]string{"go.sum", "package-lock.json"}, []string{":(exclude)*go.sum", ":(exclude)*package-lock.json"}},
+		{[]string{"", "go.sum"}, []string{":(exclude)*go.sum"}},
+		{[]string{}, []string{}},
+	}
+	for _, c := range cases {
+		t.Run(strings.Join(c.ignored, ","), func(t *testing.T) {
+			got := AppendGitExcludeArgs([]string{}, c.ignored)
+			if len(got) != len(c.want) {
+				t.Fatalf("AppendGitExcludeArgs() = %v, want %v", got, c.want)
+			}
+			for i, v := range got {
+				if v != c.want[i] {
+					t.Errorf("AppendGitExcludeArgs()[%d] = %q, want %q", i, v, c.want[i])
+				}
 			}
 		})
 	}

--- a/util/lockfiles_test.go
+++ b/util/lockfiles_test.go
@@ -1,0 +1,26 @@
+package util
+
+import "testing"
+
+func TestIsLockFile(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"go.sum", true},
+		{"backend/go.sum", true},
+		{"a/b/c/go.sum", true},
+		{"Cargo.lock", true},
+		{"main.go", false},
+		{"go.sum.bak", false},
+		{"my-go.sum", false}, // not a path-separated suffix
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			if got := IsLockFile(c.path, DefaultLockFiles); got != c.want {
+				t.Errorf("IsLockFile(%q) = %v, want %v", c.path, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Consolidates the lockfile exclusion and identification logic into a single shared utility in the `util` package.

### Key Changes
- **New Utility**: Created `util/lockfiles.go` with a shared `DefaultLockFiles` list and helper functions (`IsLockFile`, `GitExcludeArgs`).
- **Optimization**: Optimized `IsLockFile` for zero-allocation suffix checking.
- **Performance**: Moved whitespace trimming to configuration load time (`core/config`, `cmd/github`, `cmd/ai_reviewer`) to keep hot loops allocation-free.
- **Maintenance**: Restored critical documentation for `runGit` and moved unit tests to `util/lockfiles_test.go`.
- **Standards**: Added `util/AGENTS.md` with mandatory path trimming guidelines.

Closes #91