### PR TITLE
refactor: prevent goroutine leaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,35 @@ Tools that interact with external data (files, network, pipes) MUST be resilient
 ### 8. Parallel Execution Patterns
 When parallelizing tool execution or background tasks, state updates (counters, logs, metrics) MUST be performed sequentially in the main loop before spawning goroutines. This ensures that log order remains predictable and eliminates the need for mutexes or atomic operations on shared counters during the parallel phase.
 
+### 9. Goroutine Leak Prevention
+To guarantee that background tasks do not leak system resources and stack memory:
+
+#### A. Preventing Goroutine Leaks in Tests (goleak Usage)
+- **Rule**: Packages implementing concurrent or asynchronous logic (such as background workers, dispatchers, mock servers, or context cancellation paths) **MUST** configure package-level leak detection.
+- **Implementation**: Define a `TestMain` function in a `main_test.go` file within the package that delegates to `goleak`:
+  ```go
+  func TestMain(m *testing.M) {
+  	goleak.VerifyTestMain(m)
+  }
+  ```
+- **Third-Party Exclusions**: If a third-party dependency spawns untyped background singletons or leaks internally, register an exclusion at the package level instead of disabling checks entirely:
+  ```go
+  goleak.VerifyTestMain(m,
+  	goleak.IgnoreTopFunction("github.com/some/dependency.init"),
+  )
+  ```
+- **When NOT to Use**: Purely synchronous packages with zero concurrent paths (no goroutines or channels spawned) should omit `goleak` to avoid unnecessary execution overhead.
+
+#### B. Preventing Goroutine Leaks in Production (The "Always Buffer" Pattern)
+- **Rule**: Spawning a one-shot background goroutine that writes to a channel exactly once (e.g., returning a task result or error) **MUST** use a buffered channel of at least size `1` (e.g. `ch := make(chan result, 1)`).
+- **Rationale**: If the parent thread times out, panics, or exits early (e.g., via `t.Fatal` or a select branch), it stops reading from the channel. An unbuffered channel will block the worker goroutine forever. A buffered channel allows the worker to write its single result, terminate, and be garbage collected.
+- **When to Use**:
+  - When returning a single value or error from a background task.
+  - When the receiving side can abandon the read operation (e.g. using `select` with `time.After`, `ctx.Done()`, or multiple channels).
+- **When NOT to Use**:
+  - When you explicitly require **synchronous handoff** (rendezvous), where the sender goroutine must block until the receiver has actively received the data.
+  - When streaming multiple values where flow control (backpressure) is needed, in which case unbuffered or size-limited buffers are used to throttle the sender.
+
 ## Security Standards
 
 ### 1. GitHub Action Input Safety

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,4 +28,5 @@ use_repo(
     "com_github_modelcontextprotocol_go_sdk",
     "com_github_spf13_viper",
     "com_github_stretchr_testify",
+    "org_uber_go_goleak",
 )

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
     name = "core_test",
     srcs = [
         "agent_test.go",
+        "main_test.go",
         "metrics_test.go",
         "review_types_test.go",
     ],
@@ -32,5 +33,6 @@ go_test(
         "//llm",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -931,7 +931,7 @@ func TestExecuteToolCalls_Parallel(t *testing.T) {
 	}
 
 	// Run in parallel and wait for both to enter.
-	resChan := make(chan llm.Message)
+	resChan := make(chan llm.Message, 1)
 	go func() {
 		resChan <- agent.executeToolCalls(context.Background(), toolCalls)
 	}()

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -1,0 +1,11 @@
+package core
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/migueleliasweb/go-github-mock v1.5.0
 	github.com/openai/openai-go v1.12.0
 	github.com/spf13/pflag v1.0.10
+	go.uber.org/goleak v1.3.0
 	google.golang.org/genai v1.57.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ go.opentelemetry.io/otel/sdk/metric v1.36.0 h1:r0ntwwGosWGaa0CrSt8cuNuTcccMXERFw
 go.opentelemetry.io/otel/sdk/metric v1.36.0/go.mod h1:qTNOhFDfKRwX0yXOqJYegL5WRaW376QbB7P4Pb0qva4=
 go.opentelemetry.io/otel/trace v1.36.0 h1:ahxWNuqZjpdiFAyrIoQ4GIiAIhxAunQR6MUoKrsNd4w=
 go.opentelemetry.io/otel/trace v1.36.0/go.mod h1:gQ+OnDZzrybY4k4seLzPAWNwVBBVlF2szhehOBB/tGA=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=
@@ -123,8 +125,6 @@ golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/genai v1.51.0 h1:IZGuUqgfx40INv3hLFGCbOSGp0qFqm7LVmDghzNIYqg=
-google.golang.org/genai v1.51.0/go.mod h1:A3kkl0nyBjyFlNjgxIwKq70julKbIxpSxqKO5gw/gmk=
 google.golang.org/genai v1.57.0 h1:qTyG2ynz5dQy2jF4CvZdLHHVslhR0heMue+zM1a4GNM=
 google.golang.org/genai v1.57.0/go.mod h1:A3kkl0nyBjyFlNjgxIwKq70julKbIxpSxqKO5gw/gmk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250122153221-138b5a5a4fd4 h1:yrTuav+chrF0zF/joFGICKTzYv7mh/gr9AgEXrVU8ao=

--- a/tools/mcp/BUILD.bazel
+++ b/tools/mcp/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     srcs = [
         "client_test.go",
         "config_test.go",
+        "main_test.go",
     ],
     embed = [":mcp"],
     deps = [
@@ -26,5 +27,6 @@ go_test(
         "@com_github_modelcontextprotocol_go_sdk//mcp",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/tools/mcp/client_test.go
+++ b/tools/mcp/client_test.go
@@ -92,11 +92,6 @@ func TestManager_RegisterServers_Reporting(t *testing.T) {
 	manager := NewManager()
 	defer manager.Close()
 
-	// 1. Success case
-	serverTransport, _ := mcp.NewInMemoryTransports()
-	server := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
-	go func() { _ = server.Run(ctx, serverTransport) }()
-
 	// We'll mock registerServer by temporarily overriding the transport creation logic if it were possible,
 	// but since RegisterServers uses registerServer which creates transports based on config,
 	// we'll just test the reporting flow by providing a config that will fail and one that will (hypothetically) succeed if we could mock the transport.

--- a/tools/mcp/main_test.go
+++ b/tools/mcp/main_test.go
@@ -1,0 +1,16 @@
+package mcp
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	// Ignore known goroutine leak inside the third-party Model Context Protocol SDK server.go.
+	// When the transport closes, the server loop can get blocked on channel sends/receives
+	// inside its internal goroutines.
+	goleak.VerifyTestMain(m,
+		goleak.IgnoreTopFunction("github.com/modelcontextprotocol/go-sdk/mcp.(*Server).Run.func1"),
+	)
+}


### PR DESCRIPTION
Addresses issue #103.

### What's Changed
1. **Added `go.uber.org/goleak` integration**:
   - Integrated package-level leak checking via `TestMain` in `core` and `tools/mcp` packages (which implement concurrency/asynchronous logic).
   - Ignored third-party MCP SDK server run loops to prevent test failures from external closures.
2. **Applied "Always Buffer" Pattern**:
   - Converted the unbuffered worker channel in `core/agent_test.go` to a buffered channel (`make(chan llm.Message, 1)`) to avoid worker blocks when tests abort or fail.
   - Cleaned up un-cancelled background server goroutines in `tools/mcp/client_test.go`.
3. **Updated Guidelines**:
   - Updated `AGENTS.md` (and symlinked `GEMINI.md`) under `## Engineering Guidelines` to codify the new concurrency leak prevention rules.

### Verification
- All 15 unit tests pass cleanly: `bazel test //... --nocache_test_results`
- Hermetic linting is fully clean: `bazel run @rules_go//go -- run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5 run ./...`
- Auto-formatted cleanly: `bazel run //:format`