### PR TITLE
feat: add iteration budget and parallel tool instructions

### DIFF
--- a/core/agent.go
+++ b/core/agent.go
@@ -276,7 +276,28 @@ func (a *Agent) RunReview(ctx context.Context, stableSystem, dynamicSystem, requ
 			ProviderMetadata: resp.ProviderMetadata,
 		})
 
-		messages = append(messages, a.executeToolCalls(ctx, resp.ToolCalls))
+		toolMsg := a.executeToolCalls(ctx, resp.ToolCalls)
+		// executeToolCalls returns a ToolResults slice with len(toolCalls) elements.
+		// Since len(resp.ToolCalls) > 0, len(toolMsg.ToolResults) is guaranteed to be > 0.
+		// The guard is a defensive check to prevent out-of-bounds access.
+		if len(toolMsg.ToolResults) > 0 {
+			remaining := maxIterations - (iter + 1)
+			// Only append budget notes if there is at least one remaining tool iteration.
+			// When remaining == 0, the next turn will hit the end of the loop and trigger
+			// handleCapReached unconditionally, which appends its own forced-final cap message.
+			// Thus, a remaining == 0 budget note is intentionally omitted to avoid redundant notes.
+			if remaining > 0 {
+				lastIdx := len(toolMsg.ToolResults) - 1
+				var note string
+				if remaining == 1 {
+					note = fmt.Sprintf(budgetNoteLastTurn, iter+1, maxIterations)
+				} else {
+					note = fmt.Sprintf(budgetNoteGeneral, iter+1, maxIterations, remaining)
+				}
+				toolMsg.ToolResults[lastIdx].Content += note
+			}
+		}
+		messages = append(messages, toolMsg)
 	}
 
 	return a.handleCapReached(ctx, messages, maxIterations, maxTokens)
@@ -290,6 +311,10 @@ const extractionMaxAttempts = 3
 // returns a successful (nil-error) response with empty content. This is a
 // distinct failure mode from a hard error and needs its own retry budget.
 const emptyResponseMaxAttempts = 3
+
+const budgetNoteLastTurn = "\n\n---\n[SYSTEM NOTE] Iteration %d of %d. 1 more turn left. This is your last turn to call tools! In the next turn, you will be forced to finalize your review without tools. Formulate your final review now if you have enough information."
+
+const budgetNoteGeneral = "\n\n---\n[SYSTEM NOTE] Iteration %d of %d. Budget remaining: %d turns.\nPlease minimize iterations: only request further tool calls if needed to resolve remaining information gaps. If you already have enough context, formulate and return your final review now."
 
 // ExtractStructuredReview takes a raw markdown review and converts it into a
 // machine-readable StructuredReview using a second LLM pass.

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -369,8 +369,9 @@ func TestRunReview_SingleToolCall(t *testing.T) {
 	if len(toolMsg.ToolResults) != 1 {
 		t.Fatalf("tool-result message: expected 1 result, got %d", len(toolMsg.ToolResults))
 	}
-	if toolMsg.ToolResults[0].Content != wantResult {
-		t.Errorf("tool result content: got %q, want %q", toolMsg.ToolResults[0].Content, wantResult)
+	expectedContent := wantResult + fmt.Sprintf(budgetNoteGeneral, 1, 5, 4)
+	if toolMsg.ToolResults[0].Content != expectedContent {
+		t.Errorf("tool result content: got %q, want %q", toolMsg.ToolResults[0].Content, expectedContent)
 	}
 }
 
@@ -983,5 +984,99 @@ func TestExecuteToolCalls_PanicRecovery(t *testing.T) {
 	// Check that the panicking tool result contains the panic message
 	if !strings.Contains(msg.ToolResults[0].Content, "tool panicked: boom") {
 		t.Errorf("expected panic error message, got %q", msg.ToolResults[0].Content)
+	}
+}
+
+func TestRunReview_IterationBudgetNote(t *testing.T) {
+	lm := &mockLLM{
+		responses: []*llm.Response{
+			toolCallsResponse(makeToolCall("tc1", "read_file", map[string]any{"file_path": "foo.go"})),
+			toolCallsResponse(makeToolCall("tc2", "read_file", map[string]any{"file_path": "bar.go"})),
+			toolCallsResponse(makeToolCall("tc3", "read_file", map[string]any{"file_path": "baz.go"})),
+			textResponse("forced final review done"),
+		},
+	}
+	d := newMockDispatcher()
+	d.handlers["read_file"] = func(ctx context.Context, tc llm.ToolCall) (string, error) {
+		var args map[string]any
+		_ = tc.UnmarshalArguments(&args)
+		return fmt.Sprintf("content of %s", args["file_path"]), nil
+	}
+
+	agent := newTestAgent(lm, d)
+	got, err := agent.RunReview(context.Background(), "sys", "", "req", 3, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "forced final review done" {
+		t.Errorf("got final review %q, expected %q", got, "forced final review done")
+	}
+
+	// We expect 4 LLM calls in total (3 loop turns + 1 forced final review).
+	if len(lm.calls) != 4 {
+		t.Fatalf("expected 4 LLM calls, got %d", len(lm.calls))
+	}
+
+	// lm.calls[1] is the second call (Turn 2). The last message in history should be a ToolResult message.
+	history2 := lm.calls[1]
+	lastMsg2 := history2[len(history2)-1]
+	if lastMsg2.Role != llm.RoleTool {
+		t.Fatalf("expected last message in Turn 2 history to be RoleTool, got %v", lastMsg2.Role)
+	}
+	if len(lastMsg2.ToolResults) != 1 {
+		t.Fatalf("expected 1 tool result in Turn 2, got %d", len(lastMsg2.ToolResults))
+	}
+	resultContent2 := lastMsg2.ToolResults[0].Content
+	if !strings.Contains(resultContent2, "[SYSTEM NOTE] Iteration 1 of 3. Budget remaining: 2 turns.") {
+		t.Errorf("expected Turn 2 ToolResult to contain Case A budget note, got:\n%s", resultContent2)
+	}
+	if !strings.Contains(resultContent2, "Please minimize iterations: only request further tool calls if needed") {
+		t.Errorf("expected Turn 2 ToolResult to contain relaxed Case A warning, got:\n%s", resultContent2)
+	}
+
+	// lm.calls[2] is the third call (Turn 3). The last message in history should be the next ToolResult message.
+	history3 := lm.calls[2]
+	lastMsg3 := history3[len(history3)-1]
+	if lastMsg3.Role != llm.RoleTool {
+		t.Fatalf("expected last message in Turn 3 history to be RoleTool, got %v", lastMsg3.Role)
+	}
+	if len(lastMsg3.ToolResults) != 1 {
+		t.Fatalf("expected 1 tool result in Turn 3, got %d", len(lastMsg3.ToolResults))
+	}
+	resultContent3 := lastMsg3.ToolResults[0].Content
+	if !strings.Contains(resultContent3, "[SYSTEM NOTE] Iteration 2 of 3. 1 more turn left.") {
+		t.Errorf("expected Turn 3 ToolResult to contain Case B budget note, got:\n%s", resultContent3)
+	}
+	if !strings.Contains(resultContent3, "This is your last turn to call tools! In the next turn, you will be forced to finalize") {
+		t.Errorf("expected Turn 3 ToolResult to contain Case B last-turn warning, got:\n%s", resultContent3)
+	}
+
+	// lm.calls[3] is the fourth call (forced final review).
+	// The last message in history must be the RoleUser cap message, and the second-to-last
+	// must be the RoleTool message for tc3 containing NO budget note at all (remaining == 0).
+	history4 := lm.calls[3]
+	if len(history4) < 2 {
+		t.Fatalf("expected at least 2 messages in Turn 4 history, got %d", len(history4))
+	}
+
+	capMsg := history4[len(history4)-1]
+	if capMsg.Role != llm.RoleUser {
+		t.Errorf("expected last message in Turn 4 history to be RoleUser capMsg, got role %v", capMsg.Role)
+	}
+	if !strings.Contains(capMsg.Text, "[SYSTEM] The maximum number of tool-call iterations (3) has been reached.") {
+		t.Errorf("expected last message to contain cap message, got %q", capMsg.Text)
+	}
+
+	lastToolMsg := history4[len(history4)-2]
+	if lastToolMsg.Role != llm.RoleTool {
+		t.Fatalf("expected second-to-last message in Turn 4 history to be RoleTool, got %v", lastToolMsg.Role)
+	}
+	if len(lastToolMsg.ToolResults) != 1 {
+		t.Fatalf("expected 1 tool result in lastToolMsg, got %d", len(lastToolMsg.ToolResults))
+	}
+	resultContent4 := lastToolMsg.ToolResults[0].Content
+	// Since remaining was 0, it should be exactly the raw output "content of baz.go" with NO [SYSTEM NOTE].
+	if resultContent4 != "content of baz.go" {
+		t.Errorf("expected Turn 4 ToolResult to be exactly raw content, got %q", resultContent4)
 	}
 }

--- a/core/prompts/reviewer_prompt.md
+++ b/core/prompts/reviewer_prompt.md
@@ -18,10 +18,11 @@ Use the glob_files tool when you need to discover what files exist in a director
 
 Use the grep_files tool when you need to find where a specific symbol, string, or pattern is used across the repository. This is useful for understanding the impact of a change, finding examples of a pattern, or locating related logic that isn't immediately obvious from the file structure. You can use the `case_insensitive` parameter if you are unsure of the exact casing.
 
-When multiple tool calls are needed, request them all in a single response — they will be executed in parallel.
+When multiple tool calls are needed (for example, to read multiple files, search for multiple symbols, or run multiple commands), you MUST request them all in a single response so they are executed in parallel. Do not make tool calls one-by-one in subsequent turns.
 
 ## Behavior
 
+- **Iteration Budget**: You have a cap on the number of iterations (tool-call turns) allowed for this review. This budget is a maximum ceiling, not a target. You should aim to complete your review in as few iterations as possible to conserve tokens and reduce latency. Only request additional tool calls if needed to resolve remaining information gaps.
 - **Contextual Feedback**: For any specific finding, you MUST include the file path and the exact line number or range in brackets (e.g., `[path/to/file:42]` or `[path/to/file:10-20]`) at the start of the feedback item. Architectural or project-wide items should be listed without a file prefix.
 - **Direct Feedback**: Do not summarize the change. Jump straight to feedback.
 - **No File Lists**: Do not list the files reviewed at the end of the review. The final verdict must be standalone.


### PR DESCRIPTION
Closes #105

This PR addresses Issue #105 by enforcing parallel tool calls and providing Cassandra with real-time visibility of its iteration budget. This prevents it from hitting `max-iterations` limits due to sequential tool call behavior.

### Proposed Changes

#### Prompts & Configuration
- **`core/prompts/reviewer_prompt.md`**:
  - Mandates requesting all needed tools in a single turn to execute them in parallel.
  - Adds the **Iteration Budget** section explaining how the budget ceiling works.

#### ReAct Loop
- **`core/agent.go`**:
  - Appends a dynamic `[SYSTEM NOTE]` budget status indicator into the content of the very last tool result in the `RoleTool` turn.
  - Handles plural turns (`remaining > 1`), singular last turn (`remaining == 1`), and omitted notes (`remaining == 0`).
  - Extracted long format strings into package-level constants (`budgetNoteLastTurn` and `budgetNoteGeneral`).
  - Added clear documentation for defensive guards and boundary behavior.

#### Tests
- **`core/agent_test.go`**:
  - Restored strict exact-match verification in `TestRunReview_SingleToolCall`.
  - Refactored `TestRunReview_IterationBudgetNote` to cover all boundary cases (plural, singular, and cap-reached).