### PR TITLE
refactor: reduce redundant comments and update CODE_STYLE.md

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -201,21 +201,26 @@ Avoid comments that merely paraphrase what the code already says. Use
 comments to explain *why* something is done, to document non-obvious
 side effects, or to clarify tricky logic.
 
+**Exported symbols** should always have a doc comment for `godoc` and IDE
+support, but these should be refined to add value (e.g., documenting error
+conditions or invariants) rather than simply echoing the function name.
+
 ```go
 // bad
-// UnmarshalArguments unmarshals the raw JSON Arguments into the given destination.
-func (tc *ToolCall) UnmarshalArguments(dest any) error { ... }
+i++ // increment i
 
-// WriteFileWithDirs creates any missing parent directories before writing the file.
-func WriteFileWithDirs(path string, data []byte) error { ... }
+// redundant (echoes name without adding value)
+// FetchGitCommits retrieves a list of git commits.
+func FetchGitCommits(...) { ... }
 
 // good
 // Use triple-dot for comparing the tip of head with the common ancestor of base.
 diffRange = fmt.Sprintf("%s...%s", base, head)
 
-// Resolve resolves symlinks for root because on some systems (like macOS)
-// /var is a symlink to /private/var, which can cause Rel to fail.
-if resolvedRoot, err := filepath.EvalSymlinks(root); err == nil { ... }
+// UnmarshalArguments decodes the raw JSON Arguments into dest. It returns a
+// formatted error if unmarshaling fails, suitable for inclusion in LLM-visible
+// tool results.
+func (tc *ToolCall) UnmarshalArguments(dest any) error { ... }
 ```
 
 **Why:** Redundant comments are "noise" that hinders readability. High-value

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -194,3 +194,30 @@ fmt.Fprintf(&sb, "- %s\n", name)
 
 **Why:** Idiomatic code reads faster and passes the golangci-lint
 analyzers (`mapsloop`, `QF1012`) that catch drift in new code.
+
+## Concise, High-Value Comments
+
+Avoid comments that merely paraphrase what the code already says. Use
+comments to explain *why* something is done, to document non-obvious
+side effects, or to clarify tricky logic.
+
+```go
+// bad
+// UnmarshalArguments unmarshals the raw JSON Arguments into the given destination.
+func (tc *ToolCall) UnmarshalArguments(dest any) error { ... }
+
+// WriteFileWithDirs creates any missing parent directories before writing the file.
+func WriteFileWithDirs(path string, data []byte) error { ... }
+
+// good
+// Use triple-dot for comparing the tip of head with the common ancestor of base.
+diffRange = fmt.Sprintf("%s...%s", base, head)
+
+// Resolve resolves symlinks for root because on some systems (like macOS)
+// /var is a symlink to /private/var, which can cause Rel to fail.
+if resolvedRoot, err := filepath.EvalSymlinks(root); err == nil { ... }
+```
+
+**Why:** Redundant comments are "noise" that hinders readability. High-value
+comments capture intent and design rationale that isn't immediately obvious
+from the code itself.

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -213,6 +213,11 @@ i++ // increment i
 // FetchGitCommits retrieves a list of git commits.
 func FetchGitCommits(...) { ... }
 
+// good (adds context about format and behavior)
+// FetchGitCommits returns a bulleted list of commit subjects (first line of
+// message) between base and head, excluding merge commits.
+func FetchGitCommits(...) { ... }
+
 // good
 // Use triple-dot for comparing the tip of head with the common ancestor of base.
 diffRange = fmt.Sprintf("%s...%s", base, head)

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -67,12 +67,10 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return err
 	}
 
-	// Error if there are dangling positional arguments
 	if len(fs.Args()) > 0 {
 		return fmt.Errorf("unknown or positional arguments provided: %v", fs.Args())
 	}
 
-	// Move to the intended working directory if executing via bazel or explicitly requested
 	targetDir := cfg.WorkingDir
 	if targetDir == "" {
 		targetDir = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
@@ -179,7 +177,6 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	stderr.Println("  API Key: [PROVIDED]")
 	stderr.Println("===============================")
 
-	// Initialize Reviewer
 	reporter := core.NewDefaultReporter(stderr.Writer())
 	reviewer, err := core.NewReviewer(ctx, cfg, targetDir, reporter)
 	if err != nil {
@@ -187,7 +184,6 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	}
 	defer reviewer.Close()
 
-	// Ensure metrics are written even on failure
 	if cfg.MetricsJSONFile != "" {
 		defer func() {
 			metrics := reviewer.Agent.GetMetrics()
@@ -292,7 +288,6 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 
 	reviewer.Agent.Reporter().ReportReviewHeader(len(changedFiles), cfg.MainGuidelines, cfg.Model)
 
-	// Final review goes to stdout so it can be captured cleanly.
 	fmt.Println(result)
 
 	if cfg.ReviewOutputFile != "" {

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -73,6 +73,8 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 
 	targetDir := cfg.WorkingDir
 	if targetDir == "" {
+		// If executing via 'bazel run', BUILD_WORKSPACE_DIRECTORY points to the
+		// source root. Otherwise, we default to the current directory.
 		targetDir = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
 	}
 	if targetDir != "" {

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -67,8 +67,6 @@ func main() {
 		log.Fatal("Action required (add-reaction, remove-reaction, post-comment, post-structured-review, get-metadata, get-diff, get-files, get-commits)")
 	}
 
-	// Process tag: only the inner text is provided.
-	// Default to 'cassandra-ai-review' if empty.
 	if tag == "" {
 		tag = "cassandra-ai-review"
 	}
@@ -247,9 +245,6 @@ func retryGitHubWrite(ctx context.Context, fn func() (*github.Response, error), 
 // wrapTag wraps a raw slug into a hidden HTML comment tag with an optional prefix.
 // It sanitizes the slug to ensure it cannot break out of the HTML comment.
 func wrapTag(slug, prefix string) string {
-	// Sanitize slug:
-	// 1. Replace '--' with '__' because HTML comments cannot contain '--'.
-	// 2. Remove '<' and '>' to prevent breakout.
 	s := strings.ReplaceAll(slug, "--", "__")
 	s = strings.ReplaceAll(s, "<", "")
 	s = strings.ReplaceAll(s, ">", "")

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -67,6 +67,7 @@ func main() {
 		log.Fatal("Action required (add-reaction, remove-reaction, post-comment, post-structured-review, get-metadata, get-diff, get-files, get-commits)")
 	}
 
+	// Process tag: only the inner text is provided (e.g. 'cassandra-ai-review').
 	if tag == "" {
 		tag = "cassandra-ai-review"
 	}

--- a/cmd/github/main.go
+++ b/cmd/github/main.go
@@ -245,6 +245,9 @@ func retryGitHubWrite(ctx context.Context, fn func() (*github.Response, error), 
 // wrapTag wraps a raw slug into a hidden HTML comment tag with an optional prefix.
 // It sanitizes the slug to ensure it cannot break out of the HTML comment.
 func wrapTag(slug, prefix string) string {
+	// Sanitize slug to ensure it cannot break out of the HTML comment:
+	// 1. Replace '--' with '__' because HTML comments cannot contain '--'.
+	// 2. Remove '<' and '>' to prevent potential tag injection.
 	s := strings.ReplaceAll(slug, "--", "__")
 	s = strings.ReplaceAll(s, "<", "")
 	s = strings.ReplaceAll(s, ">", "")

--- a/core/agent.go
+++ b/core/agent.go
@@ -14,8 +14,12 @@ import (
 )
 
 const (
+	// MaxIterationsPerFile is the recommended number of ReAct loop iterations to
+	// allocate per changed file in the diff.
 	MaxIterationsPerFile = 5
-	AbsoluteMaxIter      = 25
+	// AbsoluteMaxIter is the hard upper bound for the ReAct loop to prevent
+	// infinite recursion or excessive token spend.
+	AbsoluteMaxIter = 25
 )
 
 // CalculateMaxIterations returns a sensible iteration cap based on the number

--- a/core/agent.go
+++ b/core/agent.go
@@ -14,10 +14,8 @@ import (
 )
 
 const (
-	// MaxIterationsPerFile is the recommended number of iterations per changed file.
 	MaxIterationsPerFile = 5
-	// AbsoluteMaxIter is the upper bound for the ReAct loop to prevent infinite recursion.
-	AbsoluteMaxIter = 25
+	AbsoluteMaxIter      = 25
 )
 
 // CalculateMaxIterations returns a sensible iteration cap based on the number
@@ -57,7 +55,6 @@ func NewDefaultReporter(w io.Writer) Reporter {
 	return &defaultReporter{w: w}
 }
 
-// defaultReporter writes progress to an io.Writer.
 type defaultReporter struct {
 	w io.Writer
 }

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -45,6 +45,9 @@ type ToolCall struct {
 	Arguments string // raw JSON
 }
 
+// UnmarshalArguments decodes the raw JSON Arguments into dest. It returns a
+// formatted error if unmarshaling fails, suitable for inclusion in LLM-visible
+// tool results.
 func (tc *ToolCall) UnmarshalArguments(dest any) error {
 	if tc.Arguments == "" {
 		return nil

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -45,8 +45,6 @@ type ToolCall struct {
 	Arguments string // raw JSON
 }
 
-// UnmarshalArguments unmarshals the raw JSON Arguments into the given destination.
-// It returns a formatted error if the unmarshaling fails.
 func (tc *ToolCall) UnmarshalArguments(dest any) error {
 	if tc.Arguments == "" {
 		return nil

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -67,12 +67,7 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 // FetchGitCommits returns a bulleted list of commit subjects (first line of
 // message) between base and head, excluding merge commits.
 func FetchGitCommits(ctx context.Context, workingDir, base, head string) (string, error) {
-	var commitRange string
-	if head == "HEAD" {
-		commitRange = base + "..HEAD"
-	} else {
-		commitRange = fmt.Sprintf("%s..%s", base, head)
-	}
+	commitRange := fmt.Sprintf("%s..%s", base, head)
 
 	out, err := runGit(ctx, workingDir, "log", "--pretty=format:- %s", "--no-merges", commitRange)
 	if err != nil {

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -64,7 +64,8 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 	return diffText, filteredFiles, nil
 }
 
-// FetchGitCommits retrieves a list of commit messages between base and head.
+// FetchGitCommits returns a bulleted list of commit subjects (first line of
+// message) between base and head, excluding merge commits.
 func FetchGitCommits(ctx context.Context, workingDir, base, head string) (string, error) {
 	var commitRange string
 	if head == "HEAD" {
@@ -75,6 +76,8 @@ func FetchGitCommits(ctx context.Context, workingDir, base, head string) (string
 
 	out, err := runGit(ctx, workingDir, "log", "--pretty=format:- %s", "--no-merges", commitRange)
 	if err != nil {
+		// If git log fails (e.g., due to a shallow clone missing history), we
+		// return an error to be handled by the caller.
 		return "", fmt.Errorf("git log %s failed: %w. Output: %s", commitRange, err, string(out))
 	}
 

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -9,11 +9,8 @@ import (
 	"github.com/menny/cassandra/util"
 )
 
-// runGit invokes `git <args>` in the given working directory (or the current
-// directory when dir is empty) and returns combined stdout+stderr. Callers
-// wrap the returned error with their own context; runGit itself does not
-// format the error so callers can inspect the exit code via errors.As
-// (*exec.ExitError) where relevant.
+// runGit invokes `git <args>` in the given directory. Callers
+// wrap the returned error with their own context.
 func runGit(ctx context.Context, dir string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	if dir != "" {
@@ -25,10 +22,8 @@ func runGit(ctx context.Context, dir string, args ...string) ([]byte, error) {
 func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLockFiles []string) (string, []string, error) {
 	var diffRange string
 	if head == "HEAD" {
-		// Use single-dot to include uncommitted changes in the working tree/index
 		diffRange = base
 	} else {
-		// Use triple-dot for comparing the tip of head with the common ancestor of base
 		diffRange = fmt.Sprintf("%s...%s", base, head)
 	}
 	cmdArgs := []string{"diff", diffRange}
@@ -46,12 +41,11 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 		return "No diff found. The repository is perfectly clean.", nil, nil
 	}
 
-	// Get file list
 	nameOnlyArgs := []string{"diff", "--name-only", diffRange, "--", "."}
 	nameOnlyArgs = util.AppendGitExcludeArgs(nameOnlyArgs, ignoredLockFiles)
 	nameOnlyOut, err := runGit(ctx, workingDir, nameOnlyArgs...)
 	if err != nil {
-		return diffText, nil, nil // Fallback if name-only fails
+		return diffText, nil, nil
 	}
 	files := strings.Split(strings.TrimSpace(string(nameOnlyOut)), "\n")
 	var filteredFiles []string
@@ -64,7 +58,6 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 	return diffText, filteredFiles, nil
 }
 
-// FetchGitCommits retrieves a list of commit messages between base and head.
 func FetchGitCommits(ctx context.Context, workingDir, base, head string) (string, error) {
 	var commitRange string
 	if head == "HEAD" {
@@ -73,10 +66,8 @@ func FetchGitCommits(ctx context.Context, workingDir, base, head string) (string
 		commitRange = fmt.Sprintf("%s..%s", base, head)
 	}
 
-	// Use a clean format for commit messages
 	out, err := runGit(ctx, workingDir, "log", "--pretty=format:- %s", "--no-merges", commitRange)
 	if err != nil {
-		// If git log fails (e.g., shallow clone), we return an error to be handled by the caller.
 		return "", fmt.Errorf("git log %s failed: %w. Output: %s", commitRange, err, string(out))
 	}
 

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -9,8 +9,11 @@ import (
 	"github.com/menny/cassandra/util"
 )
 
-// runGit invokes `git <args>` in the given directory. Callers
-// wrap the returned error with their own context.
+// runGit invokes `git <args>` in the given working directory (or the current
+// directory when dir is empty) and returns combined stdout+stderr. Callers
+// wrap the returned error with their own context; runGit itself does not
+// format the error so callers can inspect the exit code via errors.As
+// (*exec.ExitError) where relevant.
 func runGit(ctx context.Context, dir string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	if dir != "" {
@@ -22,8 +25,10 @@ func runGit(ctx context.Context, dir string, args ...string) ([]byte, error) {
 func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLockFiles []string) (string, []string, error) {
 	var diffRange string
 	if head == "HEAD" {
+		// Use single-dot to include uncommitted changes in the working tree/index
 		diffRange = base
 	} else {
+		// Use triple-dot for comparing the tip of head with the common ancestor of base
 		diffRange = fmt.Sprintf("%s...%s", base, head)
 	}
 	cmdArgs := []string{"diff", diffRange}
@@ -41,11 +46,12 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 		return "No diff found. The repository is perfectly clean.", nil, nil
 	}
 
+	// Get file list
 	nameOnlyArgs := []string{"diff", "--name-only", diffRange, "--", "."}
 	nameOnlyArgs = util.AppendGitExcludeArgs(nameOnlyArgs, ignoredLockFiles)
 	nameOnlyOut, err := runGit(ctx, workingDir, nameOnlyArgs...)
 	if err != nil {
-		return diffText, nil, nil
+		return diffText, nil, nil // Fallback if name-only fails
 	}
 	files := strings.Split(strings.TrimSpace(string(nameOnlyOut)), "\n")
 	var filteredFiles []string
@@ -58,6 +64,7 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 	return diffText, filteredFiles, nil
 }
 
+// FetchGitCommits retrieves a list of commit messages between base and head.
 func FetchGitCommits(ctx context.Context, workingDir, base, head string) (string, error) {
 	var commitRange string
 	if head == "HEAD" {

--- a/util/fs.go
+++ b/util/fs.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+// WriteFileWithDirs creates any missing parent directories before writing the
+// file with 0o644 permissions. It uses 0o755 for any created directories.
 func WriteFileWithDirs(path string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("failed to create parent directory for %s: %w", path, err)
@@ -17,6 +19,8 @@ func WriteFileWithDirs(path string, data []byte) error {
 	return nil
 }
 
+// SanitizeFileName replaces any non-alphanumeric character with an underscore,
+// ensuring the string is safe for use as a filesystem component.
 func SanitizeFileName(s string) string {
 	var result strings.Builder
 	for _, r := range s {
@@ -29,8 +33,8 @@ func SanitizeFileName(s string) string {
 	return result.String()
 }
 
-// SanitizeFileNameWithDefault returns a default value
-// if the sanitized result is empty or consists only of underscores.
+// SanitizeFileNameWithDefault sanitizes s and returns defaultName if the
+// result is empty or consists entirely of underscores.
 func SanitizeFileNameWithDefault(s, defaultName string) string {
 	res := SanitizeFileName(s)
 	if strings.Trim(res, "_") == "" {

--- a/util/fs.go
+++ b/util/fs.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 )
 
-// WriteFileWithDirs creates any missing parent directories before writing the
-// file with 0o644 permissions.
 func WriteFileWithDirs(path string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("failed to create parent directory for %s: %w", path, err)
@@ -19,7 +17,6 @@ func WriteFileWithDirs(path string, data []byte) error {
 	return nil
 }
 
-// SanitizeFileName replaces any non-alphanumeric character with an underscore.
 func SanitizeFileName(s string) string {
 	var result strings.Builder
 	for _, r := range s {
@@ -32,8 +29,8 @@ func SanitizeFileName(s string) string {
 	return result.String()
 }
 
-// SanitizeFileNameWithDefault sanitizes a filename and returns a default value
-// if the result is empty or consists only of underscores.
+// SanitizeFileNameWithDefault returns a default value
+// if the sanitized result is empty or consists only of underscores.
 func SanitizeFileNameWithDefault(s, defaultName string) string {
 	res := SanitizeFileName(s)
 	if strings.Trim(res, "_") == "" {


### PR DESCRIPTION
## Summary
This PR addresses issue #90 by reducing redundant and overly verbose comments across the codebase and establishing a clear standard in the code style guide.

### Changes
- **Guidelines**: Added a new section to `CODE_STYLE.md` titled "Concise, High-Value Comments". It clarifies that while exported symbols should always have doc comments, they should be refined to add value rather than merely paraphrasing the code.
- **Refactoring**:
  - Removed redundant comments in `llm/llm.go`, `util/fs.go`, and `tools/diff.go`.
  - Conducted a codebase scan and removed additional redundancies in `cmd/ai_reviewer/main.go`, `cmd/github/main.go`, and `core/agent.go`.
- **Preservation**: Carefully preserved (or restored) high-value documentation, such as architectural contracts in `tools/diff.go` and non-obvious logic explanations in utility functions.

### Validation
- All tests passed: `go test ./...`
- Project builds successfully: `go build ./...`

Closes #90