### PR TITLE
feat: implement parallel tool execution with concurrency limiting

### DIFF
--- a/.antigravitycli/f6ed83ed-7c9e-4b3e-a44b-6be3088081de.json
+++ b/.antigravitycli/f6ed83ed-7c9e-4b3e-a44b-6be3088081de.json
@@ -1,1 +1,0 @@
-/Users/mennyevendanan/.gemini/config/projects/f6ed83ed-7c9e-4b3e-a44b-6be3088081de.json

--- a/.antigravitycli/f6ed83ed-7c9e-4b3e-a44b-6be3088081de.json
+++ b/.antigravitycli/f6ed83ed-7c9e-4b3e-a44b-6be3088081de.json
@@ -1,0 +1,1 @@
+/Users/mennyevendanan/.gemini/config/projects/f6ed83ed-7c9e-4b3e-a44b-6be3088081de.json

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ bazel-testlogs
 
 # temp stuff
 scratch/
+.antigravitycli/
 
 # Conductor
 conductor/plan.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,9 @@ Progress reporting is abstracted via the `core.Reporter` interface.
 ### 7. Defensive Tool Implementation
 Tools that interact with external data (files, network, pipes) MUST be resilient to resource exhaustion and hangs. See [`tools/AGENTS.md`](tools/AGENTS.md) for the full requirements and security test mandates.
 
+### 8. Parallel Execution Patterns
+When parallelizing tool execution or background tasks, state updates (counters, logs, metrics) MUST be performed sequentially in the main loop before spawning goroutines. This ensures that log order remains predictable and eliminates the need for mutexes or atomic operations on shared counters during the parallel phase.
+
 ## Security Standards
 
 ### 1. GitHub Action Input Safety

--- a/core/agent.go
+++ b/core/agent.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/menny/cassandra/llm"
@@ -20,6 +21,9 @@ const (
 	// AbsoluteMaxIter is the hard upper bound for the ReAct loop to prevent
 	// infinite recursion or excessive token spend.
 	AbsoluteMaxIter = 25
+	// MaxToolConcurrency is the maximum number of tools allowed to run
+	// in parallel in a single turn.
+	MaxToolConcurrency = 8
 )
 
 // CalculateMaxIterations returns a sensible iteration cap based on the number
@@ -346,26 +350,39 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall) 
 	// role alternation (no consecutive same-role turns).
 	toolMsg := llm.Message{
 		Role:        llm.RoleTool,
-		ToolResults: make([]llm.ToolResult, 0, len(toolCalls)),
+		ToolResults: make([]llm.ToolResult, len(toolCalls)),
 	}
 
-	for _, tc := range toolCalls {
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, MaxToolConcurrency)
+
+	for i, tc := range toolCalls {
 		a.toolCalls[tc.Name]++
 		a.reporter.ReportToolCall(tc)
 
-		// Dispatch; on error, surface the message as the tool result so the
-		// LLM can reason about it rather than crashing the whole loop.
-		result, toolErr := a.registry.HandleCall(ctx, tc)
-		if toolErr != nil {
-			result = fmt.Sprintf("error: %v", toolErr)
-		}
+		wg.Add(1)
+		go func(i int, tc llm.ToolCall) {
+			defer wg.Done()
 
-		toolMsg.ToolResults = append(toolMsg.ToolResults, llm.ToolResult{
-			ToolCallID: tc.ID,
-			Name:       tc.Name,
-			Content:    result,
-		})
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			// Dispatch; on error, surface the message as the tool result so the
+			// LLM can reason about it rather than crashing the whole loop.
+			result, toolErr := a.registry.HandleCall(ctx, tc)
+			if toolErr != nil {
+				result = fmt.Sprintf("error: %v", toolErr)
+			}
+
+			toolMsg.ToolResults[i] = llm.ToolResult{
+				ToolCallID: tc.ID,
+				Name:       tc.Name,
+				Content:    result,
+			}
+		}(i, tc)
 	}
+
+	wg.Wait()
 	return toolMsg
 }
 

--- a/core/agent.go
+++ b/core/agent.go
@@ -367,6 +367,16 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall) 
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
+			defer func() {
+				if r := recover(); r != nil {
+					toolMsg.ToolResults[i] = llm.ToolResult{
+						ToolCallID: tc.ID,
+						Name:       tc.Name,
+						Content:    fmt.Sprintf("error: tool panicked: %v", r),
+					}
+				}
+			}()
+
 			// Dispatch; on error, surface the message as the tool result so the
 			// LLM can reason about it rather than crashing the whole loop.
 			result, toolErr := a.registry.HandleCall(ctx, tc)

--- a/core/agent.go
+++ b/core/agent.go
@@ -364,8 +364,17 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall) 
 		go func(i int, tc llm.ToolCall) {
 			defer wg.Done()
 
-			sem <- struct{}{}
-			defer func() { <-sem }()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				toolMsg.ToolResults[i] = llm.ToolResult{
+					ToolCallID: tc.ID,
+					Name:       tc.Name,
+					Content:    fmt.Sprintf("error: %v", ctx.Err()),
+				}
+				return
+			}
 
 			defer func() {
 				if r := recover(); r != nil {

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"strings"
 	"testing"
 	"time"
 
@@ -911,9 +912,11 @@ func TestRunReview_EmptyResponseExhausted(t *testing.T) {
 
 func TestExecuteToolCalls_Parallel(t *testing.T) {
 	dispatcher := newMockDispatcher()
-	// Each tool takes 100ms.
+	ready := make(chan struct{}, 2)
+	block := make(chan struct{})
 	dispatcher.handlers["slow_tool"] = func(ctx context.Context, tc llm.ToolCall) (string, error) {
-		time.Sleep(100 * time.Millisecond)
+		ready <- struct{}{}
+		<-block // wait until both tools are ready
 		return "done", nil
 	}
 
@@ -923,9 +926,25 @@ func TestExecuteToolCalls_Parallel(t *testing.T) {
 		{ID: "2", Name: "slow_tool"},
 	}
 
-	start := time.Now()
-	msg := agent.executeToolCalls(context.Background(), toolCalls)
-	elapsed := time.Since(start)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan llm.Message)
+	go func() {
+		done <- agent.executeToolCalls(ctx, toolCalls)
+	}()
+
+	// Wait for both tools to start executing concurrently;
+	for range 2 {
+		select {
+		case <-ready:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timeout waiting for tool to start. Execution is likely sequential.")
+		}
+	}
+
+	close(block) // Unblock both tools
+	msg := <-done
 
 	if len(msg.ToolResults) != 2 {
 		t.Fatalf("expected 2 results, got %d", len(msg.ToolResults))
@@ -935,13 +954,36 @@ func TestExecuteToolCalls_Parallel(t *testing.T) {
 	if msg.ToolResults[0].ToolCallID != "1" || msg.ToolResults[1].ToolCallID != "2" {
 		t.Errorf("results out of order: %+v", msg.ToolResults)
 	}
+}
 
-	// If sequential, would take at least 200ms.
-	// If parallel, should take slightly more than 100ms.
-	if elapsed >= 200*time.Millisecond {
-		t.Errorf("execution took %v, which suggests sequential execution (>= 200ms)", elapsed)
+func TestExecuteToolCalls_PanicRecovery(t *testing.T) {
+	dispatcher := newMockDispatcher()
+	dispatcher.handlers["panicking_tool"] = func(ctx context.Context, tc llm.ToolCall) (string, error) {
+		panic("boom")
 	}
-	if elapsed < 100*time.Millisecond {
-		t.Errorf("execution took %v, which is impossibly fast (< 100ms)", elapsed)
+	dispatcher.handlers["normal_tool"] = func(ctx context.Context, tc llm.ToolCall) (string, error) {
+		return "ok", nil
+	}
+
+	agent := newTestAgent(&mockLLM{}, dispatcher)
+	toolCalls := []llm.ToolCall{
+		{ID: "1", Name: "panicking_tool"},
+		{ID: "2", Name: "normal_tool"},
+	}
+
+	msg := agent.executeToolCalls(context.Background(), toolCalls)
+
+	if len(msg.ToolResults) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(msg.ToolResults))
+	}
+
+	// Check that the normal tool finished normally
+	if msg.ToolResults[1].Content != "ok" {
+		t.Errorf("expected normal tool result 'ok', got %q", msg.ToolResults[1].Content)
+	}
+
+	// Check that the panicking tool result contains the panic message
+	if !strings.Contains(msg.ToolResults[0].Content, "tool panicked: boom") {
+		t.Errorf("expected panic error message, got %q", msg.ToolResults[0].Content)
 	}
 }

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"maps"
 	"testing"
+	"time"
 
 	"github.com/menny/cassandra/llm"
 )
@@ -905,5 +906,42 @@ func TestRunReview_EmptyResponseExhausted(t *testing.T) {
 	// At least emptyResponseMaxAttempts calls must have been made.
 	if lm.callIdx < emptyResponseMaxAttempts {
 		t.Errorf("expected at least %d LLM calls, got %d", emptyResponseMaxAttempts, lm.callIdx)
+	}
+}
+
+func TestExecuteToolCalls_Parallel(t *testing.T) {
+	dispatcher := newMockDispatcher()
+	// Each tool takes 100ms.
+	dispatcher.handlers["slow_tool"] = func(ctx context.Context, tc llm.ToolCall) (string, error) {
+		time.Sleep(100 * time.Millisecond)
+		return "done", nil
+	}
+
+	agent := newTestAgent(&mockLLM{}, dispatcher)
+	toolCalls := []llm.ToolCall{
+		{ID: "1", Name: "slow_tool"},
+		{ID: "2", Name: "slow_tool"},
+	}
+
+	start := time.Now()
+	msg := agent.executeToolCalls(context.Background(), toolCalls)
+	elapsed := time.Since(start)
+
+	if len(msg.ToolResults) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(msg.ToolResults))
+	}
+
+	// Results should be in order.
+	if msg.ToolResults[0].ToolCallID != "1" || msg.ToolResults[1].ToolCallID != "2" {
+		t.Errorf("results out of order: %+v", msg.ToolResults)
+	}
+
+	// If sequential, would take at least 200ms.
+	// If parallel, should take slightly more than 100ms.
+	if elapsed >= 200*time.Millisecond {
+		t.Errorf("execution took %v, which suggests sequential execution (>= 200ms)", elapsed)
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("execution took %v, which is impossibly fast (< 100ms)", elapsed)
 	}
 }

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -916,8 +916,12 @@ func TestExecuteToolCalls_Parallel(t *testing.T) {
 	block := make(chan struct{})
 	dispatcher.handlers["slow_tool"] = func(ctx context.Context, tc llm.ToolCall) (string, error) {
 		ready <- struct{}{}
-		<-block // wait until both tools are ready
-		return "done", nil
+		select {
+		case <-block:
+			return "done", nil
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
 	}
 
 	agent := newTestAgent(&mockLLM{}, dispatcher)
@@ -929,7 +933,7 @@ func TestExecuteToolCalls_Parallel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	done := make(chan llm.Message)
+	done := make(chan llm.Message, 1)
 	go func() {
 		done <- agent.executeToolCalls(ctx, toolCalls)
 	}()


### PR DESCRIPTION
This PR introduces parallel tool execution in the ReAct loop to improve performance.

Key changes:
- Refactored `executeToolCalls` in `core/agent.go` to use goroutines and a `sync.WaitGroup`.
- Added a `MaxToolConcurrency` semaphore (limit 8) to prevent resource exhaustion.
- Updated `AGENTS.md` Engineering Guidelines with a new rule for parallel execution patterns.
- Added concurrency-verification tests in `core/agent_test.go`.
- Ignored `.antigravitycli/` folder in `.gitignore`.

Related to #87