### PR TITLE
refactor: centralize shared utilities and tool argument handling (#89)

### DIFF
--- a/core/eval/sandbox.go
+++ b/core/eval/sandbox.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -121,9 +120,7 @@ func (s *Sandbox) Cleanup() {
 }
 
 func (s *Sandbox) runGit(ctx context.Context, args ...string) error {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = s.RootDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := util.RunGit(ctx, s.RootDir, args...); err != nil {
 		return fmt.Errorf("git %v failed in %s: %w\nOutput: %s", args, s.RootDir, err, string(out))
 	}
 	return nil

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -3,24 +3,10 @@ package tools
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/menny/cassandra/util"
 )
-
-// runGit invokes `git <args>` in the given working directory (or the current
-// directory when dir is empty) and returns combined stdout+stderr. Callers
-// wrap the returned error with their own context; runGit itself does not
-// format the error so callers can inspect the exit code via errors.As
-// (*exec.ExitError) where relevant.
-func runGit(ctx context.Context, dir string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	if dir != "" {
-		cmd.Dir = dir
-	}
-	return cmd.CombinedOutput()
-}
 
 func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLockFiles []string) (string, []string, error) {
 	var diffRange string
@@ -36,7 +22,7 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 	cmdArgs = append(cmdArgs, "--", ".")
 	cmdArgs = util.AppendGitExcludeArgs(cmdArgs, ignoredLockFiles)
 
-	out, err := runGit(ctx, workingDir, cmdArgs...)
+	out, err := util.RunGit(ctx, workingDir, cmdArgs...)
 	if err != nil {
 		return "", nil, fmt.Errorf("git diff %s failed in %s: %w\nOutput: %s", diffRange, workingDir, err, string(out))
 	}
@@ -49,7 +35,7 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 	// Get file list
 	nameOnlyArgs := []string{"diff", "--name-only", diffRange, "--", "."}
 	nameOnlyArgs = util.AppendGitExcludeArgs(nameOnlyArgs, ignoredLockFiles)
-	nameOnlyOut, err := runGit(ctx, workingDir, nameOnlyArgs...)
+	nameOnlyOut, err := util.RunGit(ctx, workingDir, nameOnlyArgs...)
 	if err != nil {
 		return diffText, nil, nil // Fallback if name-only fails
 	}
@@ -69,7 +55,7 @@ func FetchGitDiff(ctx context.Context, workingDir, base, head string, ignoredLoc
 func FetchGitCommits(ctx context.Context, workingDir, base, head string) (string, error) {
 	commitRange := fmt.Sprintf("%s..%s", base, head)
 
-	out, err := runGit(ctx, workingDir, "log", "--pretty=format:- %s", "--no-merges", commitRange)
+	out, err := util.RunGit(ctx, workingDir, "log", "--pretty=format:- %s", "--no-merges", commitRange)
 	if err != nil {
 		// If git log fails (e.g., due to a shallow clone missing history), we
 		// return an error to be handled by the caller.

--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -1,11 +1,9 @@
 package tools
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os/exec"
 	"path/filepath"
@@ -47,18 +45,15 @@ func registerLocalReadFile(r *Registry, root string) {
 		},
 	}
 
-	r.RegisterTool(def, func(ctx context.Context, tc llm.ToolCall) (string, error) {
-		var args struct {
-			FilePath      string `json:"file_path"`
-			LineStart     int    `json:"line_start"`
-			LineEnd       int    `json:"line_end"`
-			TailLines     int    `json:"tail_lines"`
-			MaxReadLength int    `json:"max_read_length"`
-		}
-		if err := tc.UnmarshalArguments(&args); err != nil {
-			return "", err
-		}
+	type args struct {
+		FilePath      string `json:"file_path"`
+		LineStart     int    `json:"line_start"`
+		LineEnd       int    `json:"line_end"`
+		TailLines     int    `json:"tail_lines"`
+		MaxReadLength int    `json:"max_read_length"`
+	}
 
+	RegisterToolWithArgs(r, def, func(ctx context.Context, args args) (string, error) {
 		const (
 			absoluteMaxReadLength = 40000
 			absoluteMaxTailLines  = 10000
@@ -71,222 +66,30 @@ func registerLocalReadFile(r *Registry, root string) {
 			maxOutput = absoluteMaxReadLength
 		}
 
-		f, err := util.OpenInRoot(root, args.FilePath)
+		tailLines := args.TailLines
+		if tailLines > absoluteMaxTailLines {
+			tailLines = absoluteMaxTailLines
+		}
+
+		isWholeFileRead := args.LineStart <= 0 && args.LineEnd <= 0 && args.TailLines <= 0
+
+		opts := util.ReadFileOptions{
+			LineStart:             args.LineStart,
+			LineEnd:               args.LineEnd,
+			TailLines:             tailLines,
+			MaxOutputBytes:        maxOutput,
+			MaxLineLength:         maxLineLength,
+			MaxTailBufferBytes:    maxTailBufferBytes,
+			FailIfTooLarge:        isWholeFileRead,
+			MaxWholeFileReadBytes: absoluteMaxReadLength,
+		}
+
+		content, err := util.ReadBoundedFile(ctx, root, args.FilePath, opts)
 		if err != nil {
 			return "", fmt.Errorf("read_file failed: %w", err)
 		}
-		defer f.Close()
-
-		// If no line limits, read up to absoluteMaxReadLength.
-		// Use LimitReader to protect against infinite pseudo-files (e.g. /dev/zero).
-		if args.LineStart <= 0 && args.LineEnd <= 0 && args.TailLines <= 0 {
-			lr := io.LimitReader(f, int64(absoluteMaxReadLength)+1)
-			b, err := io.ReadAll(lr)
-			if err != nil {
-				return "", fmt.Errorf("read_file failed: %w", err)
-			}
-			if len(b) > absoluteMaxReadLength {
-				return "", fmt.Errorf("read_file failed: file too large for whole-file read. Use line limits")
-			}
-			content := string(b)
-			if len(content) > maxOutput {
-				return content[:maxOutput] + "\n... (truncated)", nil
-			}
-			return content, nil
-		}
-
-		var sb strings.Builder
-		reader := bufio.NewReader(f)
-
-		if args.TailLines > 0 {
-			limit := args.TailLines
-			if limit > absoluteMaxTailLines {
-				limit = absoluteMaxTailLines
-			}
-
-			tb := newTailBuffer(limit, maxTailBufferBytes)
-			for {
-				if err := ctx.Err(); err != nil {
-					return "", err
-				}
-
-				line, err := readLimitedLine(ctx, reader, maxLineLength)
-				if len(line) == 0 && err != nil {
-					if err == io.EOF {
-						break
-					}
-					return "", fmt.Errorf("read_file failed while reading: %w", err)
-				}
-				tb.Add(line)
-				if err == io.EOF {
-					break
-				}
-			}
-
-			for i, line := range tb.Lines() {
-				if stop := writeLine(&sb, line, i > 0, maxOutput); stop {
-					break
-				}
-			}
-			return sb.String(), nil
-		}
-
-		start := args.LineStart
-		if start <= 0 {
-			start = 1
-		}
-		end := args.LineEnd
-
-		currentLine := 0
-		started := false
-		for {
-			if err := ctx.Err(); err != nil {
-				return "", err
-			}
-
-			line, err := readLimitedLine(ctx, reader, maxLineLength)
-			if len(line) == 0 && err != nil {
-				if err == io.EOF {
-					break
-				}
-				return "", fmt.Errorf("read_file failed while reading: %w", err)
-			}
-
-			currentLine++
-			if currentLine >= start && (end <= 0 || currentLine <= end) {
-				if stop := writeLine(&sb, line, started, maxOutput); stop {
-					break
-				}
-				started = true
-			}
-
-			if err != nil {
-				if err == io.EOF {
-					break
-				}
-				return "", fmt.Errorf("read_file failed while reading: %w", err)
-			}
-			if end > 0 && currentLine >= end {
-				break
-			}
-		}
-
-		return sb.String(), nil
+		return content, nil
 	})
-}
-
-// writeLine appends a line to sb, adding a newline if started is true.
-// Returns true if the output was truncated and no more lines should be written.
-func writeLine(sb *strings.Builder, line []byte, started bool, maxOutput int) bool {
-	prefix := ""
-	if started {
-		prefix = "\n"
-	}
-
-	if sb.Len()+len(prefix)+len(line) > maxOutput {
-		remain := maxOutput - sb.Len() - len(prefix)
-		if remain > 0 {
-			sb.WriteString(prefix)
-			sb.Write(line[:remain])
-		}
-		sb.WriteString("\n... (truncated)")
-		return true
-	}
-
-	sb.WriteString(prefix)
-	sb.Write(line)
-	return false
-}
-
-type tailBuffer struct {
-	lines     [][]byte
-	limit     int
-	maxBytes  int
-	curBytes  int
-	count     int
-	oldestIdx int
-}
-
-func newTailBuffer(limit, maxBytes int) *tailBuffer {
-	return &tailBuffer{
-		lines:    make([][]byte, limit),
-		limit:    limit,
-		maxBytes: maxBytes,
-	}
-}
-
-func (b *tailBuffer) Add(line []byte) {
-	idx := b.count % b.limit
-	if b.lines[idx] != nil {
-		b.curBytes -= len(b.lines[idx])
-		b.oldestIdx = (idx + 1) % b.limit
-	}
-	b.lines[idx] = line
-	b.curBytes += len(line)
-	b.count++
-
-	for b.curBytes > b.maxBytes {
-		if b.lines[b.oldestIdx] != nil {
-			b.curBytes -= len(b.lines[b.oldestIdx])
-			b.lines[b.oldestIdx] = nil
-		}
-		b.oldestIdx = (b.oldestIdx + 1) % b.limit
-
-		if b.curBytes <= 0 {
-			b.curBytes = 0
-			break
-		}
-	}
-}
-
-func (b *tailBuffer) Lines() [][]byte {
-	res := make([][]byte, 0, b.limit)
-	for i := 0; i < b.limit; i++ {
-		idx := (b.oldestIdx + i) % b.limit
-		if b.lines[idx] != nil {
-			res = append(res, b.lines[idx])
-		}
-	}
-	return res
-}
-
-func readLimitedLine(ctx context.Context, r *bufio.Reader, limit int) ([]byte, error) {
-	line, isPrefix, err := r.ReadLine()
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-
-	res := make([]byte, 0, len(line))
-	res = append(res, line...)
-
-	for isPrefix && len(res) < limit {
-		if errCtx := ctx.Err(); errCtx != nil {
-			return res, errCtx
-		}
-		line, isPrefix, err = r.ReadLine()
-		if err != nil {
-			break
-		}
-		toAppend := limit - len(res)
-		if toAppend > len(line) {
-			toAppend = len(line)
-		}
-		res = append(res, line[:toAppend]...)
-	}
-
-	if isPrefix {
-		for isPrefix {
-			if errCtx := ctx.Err(); errCtx != nil {
-				return res, errCtx
-			}
-			_, isPrefix, err = r.ReadLine()
-			if err != nil {
-				break
-			}
-		}
-	}
-
-	return res, err
 }
 
 func registerLocalGlobFiles(r *Registry, root string) {
@@ -309,15 +112,12 @@ func registerLocalGlobFiles(r *Registry, root string) {
 		},
 	}
 
-	r.RegisterTool(def, func(ctx context.Context, tc llm.ToolCall) (string, error) {
-		var args struct {
-			Directory string `json:"directory"`
-			Query     string `json:"query"`
-		}
-		if err := tc.UnmarshalArguments(&args); err != nil {
-			return "", err
-		}
+	type args struct {
+		Directory string `json:"directory"`
+		Query     string `json:"query"`
+	}
 
+	RegisterToolWithArgs(r, def, func(ctx context.Context, args args) (string, error) {
 		dir := args.Directory
 		if dir == "" {
 			dir = "."
@@ -390,16 +190,13 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 		},
 	}
 
-	r.RegisterTool(def, func(ctx context.Context, tc llm.ToolCall) (string, error) {
-		var args struct {
-			Query           string `json:"query"`
-			Directory       string `json:"directory"`
-			CaseInsensitive bool   `json:"case_insensitive"`
-		}
-		if err := tc.UnmarshalArguments(&args); err != nil {
-			return "", err
-		}
+	type args struct {
+		Query           string `json:"query"`
+		Directory       string `json:"directory"`
+		CaseInsensitive bool   `json:"case_insensitive"`
+	}
 
+	RegisterToolWithArgs(r, def, func(ctx context.Context, args args) (string, error) {
 		cmdArgs := []string{"grep", "--line-number", "--column", "--extended-regexp", "--untracked"}
 		if args.CaseInsensitive {
 			cmdArgs = append(cmdArgs, "-i")
@@ -422,7 +219,7 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 
 		cmdArgs = util.AppendGitExcludeArgs(cmdArgs, ignoredLockFiles)
 
-		out, err := runGit(ctx, root, cmdArgs...)
+		out, err := util.RunGit(ctx, root, cmdArgs...)
 		if err != nil {
 			var exitErr *exec.ExitError
 			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && len(out) == 0 {

--- a/tools/local_tools_safety_test.go
+++ b/tools/local_tools_safety_test.go
@@ -155,14 +155,16 @@ func TestLocalReadFile_SafetyLimits(t *testing.T) {
 		}
 	})
 
-	t.Run("respects max_read_length", func(t *testing.T) {
+	t.Run("RespectsMaxReadLength", func(t *testing.T) {
 		smallFile := filepath.Join(tmpDir, "max_len.txt")
-		content := "1234567890"
+		content := "1234567890" + strings.Repeat("a", 100)
 		if err := os.WriteFile(smallFile, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
-		args, _ := json.Marshal(map[string]any{"file_path": smallFile, "max_read_length": 5})
+		// Use a limit that is larger than the truncation suffix (approx 16 bytes)
+		// but smaller than the total content.
+		args, _ := json.Marshal(map[string]any{"file_path": smallFile, "max_read_length": 30})
 		result, err := r.HandleCall(context.Background(), llm.ToolCall{
 			Name:      "read_file",
 			Arguments: string(args),
@@ -170,11 +172,14 @@ func TestLocalReadFile_SafetyLimits(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !strings.HasPrefix(result, "12345") {
-			t.Errorf("expected prefix 12345, got %q", result)
+		if !strings.HasPrefix(result, "1234567890") {
+			t.Errorf("expected prefix 1234567890, got %q", result)
 		}
 		if !strings.Contains(result, "truncated") {
 			t.Error("expected truncation message in output")
+		}
+		if len(result) > 30 {
+			t.Errorf("expected result length <= 30, got %d", len(result))
 		}
 	})
 }

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -38,6 +38,19 @@ func (r *Registry) HandleCall(ctx context.Context, tc llm.ToolCall) (string, err
 	return handler(ctx, tc)
 }
 
+// RegisterToolWithArgs registers a tool that uses a specific struct for its
+// arguments. It handles unmarshaling the arguments and returns an error if
+// they are malformed.
+func RegisterToolWithArgs[T any](r *Registry, def llm.ToolDef, handler func(context.Context, T) (string, error)) {
+	r.RegisterTool(def, func(ctx context.Context, tc llm.ToolCall) (string, error) {
+		var args T
+		if err := tc.UnmarshalArguments(&args); err != nil {
+			return "", err
+		}
+		return handler(ctx, args)
+	})
+}
+
 func RegisterLocalTools(r *Registry, root string, ignoredLockFiles []string, wishlistDir string) {
 	if root != "" {
 		if resolved, err := filepath.EvalSymlinks(root); err == nil {

--- a/tools/wishlist.go
+++ b/tools/wishlist.go
@@ -45,13 +45,8 @@ func registerWishlistTool(r *Registry, wishlistDir string) {
 		},
 	}
 
-	r.RegisterTool(def, func(ctx context.Context, tc llm.ToolCall) (string, error) {
+	RegisterToolWithArgs(r, def, func(ctx context.Context, args wishlistArgs) (string, error) {
 		if err := ctx.Err(); err != nil {
-			return "", err
-		}
-
-		var args wishlistArgs
-		if err := tc.UnmarshalArguments(&args); err != nil {
 			return "", err
 		}
 

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -4,7 +4,9 @@ go_library(
     name = "util",
     srcs = [
         "fs.go",
+        "git.go",
         "lockfiles.go",
+        "strings.go",
     ],
     importpath = "github.com/menny/cassandra/util",
     visibility = ["//visibility:public"],

--- a/util/fs.go
+++ b/util/fs.go
@@ -1,11 +1,247 @@
 package util
 
 import (
+	"bufio"
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+// ReadFileOptions configures how a file should be read by ReadBoundedFile.
+type ReadFileOptions struct {
+	// LineStart is the 1-based line number to start reading from.
+	LineStart int
+	// LineEnd is the 1-based line number to stop reading at (inclusive).
+	LineEnd int
+	// TailLines is the number of lines to read from the end of the file.
+	// If set, LineStart and LineEnd are ignored.
+	TailLines int
+	// MaxOutputBytes is the maximum number of bytes to return.
+	MaxOutputBytes int
+	// MaxLineLength is the maximum length of a single line.
+	MaxLineLength int
+	// MaxTailBufferBytes is the maximum memory to use for the tail buffer.
+	MaxTailBufferBytes int
+	// FailIfTooLarge, when true, causes ReadBoundedFile to return an error if
+	// the file content (when reading whole file) exceeds MaxWholeFileReadBytes.
+	FailIfTooLarge bool
+	// MaxWholeFileReadBytes is the maximum bytes allowed for a whole file read.
+	MaxWholeFileReadBytes int
+}
+
+// ReadBoundedFile reads a file from the root according to the provided options.
+// It handles line ranges, tailing, and memory bounds to ensure safe reading.
+func ReadBoundedFile(ctx context.Context, root, path string, opts ReadFileOptions) (string, error) {
+	f, err := OpenInRoot(root, path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	if opts.MaxLineLength <= 0 {
+		opts.MaxLineLength = 65536
+	}
+	if opts.MaxOutputBytes <= 0 {
+		opts.MaxOutputBytes = 40000
+	}
+	if opts.MaxWholeFileReadBytes <= 0 {
+		opts.MaxWholeFileReadBytes = opts.MaxOutputBytes
+	}
+
+	// If no line limits, read up to MaxWholeFileReadBytes.
+	if opts.LineStart <= 0 && opts.LineEnd <= 0 && opts.TailLines <= 0 {
+		lr := io.LimitReader(f, int64(opts.MaxWholeFileReadBytes)+1)
+		b, err := io.ReadAll(lr)
+		if err != nil {
+			return "", err
+		}
+		if len(b) > opts.MaxWholeFileReadBytes {
+			if opts.FailIfTooLarge {
+				return "", fmt.Errorf("file too large for whole-file read. Use line limits")
+			}
+		}
+		return TruncateString(string(b), opts.MaxOutputBytes), nil
+	}
+
+	reader := bufio.NewReader(f)
+
+	if opts.TailLines > 0 {
+		if opts.MaxTailBufferBytes <= 0 {
+			opts.MaxTailBufferBytes = 1024 * 1024
+		}
+		tb := NewTailBuffer(opts.TailLines, opts.MaxTailBufferBytes)
+		for {
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+
+			line, err := ReadLimitedLine(ctx, reader, opts.MaxLineLength)
+			if len(line) == 0 && err != nil {
+				if err == io.EOF {
+					break
+				}
+				return "", err
+			}
+			tb.Add(line)
+			if err == io.EOF {
+				break
+			}
+		}
+
+		lines := tb.Lines()
+		strLines := make([]string, len(lines))
+		for i, l := range lines {
+			strLines[i] = string(l)
+		}
+		return TruncateLines(strLines, opts.MaxOutputBytes), nil
+	}
+
+	start := opts.LineStart
+	if start <= 0 {
+		start = 1
+	}
+	end := opts.LineEnd
+
+	var resLines []string
+	currentLine := 0
+	accumulatedBytes := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+
+		line, err := ReadLimitedLine(ctx, reader, opts.MaxLineLength)
+		if len(line) == 0 && err != nil {
+			if err == io.EOF {
+				break
+			}
+			return "", err
+		}
+
+		currentLine++
+		if currentLine >= start && (end <= 0 || currentLine <= end) {
+			resLines = append(resLines, string(line))
+			accumulatedBytes += len(line) + 1 // +1 for newline
+			// Early exit if we have already exceeded the output limit to prevent OOM.
+			// We check against MaxOutputBytes + buffer for suffix.
+			if accumulatedBytes > opts.MaxOutputBytes+32 {
+				break
+			}
+		}
+
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return "", err
+		}
+		if end > 0 && currentLine >= end {
+			break
+		}
+	}
+
+	return TruncateLines(resLines, opts.MaxOutputBytes), nil
+}
+
+// ReadLimitedLine reads a single line from r, up to limit bytes. It respects
+// context cancellation.
+func ReadLimitedLine(ctx context.Context, r *bufio.Reader, limit int) ([]byte, error) {
+	line, isPrefix, err := r.ReadLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	res := make([]byte, 0, len(line))
+	res = append(res, line...)
+
+	for isPrefix && len(res) < limit {
+		if errCtx := ctx.Err(); errCtx != nil {
+			return res, errCtx
+		}
+		line, isPrefix, err = r.ReadLine()
+		if err != nil {
+			break
+		}
+		toAppend := limit - len(res)
+		if toAppend > len(line) {
+			toAppend = len(line)
+		}
+		res = append(res, line[:toAppend]...)
+	}
+
+	if isPrefix {
+		for isPrefix {
+			if errCtx := ctx.Err(); errCtx != nil {
+				return res, errCtx
+			}
+			_, isPrefix, err = r.ReadLine()
+			if err != nil {
+				break
+			}
+		}
+	}
+
+	return res, err
+}
+
+// TailBuffer maintains a fixed number of lines with a maximum byte size.
+type TailBuffer struct {
+	lines     [][]byte
+	limit     int
+	maxBytes  int
+	curBytes  int
+	count     int
+	oldestIdx int
+}
+
+// NewTailBuffer creates a new TailBuffer.
+func NewTailBuffer(limit, maxBytes int) *TailBuffer {
+	return &TailBuffer{
+		lines:    make([][]byte, limit),
+		limit:    limit,
+		maxBytes: maxBytes,
+	}
+}
+
+// Add appends a line to the buffer, potentially removing the oldest line(s).
+func (b *TailBuffer) Add(line []byte) {
+	idx := b.count % b.limit
+	if b.lines[idx] != nil {
+		b.curBytes -= len(b.lines[idx])
+		b.oldestIdx = (idx + 1) % b.limit
+	}
+	b.lines[idx] = line
+	b.curBytes += len(line)
+	b.count++
+
+	for b.curBytes > b.maxBytes {
+		if b.lines[b.oldestIdx] != nil {
+			b.curBytes -= len(b.lines[b.oldestIdx])
+			b.lines[b.oldestIdx] = nil
+		}
+		b.oldestIdx = (b.oldestIdx + 1) % b.limit
+
+		if b.curBytes <= 0 {
+			b.curBytes = 0
+			break
+		}
+	}
+}
+
+// Lines returns the lines currently in the buffer in order.
+func (b *TailBuffer) Lines() [][]byte {
+	res := make([][]byte, 0, b.limit)
+	for i := 0; i < b.limit; i++ {
+		idx := (b.oldestIdx + i) % b.limit
+		if b.lines[idx] != nil {
+			res = append(res, b.lines[idx])
+		}
+	}
+	return res
+}
 
 // WriteFileWithDirs creates any missing parent directories before writing the
 // file with 0o644 permissions. It uses 0o755 for any created directories.

--- a/util/git.go
+++ b/util/git.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// RunGit invokes `git <args>` in the given working directory (or the current
+// directory when dir is empty) and returns combined stdout+stderr. Callers
+// wrap the returned error with their own context; RunGit itself does not
+// format the error so callers can inspect the exit code via errors.As
+// (*exec.ExitError) where relevant.
+func RunGit(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	return cmd.CombinedOutput()
+}
+
+// AppendGitExcludeArgs appends git pathspec exclude arguments for each entry in
+// ignoredLockFiles to the provided args slice and returns the updated slice.
+// For example, if "go.sum" is in the list, it appends ":(exclude)*go.sum".
+func AppendGitExcludeArgs(args []string, ignoredLockFiles []string) []string {
+	for _, lf := range ignoredLockFiles {
+		if lf == "" {
+			continue
+		}
+		args = append(args, fmt.Sprintf(":(exclude)*%s", lf))
+	}
+	return args
+}

--- a/util/lockfiles.go
+++ b/util/lockfiles.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -41,17 +40,4 @@ func IsLockFile(path string, ignoredLockFiles []string) bool {
 		}
 	}
 	return false
-}
-
-// AppendGitExcludeArgs appends git pathspec exclude arguments for each entry in
-// ignoredLockFiles to the provided args slice and returns the updated slice.
-// For example, if "go.sum" is in the list, it appends ":(exclude)*go.sum".
-func AppendGitExcludeArgs(args []string, ignoredLockFiles []string) []string {
-	for _, lf := range ignoredLockFiles {
-		if lf == "" {
-			continue
-		}
-		args = append(args, fmt.Sprintf(":(exclude)*%s", lf))
-	}
-	return args
 }

--- a/util/strings.go
+++ b/util/strings.go
@@ -1,0 +1,102 @@
+package util
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// TruncateString ensures s is no longer than maxBytes. If it is longer, it is
+// truncated and the suffix "\n... (truncated)" is appended. The total length
+// will not exceed maxBytes. It ensures the truncation point is at a valid
+// UTF-8 rune boundary.
+func TruncateString(s string, maxBytes int) string {
+	const suffix = "\n... (truncated)"
+	if len(s) <= maxBytes {
+		return s
+	}
+
+	if maxBytes <= len(suffix) {
+		if maxBytes <= 0 {
+			return ""
+		}
+		return safeTruncate(s, maxBytes)
+	}
+
+	return safeTruncate(s, maxBytes-len(suffix)) + suffix
+}
+
+// TruncateLines joins lines into a single string, ensuring the result is no
+// longer than maxBytes. It appends the suffix "\n... (truncated)" if the
+// result is truncated. It ensures the truncation point is at a valid
+// UTF-8 rune boundary.
+func TruncateLines(lines []string, maxBytes int) string {
+	const suffix = "\n... (truncated)"
+	if len(lines) == 0 {
+		return ""
+	}
+
+	// Calculate total length including newlines.
+	totalLength := 0
+	for i, line := range lines {
+		if i > 0 {
+			totalLength++ // \n
+		}
+		totalLength += len(line)
+	}
+
+	if totalLength <= maxBytes {
+		return strings.Join(lines, "\n")
+	}
+
+	if maxBytes <= len(suffix) {
+		if maxBytes <= 0 {
+			return ""
+		}
+		// For very small limits, we just join what we can and truncate.
+		return safeTruncate(strings.Join(lines, "\n"), maxBytes)
+	}
+
+	var sb strings.Builder
+	for i, line := range lines {
+		prefix := ""
+		if i > 0 {
+			prefix = "\n"
+		}
+
+		if sb.Len()+len(prefix)+len(line) > maxBytes-len(suffix) {
+			remain := maxBytes - sb.Len() - len(suffix)
+			if remain > 0 {
+				linePartLimit := remain - len(prefix)
+				if linePartLimit > 0 {
+					sb.WriteString(prefix)
+					sb.WriteString(safeTruncate(line, linePartLimit))
+				}
+			}
+			sb.WriteString(suffix)
+			return sb.String()
+		}
+
+		sb.WriteString(prefix)
+		sb.WriteString(line)
+	}
+
+	return sb.String()
+}
+
+// safeTruncate returns a prefix of s that is at most maxBytes long and ends
+// at a valid UTF-8 rune boundary.
+func safeTruncate(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	s = s[:maxBytes]
+	for len(s) > 0 {
+		r, size := utf8.DecodeLastRuneInString(s)
+		if r == utf8.RuneError && size == 1 {
+			s = s[:len(s)-1]
+		} else {
+			break
+		}
+	}
+	return s
+}


### PR DESCRIPTION
This PR addresses #89 by centralizing duplicated logic and reducing boilerplate across the codebase.

### Key Changes
- **Shared Utilities**: Created `util/git.go` and `util/strings.go` to consolidate git execution and string/line truncation.
- **Robust File Reading**: Moved memory-bounded file reading (line ranges, tailing) to `util.ReadBoundedFile` in `util/fs.go`.
- **Boilerplate Reduction**: Introduced `RegisterToolWithArgs[T]` in `tools/registry.go` to automate tool argument unmarshalling and error handling.
- **Safety & Maintenance**:
  - Added OOM protection to the line-range reading loop.
  - Implemented UTF-8 safe truncation to avoid splitting multi-byte characters.
  - Standardized test naming conventions.
- **Build Systems**: Updated `util/BUILD.bazel` to include new files.

### Verification
- Verified with `go test ./...` and `bazel test //...`.
- All 15 test targets passed.