### PR TITLE
refactor: refine provider options, thinking budget coercion, and concurrency checks

### DIFF
--- a/.cassandra.google.provider.settings.json
+++ b/.cassandra.google.provider.settings.json
@@ -1,0 +1,3 @@
+{
+  "thinking-level": "high"
+}

--- a/.cassandra.google.provider.settings.json
+++ b/.cassandra.google.provider.settings.json
@@ -1,3 +1,3 @@
 {
-  "thinking-level": "high"
+  "thinking-level": "HIGH"
 }

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,10 @@ inputs:
   max_tokens:
     description: 'Max tokens for the LLM response'
     required: false
+  provider_options:
+    description: 'Multiline string where each line is a provider-specific option (e.g. thinking-level=high)'
+    required: false
+    default: ''
 outputs:
   review_file:
     description: 'Path to the generated markdown review file.'
@@ -281,6 +285,7 @@ runs:
         ALLOW_URL_FETCH: ${{ inputs.allow_url_fetch }}
         IGNORED_LOCK_FILES: ${{ inputs.ignored_lock_files }}
         MAX_TOKENS: ${{ inputs.max_tokens }}
+        PROVIDER_OPTIONS: ${{ inputs.provider_options }}
       run: |
         # Use temporary files for the review outputs
         REVIEW_FILE="${{ runner.temp }}/cassandra_review.md"
@@ -359,6 +364,13 @@ runs:
         if [[ -n "$IGNORED_LOCK_FILES" ]]; then
           JOINED_IGNORED_LOCK_FILES=$(echo "$IGNORED_LOCK_FILES" | tr -d '\r' | tr '\n' ',' | sed 's/,,*/,/g' | sed 's/^,//;s/,$//')
           ARGS+=(--ignored-lock-files "$JOINED_IGNORED_LOCK_FILES")
+        fi
+
+        if [[ -n "$PROVIDER_OPTIONS" ]]; then
+          while read -r line || [[ -n "$line" ]]; do
+            if [[ -z "$line" ]]; then continue; fi
+            ARGS+=(--provider-options "$line")
+          done <<< "$PROVIDER_OPTIONS"
         fi
 
         if [[ -f "$METADATA_FILE" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -80,8 +80,8 @@ inputs:
   max_tokens:
     description: 'Max tokens for the LLM response'
     required: false
-  provider_options:
-    description: 'Multiline string where each line is a provider-specific option (e.g. thinking-level=high)'
+  provider_options_file:
+    description: 'Path to a JSON file containing provider-specific options'
     required: false
     default: ''
 outputs:
@@ -285,7 +285,7 @@ runs:
         ALLOW_URL_FETCH: ${{ inputs.allow_url_fetch }}
         IGNORED_LOCK_FILES: ${{ inputs.ignored_lock_files }}
         MAX_TOKENS: ${{ inputs.max_tokens }}
-        PROVIDER_OPTIONS: ${{ inputs.provider_options }}
+        PROVIDER_OPTIONS_FILE: ${{ inputs.provider_options_file }}
       run: |
         # Use temporary files for the review outputs
         REVIEW_FILE="${{ runner.temp }}/cassandra_review.md"
@@ -366,11 +366,13 @@ runs:
           ARGS+=(--ignored-lock-files "$JOINED_IGNORED_LOCK_FILES")
         fi
 
-        if [[ -n "$PROVIDER_OPTIONS" ]]; then
-          while read -r line || [[ -n "$line" ]]; do
-            if [[ -z "$line" ]]; then continue; fi
-            ARGS+=(--provider-options "$line")
-          done <<< "$PROVIDER_OPTIONS"
+        if [[ -n "$PROVIDER_OPTIONS_FILE" ]]; then
+          RESOLVED_OPTS="${{ github.workspace }}/$WORKING_DIRECTORY/$PROVIDER_OPTIONS_FILE"
+          if [[ -f "$RESOLVED_OPTS" ]]; then
+            ARGS+=(--provider-options-file "$RESOLVED_OPTS")
+          else
+            ARGS+=(--provider-options-file "$PROVIDER_OPTIONS_FILE")
+          fi
         fi
 
         if [[ -f "$METADATA_FILE" ]]; then

--- a/cassandra.toml
+++ b/cassandra.toml
@@ -3,7 +3,7 @@
 # Precedence: CLI Arguments > Configuration File > Defaults
 
 provider = "google"
-model = "gemini-3.1-pro-preview"
+model = "gemini-3.5-flash"
 allow-url-fetch = true
 
 # Path to an MCP configuration file.
@@ -16,3 +16,6 @@ supplemental-guidelines = [
     ".cassandra/self-preservation.md",
     ".cassandra/drive-by-fixes.md"
 ]
+
+[provider-options]
+thinking-level = "high"

--- a/cassandra.toml
+++ b/cassandra.toml
@@ -17,4 +17,4 @@ supplemental-guidelines = [
     ".cassandra/drive-by-fixes.md"
 ]
 
-provider-options-file = "scratch/provider_options.json"
+provider-options-file = ".cassandra.google.provider.settings.json"

--- a/cassandra.toml
+++ b/cassandra.toml
@@ -17,5 +17,4 @@ supplemental-guidelines = [
     ".cassandra/drive-by-fixes.md"
 ]
 
-[provider-options]
-thinking-level = "high"
+provider-options-file = "scratch/provider_options.json"

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -59,7 +59,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	fs.StringVar(&cfg.Provider, "provider", "", "LLM provider to use (google, anthropic, openai)")
 	fs.StringVar(&cfg.ProviderAPIKey, "provider-api-key", "", "API key for the selected provider (required)")
 	fs.StringVar(&cfg.ProviderURL, "provider-url", "", "Optional API endpoint URL override (e.g. for OpenAI-compatible providers like Ollama)")
-	fs.StringToString("provider-options", map[string]string{}, "Provider-specific options in key=value format (can be used multiple times)")
+	fs.StringVar(&cfg.ProviderOptionsFile, "provider-options-file", "", "Path to a JSON file containing provider-specific options")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -122,15 +122,16 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return fmt.Errorf("failed to unmarshal configuration: %w", err)
 	}
 
-	// Flag overrides for map types need manual merging because viper.Unmarshal
-	// often overwrites the entire map if any part is set via flags.
-	if opts := v.GetStringMap("provider-options"); len(opts) > 0 {
-		if cfg.ProviderOptions == nil {
-			cfg.ProviderOptions = make(map[string]any)
+	if cfg.ProviderOptionsFile != "" {
+		data, err := os.ReadFile(cfg.ProviderOptionsFile)
+		if err != nil {
+			return fmt.Errorf("failed to read provider options file %q: %w", cfg.ProviderOptionsFile, err)
 		}
-		for k, val := range opts {
-			cfg.ProviderOptions[k] = val
+		var opts map[string]any
+		if err := json.Unmarshal(data, &opts); err != nil {
+			return fmt.Errorf("failed to parse provider options file %q as JSON: %w", cfg.ProviderOptionsFile, err)
 		}
+		cfg.ProviderOptions = opts
 	}
 
 	trimmed := make([]string, len(cfg.IgnoredLockFiles))

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -59,6 +59,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	fs.StringVar(&cfg.Provider, "provider", "", "LLM provider to use (google, anthropic, openai)")
 	fs.StringVar(&cfg.ProviderAPIKey, "provider-api-key", "", "API key for the selected provider (required)")
 	fs.StringVar(&cfg.ProviderURL, "provider-url", "", "Optional API endpoint URL override (e.g. for OpenAI-compatible providers like Ollama)")
+	fs.StringToString("provider-options", map[string]string{}, "Provider-specific options in key=value format (can be used multiple times)")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -121,6 +122,17 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return fmt.Errorf("failed to unmarshal configuration: %w", err)
 	}
 
+	// Flag overrides for map types need manual merging because viper.Unmarshal
+	// often overwrites the entire map if any part is set via flags.
+	if opts := v.GetStringMap("provider-options"); len(opts) > 0 {
+		if cfg.ProviderOptions == nil {
+			cfg.ProviderOptions = make(map[string]any)
+		}
+		for k, val := range opts {
+			cfg.ProviderOptions[k] = val
+		}
+	}
+
 	trimmed := make([]string, len(cfg.IgnoredLockFiles))
 	for i, lf := range cfg.IgnoredLockFiles {
 		trimmed[i] = strings.TrimSpace(lf)
@@ -152,6 +164,9 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		stderr.Printf("  LLM Provider URL: %s\n", cfg.ProviderURL)
 	}
 	stderr.Printf("  Max Tokens: %d\n", cfg.MaxTokens)
+	if len(cfg.ProviderOptions) > 0 {
+		stderr.Printf("  Provider Options: %+v\n", cfg.ProviderOptions)
+	}
 	if cfg.MainGuidelines != "" {
 		stderr.Printf("  Main Guidelines: %s\n", cfg.MainGuidelines)
 	}

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -122,16 +122,8 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return fmt.Errorf("failed to unmarshal configuration: %w", err)
 	}
 
-	if cfg.ProviderOptionsFile != "" {
-		data, err := os.ReadFile(cfg.ProviderOptionsFile)
-		if err != nil {
-			return fmt.Errorf("failed to read provider options file %q: %w", cfg.ProviderOptionsFile, err)
-		}
-		var opts map[string]any
-		if err := json.Unmarshal(data, &opts); err != nil {
-			return fmt.Errorf("failed to parse provider options file %q as JSON: %w", cfg.ProviderOptionsFile, err)
-		}
-		cfg.ProviderOptions = opts
+	if err := cfg.LoadProviderOptions(); err != nil {
+		return err
 	}
 
 	trimmed := make([]string, len(cfg.IgnoredLockFiles))

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -88,7 +88,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		return fmt.Errorf("judge configuration is incomplete (judge-provider, judge-model, and judge-api-key are required)")
 	}
 
-	judge, err := factory.New(ctx, judgeProvider, judgeModel, judgeAPIKey, judgeURL)
+	judge, err := factory.New(ctx, judgeProvider, judgeModel, judgeAPIKey, judgeURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to init judge: %w", err)
 	}

--- a/core/agent.go
+++ b/core/agent.go
@@ -371,7 +371,7 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall) 
 				toolMsg.ToolResults[i] = llm.ToolResult{
 					ToolCallID: tc.ID,
 					Name:       tc.Name,
-					Content:    fmt.Sprintf("error: %v", ctx.Err()),
+					Content:    fmt.Sprintf("error: context canceled: %v", ctx.Err()),
 				}
 				return
 			}

--- a/core/agent.go
+++ b/core/agent.go
@@ -369,7 +369,7 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall) 
 				toolMsg.ToolResults[i] = llm.ToolResult{
 					ToolCallID: tc.ID,
 					Name:       tc.Name,
-					Content:    fmt.Sprintf("error: context canceled: %v", ctx.Err()),
+					Content:    fmt.Sprintf("error: %v", ctx.Err()),
 				}
 				return
 			case sem <- struct{}{}:
@@ -380,7 +380,7 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall) 
 				toolMsg.ToolResults[i] = llm.ToolResult{
 					ToolCallID: tc.ID,
 					Name:       tc.Name,
-					Content:    fmt.Sprintf("error: context canceled: %v", err),
+					Content:    fmt.Sprintf("error: %v", err),
 				}
 				return
 			}

--- a/core/agent.go
+++ b/core/agent.go
@@ -364,18 +364,7 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall) 
 		go func(i int, tc llm.ToolCall) {
 			defer wg.Done()
 
-			if err := ctx.Err(); err != nil {
-				toolMsg.ToolResults[i] = llm.ToolResult{
-					ToolCallID: tc.ID,
-					Name:       tc.Name,
-					Content:    fmt.Sprintf("error: context canceled: %v", err),
-				}
-				return
-			}
-
 			select {
-			case sem <- struct{}{}:
-				defer func() { <-sem }()
 			case <-ctx.Done():
 				toolMsg.ToolResults[i] = llm.ToolResult{
 					ToolCallID: tc.ID,
@@ -383,6 +372,8 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall) 
 					Content:    fmt.Sprintf("error: context canceled: %v", ctx.Err()),
 				}
 				return
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
 			}
 
 			if err := ctx.Err(); err != nil {

--- a/core/agent.go
+++ b/core/agent.go
@@ -364,6 +364,15 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall) 
 		go func(i int, tc llm.ToolCall) {
 			defer wg.Done()
 
+			if err := ctx.Err(); err != nil {
+				toolMsg.ToolResults[i] = llm.ToolResult{
+					ToolCallID: tc.ID,
+					Name:       tc.Name,
+					Content:    fmt.Sprintf("error: context canceled: %v", err),
+				}
+				return
+			}
+
 			select {
 			case sem <- struct{}{}:
 				defer func() { <-sem }()
@@ -372,6 +381,15 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall) 
 					ToolCallID: tc.ID,
 					Name:       tc.Name,
 					Content:    fmt.Sprintf("error: context canceled: %v", ctx.Err()),
+				}
+				return
+			}
+
+			if err := ctx.Err(); err != nil {
+				toolMsg.ToolResults[i] = llm.ToolResult{
+					ToolCallID: tc.ID,
+					Name:       tc.Name,
+					Content:    fmt.Sprintf("error: context canceled: %v", err),
 				}
 				return
 			}

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"maps"
 	"strings"
+	"sync"
 	"testing"
-	"time"
 
 	"github.com/menny/cassandra/llm"
 )
@@ -298,7 +298,7 @@ func TestAgent_ExecuteToolCalls(t *testing.T) {
 		if len(msg.ToolResults) != 1 {
 			t.Fatal("expected 1 result")
 		}
-		if msg.ToolResults[0].Content != "error: context canceled" {
+		if msg.ToolResults[0].Content != "error: context canceled: context canceled" {
 			t.Errorf("expected context canceled error, got: %q", msg.ToolResults[0].Content)
 		}
 	})
@@ -912,49 +912,43 @@ func TestRunReview_EmptyResponseExhausted(t *testing.T) {
 
 func TestExecuteToolCalls_Parallel(t *testing.T) {
 	dispatcher := newMockDispatcher()
-	ready := make(chan struct{}, 2)
-	block := make(chan struct{})
-	dispatcher.handlers["slow_tool"] = func(ctx context.Context, tc llm.ToolCall) (string, error) {
-		ready <- struct{}{}
-		select {
-		case <-block:
-			return "done", nil
-		case <-ctx.Done():
-			return "", ctx.Err()
-		}
+
+	var entered sync.WaitGroup
+	entered.Add(2)
+	release := make(chan struct{})
+
+	dispatcher.handlers["parallel_tool"] = func(ctx context.Context, tc llm.ToolCall) (string, error) {
+		entered.Done()
+		<-release
+		return "done", nil
 	}
 
 	agent := newTestAgent(&mockLLM{}, dispatcher)
 	toolCalls := []llm.ToolCall{
-		{ID: "1", Name: "slow_tool"},
-		{ID: "2", Name: "slow_tool"},
+		{ID: "1", Name: "parallel_tool"},
+		{ID: "2", Name: "parallel_tool"},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	done := make(chan llm.Message, 1)
+	// Run in parallel and wait for both to enter.
+	resChan := make(chan llm.Message)
 	go func() {
-		done <- agent.executeToolCalls(ctx, toolCalls)
+		resChan <- agent.executeToolCalls(context.Background(), toolCalls)
 	}()
 
-	// Wait for both tools to start executing concurrently;
-	for range 2 {
-		select {
-		case <-ready:
-		case <-time.After(2 * time.Second):
-			t.Fatal("Timeout waiting for tool to start. Execution is likely sequential.")
-		}
-	}
+	// If they are parallel, both will call entered.Done() and wait on release.
+	// We wait for both to enter here.
+	entered.Wait()
 
-	close(block) // Unblock both tools
-	msg := <-done
+	// Now release both.
+	close(release)
+
+	msg := <-resChan
 
 	if len(msg.ToolResults) != 2 {
 		t.Fatalf("expected 2 results, got %d", len(msg.ToolResults))
 	}
 
-	// Results should be in order.
+	// Results should be in order regardless of execution order.
 	if msg.ToolResults[0].ToolCallID != "1" || msg.ToolResults[1].ToolCallID != "2" {
 		t.Errorf("results out of order: %+v", msg.ToolResults)
 	}

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -298,7 +298,7 @@ func TestAgent_ExecuteToolCalls(t *testing.T) {
 		if len(msg.ToolResults) != 1 {
 			t.Fatal("expected 1 result")
 		}
-		if msg.ToolResults[0].Content != "error: context canceled: context canceled" {
+		if msg.ToolResults[0].Content != "error: context canceled" {
 			t.Errorf("expected context canceled error, got: %q", msg.ToolResults[0].Content)
 		}
 	})

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -96,19 +96,28 @@ func Load(configFile string) (*Config, error) {
 	}
 	cfg.IgnoredLockFiles = trimmed
 
-	if cfg.ProviderOptionsFile != "" {
-		data, err := os.ReadFile(cfg.ProviderOptionsFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read provider options file %q: %w", cfg.ProviderOptionsFile, err)
-		}
-		var opts map[string]any
-		if err := json.Unmarshal(data, &opts); err != nil {
-			return nil, fmt.Errorf("failed to parse provider options file %q as JSON: %w", cfg.ProviderOptionsFile, err)
-		}
-		cfg.ProviderOptions = opts
+	if err := cfg.LoadProviderOptions(); err != nil {
+		return nil, err
 	}
 
 	return cfg, nil
+}
+
+// LoadProviderOptions loads provider options from the configured ProviderOptionsFile.
+func (cfg *Config) LoadProviderOptions() error {
+	if cfg.ProviderOptionsFile == "" {
+		return nil
+	}
+	data, err := os.ReadFile(cfg.ProviderOptionsFile)
+	if err != nil {
+		return fmt.Errorf("failed to read provider options file %q: %w", cfg.ProviderOptionsFile, err)
+	}
+	var opts map[string]any
+	if err := json.Unmarshal(data, &opts); err != nil {
+		return fmt.Errorf("failed to parse provider options file %q as JSON: %w", cfg.ProviderOptionsFile, err)
+	}
+	cfg.ProviderOptions = opts
+	return nil
 }
 
 // ResolveGuidelinesContent fetches the content of a guideline, either from a file or the library.

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -39,7 +40,8 @@ type Config struct {
 	IgnoredLockFiles             []string       `mapstructure:"ignored-lock-files"`
 	ConfigFile                   string         `mapstructure:"config"`
 	WishlistDir                  string         `mapstructure:"wishlist-dir"`
-	ProviderOptions              map[string]any `mapstructure:"provider-options"`
+	ProviderOptionsFile          string         `mapstructure:"provider-options-file"`
+	ProviderOptions              map[string]any `mapstructure:"-"`
 }
 
 // NewDefaultConfig returns a Config with default values populated.
@@ -93,6 +95,18 @@ func Load(configFile string) (*Config, error) {
 		trimmed[i] = strings.TrimSpace(lf)
 	}
 	cfg.IgnoredLockFiles = trimmed
+
+	if cfg.ProviderOptionsFile != "" {
+		data, err := os.ReadFile(cfg.ProviderOptionsFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read provider options file %q: %w", cfg.ProviderOptionsFile, err)
+		}
+		var opts map[string]any
+		if err := json.Unmarshal(data, &opts); err != nil {
+			return nil, fmt.Errorf("failed to parse provider options file %q as JSON: %w", cfg.ProviderOptionsFile, err)
+		}
+		cfg.ProviderOptions = opts
+	}
 
 	return cfg, nil
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -15,30 +15,31 @@ import (
 
 // Config represents the complete configuration for a Cassandra reviewer.
 type Config struct {
-	Base                         string   `mapstructure:"base"`
-	Head                         string   `mapstructure:"head"`
-	Model                        string   `mapstructure:"model"`
-	Provider                     string   `mapstructure:"provider"`
-	ProviderAPIKey               string   `mapstructure:"provider-api-key"`
-	ProviderURL                  string   `mapstructure:"provider-url"`
-	WorkingDir                   string   `mapstructure:"-"`
-	MainGuidelines               string   `mapstructure:"main-guidelines"`
-	SupplementalGuidelines       []string `mapstructure:"supplemental-guidelines"`
-	MaxTokens                    int      `mapstructure:"max-tokens"`
-	ReviewOutputFile             string   `mapstructure:"review-output-file"`
-	OutputJSONFile               string   `mapstructure:"output-json"`
-	MetricsJSONFile              string   `mapstructure:"metrics-json"`
-	ExtractionModel              string   `mapstructure:"extraction-model"`
-	MetadataJSONFile             string   `mapstructure:"metadata-json"`
-	ApprovalEvaluationPromptFile string   `mapstructure:"approval-evaluation-prompt-file"`
-	DiffFile                     string   `mapstructure:"diff-file"`
-	FilesListFile                string   `mapstructure:"files-list-file"`
-	CommitsFile                  string   `mapstructure:"commits-file"`
-	MCPConfigFile                string   `mapstructure:"mcp-config"`
-	AllowURLFetch                bool     `mapstructure:"allow-url-fetch"`
-	IgnoredLockFiles             []string `mapstructure:"ignored-lock-files"`
-	ConfigFile                   string   `mapstructure:"config"`
-	WishlistDir                  string   `mapstructure:"wishlist-dir"`
+	Base                         string         `mapstructure:"base"`
+	Head                         string         `mapstructure:"head"`
+	Model                        string         `mapstructure:"model"`
+	Provider                     string         `mapstructure:"provider"`
+	ProviderAPIKey               string         `mapstructure:"provider-api-key"`
+	ProviderURL                  string         `mapstructure:"provider-url"`
+	WorkingDir                   string         `mapstructure:"-"`
+	MainGuidelines               string         `mapstructure:"main-guidelines"`
+	SupplementalGuidelines       []string       `mapstructure:"supplemental-guidelines"`
+	MaxTokens                    int            `mapstructure:"max-tokens"`
+	ReviewOutputFile             string         `mapstructure:"review-output-file"`
+	OutputJSONFile               string         `mapstructure:"output-json"`
+	MetricsJSONFile              string         `mapstructure:"metrics-json"`
+	ExtractionModel              string         `mapstructure:"extraction-model"`
+	MetadataJSONFile             string         `mapstructure:"metadata-json"`
+	ApprovalEvaluationPromptFile string         `mapstructure:"approval-evaluation-prompt-file"`
+	DiffFile                     string         `mapstructure:"diff-file"`
+	FilesListFile                string         `mapstructure:"files-list-file"`
+	CommitsFile                  string         `mapstructure:"commits-file"`
+	MCPConfigFile                string         `mapstructure:"mcp-config"`
+	AllowURLFetch                bool           `mapstructure:"allow-url-fetch"`
+	IgnoredLockFiles             []string       `mapstructure:"ignored-lock-files"`
+	ConfigFile                   string         `mapstructure:"config"`
+	WishlistDir                  string         `mapstructure:"wishlist-dir"`
+	ProviderOptions              map[string]any `mapstructure:"provider-options"`
 }
 
 // NewDefaultConfig returns a Config with default values populated.

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -33,7 +33,7 @@ func NewReviewer(ctx context.Context, cfg *config.Config, targetDir string, repo
 		reporter = NewDefaultReporter(os.Stderr)
 	}
 
-	client, err := factory.New(ctx, cfg.Provider, cfg.Model, cfg.ProviderAPIKey, cfg.ProviderURL)
+	client, err := factory.New(ctx, cfg.Provider, cfg.Model, cfg.ProviderAPIKey, cfg.ProviderURL, cfg.ProviderOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize LLM: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/migueleliasweb/go-github-mock v1.5.0
 	github.com/openai/openai-go v1.12.0
 	github.com/spf13/pflag v1.0.10
-	google.golang.org/genai v1.51.0
+	google.golang.org/genai v1.57.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genai v1.51.0 h1:IZGuUqgfx40INv3hLFGCbOSGp0qFqm7LVmDghzNIYqg=
 google.golang.org/genai v1.51.0/go.mod h1:A3kkl0nyBjyFlNjgxIwKq70julKbIxpSxqKO5gw/gmk=
+google.golang.org/genai v1.57.0 h1:qTyG2ynz5dQy2jF4CvZdLHHVslhR0heMue+zM1a4GNM=
+google.golang.org/genai v1.57.0/go.mod h1:A3kkl0nyBjyFlNjgxIwKq70julKbIxpSxqKO5gw/gmk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250122153221-138b5a5a4fd4 h1:yrTuav+chrF0zF/joFGICKTzYv7mh/gr9AgEXrVU8ao=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250122153221-138b5a5a4fd4/go.mod h1:+2Yz8+CLJbIfL9z73EW45avw8Lmge3xVElCP9zEKi50=
 google.golang.org/grpc v1.70.0 h1:pWFv03aZoHzlRKHWicjsZytKAiYCtNS0dHbXnIdq7jQ=

--- a/llm/anthropic/provider.go
+++ b/llm/anthropic/provider.go
@@ -24,13 +24,22 @@ const submitReviewToolName = "submit_review"
 type Provider struct {
 	client    anthropicsdk.Client
 	modelName string
+	options   map[string]any
 }
 
 // New creates a Provider for the given model. Extra SDK options (e.g.
 // option.WithBaseURL) can be passed for testing or proxying.
-func New(apiKey, modelName string, opts ...option.RequestOption) *Provider {
+//
+// Note: the options map is currently ignored by this provider but is received
+// to maintain architectural parity with other providers (e.g. Google) that
+// support model-specific tuning via the configuration file.
+func New(apiKey, modelName string, options map[string]any, opts ...option.RequestOption) *Provider {
 	allOpts := append([]option.RequestOption{option.WithAPIKey(apiKey)}, opts...)
-	return &Provider{client: anthropicsdk.NewClient(allOpts...), modelName: modelName}
+	return &Provider{
+		client:    anthropicsdk.NewClient(allOpts...),
+		modelName: modelName,
+		options:   options,
+	}
 }
 
 // GenerateContent sends messages to the Anthropic Messages API and returns a

--- a/llm/factory/factory.go
+++ b/llm/factory/factory.go
@@ -27,9 +27,6 @@ const (
 // providerFactory constructs a provider-specific llm.Model. Implementations
 // may use ctx (e.g. to dial eagerly) or ignore it. baseURL overrides the
 // provider's default API endpoint; pass an empty string for the default.
-// providerFactory constructs a provider-specific llm.Model. Implementations
-// may use ctx (e.g. to dial eagerly) or ignore it. baseURL overrides the
-// provider's default API endpoint; pass an empty string for the default.
 type providerFactory func(ctx context.Context, apiKey, modelName, baseURL string, options map[string]any) (llm.Model, error)
 
 // providers is the registry of supported Providers. Adding a new provider

--- a/llm/factory/factory.go
+++ b/llm/factory/factory.go
@@ -27,30 +27,33 @@ const (
 // providerFactory constructs a provider-specific llm.Model. Implementations
 // may use ctx (e.g. to dial eagerly) or ignore it. baseURL overrides the
 // provider's default API endpoint; pass an empty string for the default.
-type providerFactory func(ctx context.Context, apiKey, modelName, baseURL string) (llm.Model, error)
+// providerFactory constructs a provider-specific llm.Model. Implementations
+// may use ctx (e.g. to dial eagerly) or ignore it. baseURL overrides the
+// provider's default API endpoint; pass an empty string for the default.
+type providerFactory func(ctx context.Context, apiKey, modelName, baseURL string, options map[string]any) (llm.Model, error)
 
 // providers is the registry of supported Providers. Adding a new provider
 // is a single entry here; factory.New and the "unsupported provider" error
 // message derive from this map automatically.
 var providers = map[Provider]providerFactory{
-	ProviderAnthropic: func(_ context.Context, apiKey, modelName, baseURL string) (llm.Model, error) {
+	ProviderAnthropic: func(_ context.Context, apiKey, modelName, baseURL string, options map[string]any) (llm.Model, error) {
 		if baseURL != "" {
 			fmt.Fprintf(os.Stderr, "Warning: baseURL %q is ignored by the anthropic provider\n", baseURL)
 		}
 		// Anthropic client is constructed synchronously; ctx is unused at
 		// construction time (the SDK dials lazily per request).
-		return anthropic.New(apiKey, modelName), nil
+		return anthropic.New(apiKey, modelName, options), nil
 	},
-	ProviderGoogle: func(ctx context.Context, apiKey, modelName, baseURL string) (llm.Model, error) {
+	ProviderGoogle: func(ctx context.Context, apiKey, modelName, baseURL string, options map[string]any) (llm.Model, error) {
 		if baseURL != "" {
 			fmt.Fprintf(os.Stderr, "Warning: baseURL %q is ignored by the google provider\n", baseURL)
 		}
-		return google.New(ctx, apiKey, modelName)
+		return google.New(ctx, apiKey, modelName, options)
 	},
-	ProviderOpenAI: func(_ context.Context, apiKey, modelName, baseURL string) (llm.Model, error) {
+	ProviderOpenAI: func(_ context.Context, apiKey, modelName, baseURL string, options map[string]any) (llm.Model, error) {
 		// OpenAI client is constructed synchronously; ctx is unused at
 		// construction time (the SDK dials lazily per request).
-		return openai.New(apiKey, modelName, baseURL), nil
+		return openai.New(apiKey, modelName, baseURL, options), nil
 	},
 }
 
@@ -60,13 +63,13 @@ var providers = map[Provider]providerFactory{
 // allowing callers to target OpenAI-compatible services (e.g. Ollama).
 // The returned model automatically retries transient errors with exponential
 // back-off using llm.DefaultRetryAttempts and llm.DefaultRetryBaseDelay.
-func New(ctx context.Context, provider, modelName, apiKey, baseURL string) (llm.Model, error) {
+func New(ctx context.Context, provider, modelName, apiKey, baseURL string, options map[string]any) (llm.Model, error) {
 	f, ok := providers[Provider(provider)]
 	if !ok {
 		return nil, fmt.Errorf("unsupported provider %q: supported providers are %s",
 			provider, supportedProviders())
 	}
-	inner, err := f(ctx, apiKey, modelName, baseURL)
+	inner, err := f(ctx, apiKey, modelName, baseURL, options)
 	if err != nil {
 		return nil, err
 	}

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strconv"
 
 	"google.golang.org/genai"
 
@@ -38,6 +39,37 @@ func clampInt32(n int) int32 {
 		return math.MinInt32
 	}
 	return int32(n) //nolint:gosec // bounds-checked above
+}
+
+// parseThinkingBudget safely coerces a thinking budget option of unknown type (e.g. from JSON/Viper)
+// into an int32 representation. Returns the parsed value and true if conversion succeeded, or (0, false) otherwise.
+func parseThinkingBudget(opt any) (int32, bool) {
+	switch v := opt.(type) {
+	case int:
+		return int32(v), true
+	case int32:
+		return v, true
+	case int64:
+		if v > math.MaxInt32 || v < math.MinInt32 {
+			return 0, false
+		}
+		return int32(v), true
+	case float64:
+		if v > float64(math.MaxInt32) || v < float64(math.MinInt32) {
+			return 0, false
+		}
+		return int32(v), true
+	case string:
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		if parsed > math.MaxInt32 || parsed < math.MinInt32 {
+			return 0, false
+		}
+		return int32(parsed), true
+	}
+	return 0, false
 }
 
 // jsonSchemaTypes maps JSON Schema type names (lowercase) to their
@@ -85,12 +117,13 @@ func (p *Provider) GenerateContent(ctx context.Context, messages []llm.Message, 
 		config.ThinkingConfig.ThinkingLevel = genai.ThinkingLevel(level)
 		config.ThinkingConfig.IncludeThoughts = true
 	}
-	if budget, ok := p.options["thinking-budget"].(float64); ok {
-		if config.ThinkingConfig == nil {
-			config.ThinkingConfig = &genai.ThinkingConfig{}
+	if opt, ok := p.options["thinking-budget"]; ok {
+		if budget, parsed := parseThinkingBudget(opt); parsed {
+			if config.ThinkingConfig == nil {
+				config.ThinkingConfig = &genai.ThinkingConfig{}
+			}
+			config.ThinkingConfig.ThinkingBudget = &budget
 		}
-		b := int32(budget)
-		config.ThinkingConfig.ThinkingBudget = &b
 	}
 	if systemInstruction != nil {
 		config.SystemInstruction = systemInstruction
@@ -128,12 +161,13 @@ func (p *Provider) GenerateStructuredContent(ctx context.Context, messages []llm
 		genaiConfig.ThinkingConfig.ThinkingLevel = genai.ThinkingLevel(level)
 		genaiConfig.ThinkingConfig.IncludeThoughts = true
 	}
-	if budget, ok := p.options["thinking-budget"].(float64); ok {
-		if genaiConfig.ThinkingConfig == nil {
-			genaiConfig.ThinkingConfig = &genai.ThinkingConfig{}
+	if opt, ok := p.options["thinking-budget"]; ok {
+		if budget, parsed := parseThinkingBudget(opt); parsed {
+			if genaiConfig.ThinkingConfig == nil {
+				genaiConfig.ThinkingConfig = &genai.ThinkingConfig{}
+			}
+			genaiConfig.ThinkingConfig.ThinkingBudget = &budget
 		}
-		b := int32(budget)
-		genaiConfig.ThinkingConfig.ThinkingBudget = &b
 	}
 	if systemInstruction != nil {
 		genaiConfig.SystemInstruction = systemInstruction

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -99,17 +99,9 @@ func New(ctx context.Context, apiKey, modelName string, options map[string]any) 
 	return &Provider{client: c, modelName: modelName, options: options}, nil
 }
 
-// GenerateContent sends messages to the Gemini API and returns a normalised
-// llm.Response.
-func (p *Provider) GenerateContent(ctx context.Context, messages []llm.Message, tools []llm.ToolDef, maxTokens int) (*llm.Response, error) {
-	contents, systemInstruction, err := toContents(messages)
-	if err != nil {
-		return nil, fmt.Errorf("google: building contents: %w", err)
-	}
-
-	config := &genai.GenerateContentConfig{
-		MaxOutputTokens: clampInt32(maxTokens),
-	}
+// applyThinkingConfig extracts, parses, and applies the "thinking-level" and "thinking-budget"
+// options onto the genai.GenerateContentConfig struct if present.
+func (p *Provider) applyThinkingConfig(config *genai.GenerateContentConfig) {
 	if level, ok := p.options["thinking-level"].(string); ok {
 		if config.ThinkingConfig == nil {
 			config.ThinkingConfig = &genai.ThinkingConfig{}
@@ -125,6 +117,20 @@ func (p *Provider) GenerateContent(ctx context.Context, messages []llm.Message, 
 			config.ThinkingConfig.ThinkingBudget = &budget
 		}
 	}
+}
+
+// GenerateContent sends messages to the Gemini API and returns a normalised
+// llm.Response.
+func (p *Provider) GenerateContent(ctx context.Context, messages []llm.Message, tools []llm.ToolDef, maxTokens int) (*llm.Response, error) {
+	contents, systemInstruction, err := toContents(messages)
+	if err != nil {
+		return nil, fmt.Errorf("google: building contents: %w", err)
+	}
+
+	config := &genai.GenerateContentConfig{
+		MaxOutputTokens: clampInt32(maxTokens),
+	}
+	p.applyThinkingConfig(config)
 	if systemInstruction != nil {
 		config.SystemInstruction = systemInstruction
 	}
@@ -154,21 +160,7 @@ func (p *Provider) GenerateStructuredContent(ctx context.Context, messages []llm
 		ResponseMIMEType: "application/json",
 		ResponseSchema:   convertSchema(schema),
 	}
-	if level, ok := p.options["thinking-level"].(string); ok {
-		if genaiConfig.ThinkingConfig == nil {
-			genaiConfig.ThinkingConfig = &genai.ThinkingConfig{}
-		}
-		genaiConfig.ThinkingConfig.ThinkingLevel = genai.ThinkingLevel(level)
-		genaiConfig.ThinkingConfig.IncludeThoughts = true
-	}
-	if opt, ok := p.options["thinking-budget"]; ok {
-		if budget, parsed := parseThinkingBudget(opt); parsed {
-			if genaiConfig.ThinkingConfig == nil {
-				genaiConfig.ThinkingConfig = &genai.ThinkingConfig{}
-			}
-			genaiConfig.ThinkingConfig.ThinkingBudget = &budget
-		}
-	}
+	p.applyThinkingConfig(genaiConfig)
 	if systemInstruction != nil {
 		genaiConfig.SystemInstruction = systemInstruction
 	}

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"strconv"
+	"strings"
 
 	"google.golang.org/genai"
 
@@ -106,7 +107,7 @@ func (p *Provider) applyThinkingConfig(config *genai.GenerateContentConfig) {
 		if config.ThinkingConfig == nil {
 			config.ThinkingConfig = &genai.ThinkingConfig{}
 		}
-		config.ThinkingConfig.ThinkingLevel = genai.ThinkingLevel(level)
+		config.ThinkingConfig.ThinkingLevel = genai.ThinkingLevel(strings.ToUpper(level))
 		config.ThinkingConfig.IncludeThoughts = true
 	}
 	if opt, ok := p.options["thinking-budget"]; ok {

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"os"
 	"strconv"
-	"strings"
 
 	"google.golang.org/genai"
 
@@ -107,7 +106,7 @@ func (p *Provider) applyThinkingConfig(config *genai.GenerateContentConfig) {
 		if config.ThinkingConfig == nil {
 			config.ThinkingConfig = &genai.ThinkingConfig{}
 		}
-		config.ThinkingConfig.ThinkingLevel = genai.ThinkingLevel(strings.ToUpper(level))
+		config.ThinkingConfig.ThinkingLevel = genai.ThinkingLevel(level)
 		config.ThinkingConfig.IncludeThoughts = true
 	}
 	if opt, ok := p.options["thinking-budget"]; ok {

--- a/llm/google/provider.go
+++ b/llm/google/provider.go
@@ -55,15 +55,16 @@ var jsonSchemaTypes = map[string]genai.Type{
 type Provider struct {
 	client    *genai.Client
 	modelName string
+	options   map[string]any
 }
 
 // New creates a Provider for the given model using the Gemini Developer API.
-func New(ctx context.Context, apiKey, modelName string) (*Provider, error) {
+func New(ctx context.Context, apiKey, modelName string, options map[string]any) (*Provider, error) {
 	c, err := genai.NewClient(ctx, &genai.ClientConfig{APIKey: apiKey})
 	if err != nil {
 		return nil, fmt.Errorf("google: failed to create client: %w", err)
 	}
-	return &Provider{client: c, modelName: modelName}, nil
+	return &Provider{client: c, modelName: modelName, options: options}, nil
 }
 
 // GenerateContent sends messages to the Gemini API and returns a normalised
@@ -76,6 +77,20 @@ func (p *Provider) GenerateContent(ctx context.Context, messages []llm.Message, 
 
 	config := &genai.GenerateContentConfig{
 		MaxOutputTokens: clampInt32(maxTokens),
+	}
+	if level, ok := p.options["thinking-level"].(string); ok {
+		if config.ThinkingConfig == nil {
+			config.ThinkingConfig = &genai.ThinkingConfig{}
+		}
+		config.ThinkingConfig.ThinkingLevel = genai.ThinkingLevel(level)
+		config.ThinkingConfig.IncludeThoughts = true
+	}
+	if budget, ok := p.options["thinking-budget"].(float64); ok {
+		if config.ThinkingConfig == nil {
+			config.ThinkingConfig = &genai.ThinkingConfig{}
+		}
+		b := int32(budget)
+		config.ThinkingConfig.ThinkingBudget = &b
 	}
 	if systemInstruction != nil {
 		config.SystemInstruction = systemInstruction
@@ -105,6 +120,20 @@ func (p *Provider) GenerateStructuredContent(ctx context.Context, messages []llm
 		MaxOutputTokens:  clampInt32(maxTokens),
 		ResponseMIMEType: "application/json",
 		ResponseSchema:   convertSchema(schema),
+	}
+	if level, ok := p.options["thinking-level"].(string); ok {
+		if genaiConfig.ThinkingConfig == nil {
+			genaiConfig.ThinkingConfig = &genai.ThinkingConfig{}
+		}
+		genaiConfig.ThinkingConfig.ThinkingLevel = genai.ThinkingLevel(level)
+		genaiConfig.ThinkingConfig.IncludeThoughts = true
+	}
+	if budget, ok := p.options["thinking-budget"].(float64); ok {
+		if genaiConfig.ThinkingConfig == nil {
+			genaiConfig.ThinkingConfig = &genai.ThinkingConfig{}
+		}
+		b := int32(budget)
+		genaiConfig.ThinkingConfig.ThinkingBudget = &b
 	}
 	if systemInstruction != nil {
 		genaiConfig.SystemInstruction = systemInstruction

--- a/llm/google/provider_test.go
+++ b/llm/google/provider_test.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -345,4 +346,38 @@ func TestParseGenaiResponse_NoCandidates(t *testing.T) {
 	resp := &genai.GenerateContentResponse{}
 	_, err := parseGenaiResponse(resp)
 	assert.Error(t, err)
+}
+
+func TestParseThinkingBudget(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      any
+		wantVal    int32
+		wantParsed bool
+	}{
+		{"nil input", nil, 0, false},
+		{"int input", 1024, 1024, true},
+		{"int32 input", int32(2048), 2048, true},
+		{"int64 input", int64(4096), 4096, true},
+		{"int64 out of bounds positive", int64(math.MaxInt32 + 1), 0, false},
+		{"int64 out of bounds negative", int64(math.MinInt32 - 1), 0, false},
+		{"float64 input", float64(2048), 2048, true},
+		{"float64 out of bounds positive", float64(math.MaxInt32) + 1.0, 0, false},
+		{"float64 out of bounds negative", float64(math.MinInt32) - 1.0, 0, false},
+		{"string numeric input", "4096", 4096, true},
+		{"string non-numeric input", "invalid", 0, false},
+		{"string out of bounds positive", "2147483648", 0, false},
+		{"string out of bounds negative", "-2147483649", 0, false},
+		{"invalid type struct", struct{}{}, 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, parsed := parseThinkingBudget(tt.input)
+			assert.Equal(t, tt.wantParsed, parsed)
+			if tt.wantParsed {
+				assert.Equal(t, tt.wantVal, val)
+			}
+		})
+	}
 }

--- a/llm/google/provider_test.go
+++ b/llm/google/provider_test.go
@@ -409,12 +409,12 @@ func TestApplyThinkingConfig(t *testing.T) {
 			},
 		},
 		{
-			name:     "thinking level only - lowercase gets normalized",
+			name:     "thinking level only - lowercase passed raw",
 			options:  map[string]any{"thinking-level": "high"},
 			setupCfg: func() *genai.GenerateContentConfig { return &genai.GenerateContentConfig{} },
 			verify: func(t *testing.T, cfg *genai.GenerateContentConfig) {
 				require.NotNil(t, cfg.ThinkingConfig)
-				assert.Equal(t, genai.ThinkingLevel("HIGH"), cfg.ThinkingConfig.ThinkingLevel)
+				assert.Equal(t, genai.ThinkingLevel("high"), cfg.ThinkingConfig.ThinkingLevel)
 				assert.True(t, cfg.ThinkingConfig.IncludeThoughts)
 				assert.Nil(t, cfg.ThinkingConfig.ThinkingBudget)
 			},
@@ -439,7 +439,7 @@ func TestApplyThinkingConfig(t *testing.T) {
 			setupCfg: func() *genai.GenerateContentConfig { return &genai.GenerateContentConfig{} },
 			verify: func(t *testing.T, cfg *genai.GenerateContentConfig) {
 				require.NotNil(t, cfg.ThinkingConfig)
-				assert.Equal(t, genai.ThinkingLevel("MEDIUM"), cfg.ThinkingConfig.ThinkingLevel)
+				assert.Equal(t, genai.ThinkingLevel("medium"), cfg.ThinkingConfig.ThinkingLevel)
 				assert.True(t, cfg.ThinkingConfig.IncludeThoughts)
 				require.NotNil(t, cfg.ThinkingConfig.ThinkingBudget)
 				assert.Equal(t, int32(2048), *cfg.ThinkingConfig.ThinkingBudget)

--- a/llm/google/provider_test.go
+++ b/llm/google/provider_test.go
@@ -381,3 +381,78 @@ func TestParseThinkingBudget(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyThinkingConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  map[string]any
+		setupCfg func() *genai.GenerateContentConfig
+		verify   func(t *testing.T, cfg *genai.GenerateContentConfig)
+	}{
+		{
+			name:     "no options",
+			options:  nil,
+			setupCfg: func() *genai.GenerateContentConfig { return &genai.GenerateContentConfig{} },
+			verify: func(t *testing.T, cfg *genai.GenerateContentConfig) {
+				assert.Nil(t, cfg.ThinkingConfig)
+			},
+		},
+		{
+			name:     "thinking level only - uppercase",
+			options:  map[string]any{"thinking-level": "THINKING_LEVEL_ON"},
+			setupCfg: func() *genai.GenerateContentConfig { return &genai.GenerateContentConfig{} },
+			verify: func(t *testing.T, cfg *genai.GenerateContentConfig) {
+				require.NotNil(t, cfg.ThinkingConfig)
+				assert.Equal(t, genai.ThinkingLevel("THINKING_LEVEL_ON"), cfg.ThinkingConfig.ThinkingLevel)
+				assert.True(t, cfg.ThinkingConfig.IncludeThoughts)
+				assert.Nil(t, cfg.ThinkingConfig.ThinkingBudget)
+			},
+		},
+		{
+			name:     "thinking level only - lowercase gets normalized",
+			options:  map[string]any{"thinking-level": "high"},
+			setupCfg: func() *genai.GenerateContentConfig { return &genai.GenerateContentConfig{} },
+			verify: func(t *testing.T, cfg *genai.GenerateContentConfig) {
+				require.NotNil(t, cfg.ThinkingConfig)
+				assert.Equal(t, genai.ThinkingLevel("HIGH"), cfg.ThinkingConfig.ThinkingLevel)
+				assert.True(t, cfg.ThinkingConfig.IncludeThoughts)
+				assert.Nil(t, cfg.ThinkingConfig.ThinkingBudget)
+			},
+		},
+		{
+			name:     "thinking budget only - valid int",
+			options:  map[string]any{"thinking-budget": 1024},
+			setupCfg: func() *genai.GenerateContentConfig { return &genai.GenerateContentConfig{} },
+			verify: func(t *testing.T, cfg *genai.GenerateContentConfig) {
+				require.NotNil(t, cfg.ThinkingConfig)
+				require.NotNil(t, cfg.ThinkingConfig.ThinkingBudget)
+				assert.Equal(t, int32(1024), *cfg.ThinkingConfig.ThinkingBudget)
+				assert.False(t, cfg.ThinkingConfig.IncludeThoughts)
+			},
+		},
+		{
+			name: "both level and budget",
+			options: map[string]any{
+				"thinking-level":  "medium",
+				"thinking-budget": "2048",
+			},
+			setupCfg: func() *genai.GenerateContentConfig { return &genai.GenerateContentConfig{} },
+			verify: func(t *testing.T, cfg *genai.GenerateContentConfig) {
+				require.NotNil(t, cfg.ThinkingConfig)
+				assert.Equal(t, genai.ThinkingLevel("MEDIUM"), cfg.ThinkingConfig.ThinkingLevel)
+				assert.True(t, cfg.ThinkingConfig.IncludeThoughts)
+				require.NotNil(t, cfg.ThinkingConfig.ThinkingBudget)
+				assert.Equal(t, int32(2048), *cfg.ThinkingConfig.ThinkingBudget)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Provider{options: tt.options}
+			cfg := tt.setupCfg()
+			p.applyThinkingConfig(cfg)
+			tt.verify(t, cfg)
+		})
+	}
+}

--- a/llm/openai/provider.go
+++ b/llm/openai/provider.go
@@ -21,19 +21,28 @@ const submitReviewToolName = "submit_review"
 type Provider struct {
 	client    openaisdk.Client
 	modelName string
+	options   map[string]any
 }
 
 // New creates a Provider for the given model. baseURL overrides the default
 // OpenAI API endpoint — pass an empty string to use the official API. This
 // allows targeting OpenAI-compatible providers (e.g. Ollama, local LLMs).
 // Extra SDK options can be passed for testing or additional configuration.
-func New(apiKey, modelName, baseURL string, opts ...option.RequestOption) *Provider {
+//
+// Note: the options map is currently ignored by this provider but is received
+// to maintain architectural parity with other providers (e.g. Google) that
+// support model-specific tuning via the configuration file.
+func New(apiKey, modelName, baseURL string, options map[string]any, opts ...option.RequestOption) *Provider {
 	allOpts := []option.RequestOption{option.WithAPIKey(apiKey)}
 	if baseURL != "" {
 		allOpts = append(allOpts, option.WithBaseURL(baseURL))
 	}
 	allOpts = append(allOpts, opts...)
-	return &Provider{client: openaisdk.NewClient(allOpts...), modelName: modelName}
+	return &Provider{
+		client:    openaisdk.NewClient(allOpts...),
+		modelName: modelName,
+		options:   options,
+	}
 }
 
 // GenerateContent sends messages to the OpenAI Chat Completions API and

--- a/llm/openai/provider_test.go
+++ b/llm/openai/provider_test.go
@@ -359,7 +359,7 @@ func TestNew_BaseURL_GenerateContent(t *testing.T) {
 	// parses the response correctly.
 	srv, capturedPath := newFakeChatServer(t, chatCompletionResponse("hello from custom url"))
 
-	p := New("fake-api-key", "test-model", srv.URL)
+	p := New("fake-api-key", "test-model", srv.URL, nil)
 	resp, err := p.GenerateContent(context.Background(), []llm.Message{
 		{Role: llm.RoleUser, Text: "ping"},
 	}, nil, 100)
@@ -374,7 +374,7 @@ func TestNew_BaseURL_GenerateStructuredContent(t *testing.T) {
 	// Verify that GenerateStructuredContent also honours the custom base URL.
 	srv, capturedPath := newFakeChatServer(t, chatCompletionResponse(`{"key":"value"}`))
 
-	p := New("fake-api-key", "test-model", srv.URL)
+	p := New("fake-api-key", "test-model", srv.URL, nil)
 	schema := map[string]any{"type": "object"}
 	resp, err := p.GenerateStructuredContent(context.Background(), []llm.Message{
 		{Role: llm.RoleUser, Text: "extract"},
@@ -390,7 +390,7 @@ func TestNew_EmptyBaseURL_UsesDefault(t *testing.T) {
 	// Passing an empty baseURL must not modify the client in any way that
 	// breaks construction. We just verify that New succeeds and returns a
 	// non-nil provider (no live request is made in this test).
-	p := New("fake-api-key", "test-model", "")
+	p := New("fake-api-key", "test-model", "", nil)
 	assert.NotNil(t, p)
 	assert.Equal(t, "test-model", p.modelName)
 }


### PR DESCRIPTION
Transition the provider-options input to a JSON-file-only architecture to avoid fragile inline TOML or CLI flag structures. Add a robust type-coercion parser for Gemini's thinking-budget to prevent unmarshaling errors across different configuration pipelines.

Additionally, simplify the prioritized context cancellation check in the concurrency dispatcher to remove redundant checks without compromising the scheduler race protection.

Finally, extract and centralize the Gemini thinking configuration logic into a single private helper method `applyThinkingConfig` to keep the code DRY.