### PR TITLE
feat: add emit_reviewer_state monologue tool

### DIFF
--- a/core/agent.go
+++ b/core/agent.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/menny/cassandra/llm"
+	"github.com/menny/cassandra/tools"
 )
 
 const (
@@ -140,7 +141,10 @@ type AgentOption func(*Agent)
 // WithStderr redirects diagnostic/progress output to w instead of os.Stderr.
 // Useful in tests to suppress noise (pass io.Discard).
 func WithStderr(w io.Writer) AgentOption {
-	return func(a *Agent) { a.reporter = &defaultReporter{w: w} }
+	return func(a *Agent) {
+		a.reporter = &defaultReporter{w: w}
+		a.stderr = w
+	}
 }
 
 // WithReporter sets a custom reporter for the Agent.
@@ -160,6 +164,7 @@ type Agent struct {
 	totalUsage llm.Usage
 	toolCalls  map[string]int
 	iterations int
+	stderr     io.Writer
 }
 
 // NewAgent creates an Agent. Diagnostic / progress output goes to os.Stderr by
@@ -171,6 +176,7 @@ func NewAgent(model llm.Model, registry ToolDispatcher, opts ...AgentOption) *Ag
 		registry:  registry,
 		reporter:  &defaultReporter{w: os.Stderr},
 		toolCalls: make(map[string]int),
+		stderr:    os.Stderr,
 	}
 	for _, o := range opts {
 		o(a)
@@ -219,6 +225,7 @@ func (a *Agent) GetMetrics() SessionMetrics {
 // loop is forcibly terminated. Pass 0 to use the default cap.
 // maxTokens limits the length of the LLM response.
 func (a *Agent) RunReview(ctx context.Context, stableSystem, dynamicSystem, requestText string, maxIterations, maxTokens int) (string, error) {
+	ctx = tools.ContextWithStateWriter(ctx, a.stderr)
 	if maxIterations <= 0 {
 		maxIterations = AbsoluteMaxIter
 	}

--- a/core/prompts/reviewer_prompt.md
+++ b/core/prompts/reviewer_prompt.md
@@ -20,6 +20,8 @@ Use the grep_files tool when you need to find where a specific symbol, string, o
 
 When multiple tool calls are needed (for example, to read multiple files, search for multiple symbols, or run multiple commands), you MUST request them all in a single response so they are executed in parallel. Do not make tool calls one-by-one in subsequent turns.
 
+Before invoking file-system tools, or when changing your review strategy, you MUST call `emit_reviewer_state` to explain your rationale. Do not output raw text to think.
+
 ## Behavior
 
 - **Iteration Budget**: You have a cap on the number of iterations (tool-call turns) allowed for this review. This budget is a maximum ceiling, not a target. You should aim to complete your review in as few iterations as possible to conserve tokens and reduce latency. Only request additional tool calls if needed to resolve remaining information gaps.

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "tools",
     srcs = [
         "diff.go",
+        "emit_reviewer_state.go",
         "local_tools.go",
         "registry.go",
         "wishlist.go",
@@ -20,6 +21,7 @@ go_test(
     name = "tools_test",
     srcs = [
         "diff_test.go",
+        "emit_reviewer_state_test.go",
         "local_tools_safety_test.go",
         "local_tools_test.go",
         "wishlist_test.go",

--- a/tools/emit_reviewer_state.go
+++ b/tools/emit_reviewer_state.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/menny/cassandra/llm"
+)
+
+type stateWriterKeyType struct{}
+
+var stateWriterKey stateWriterKeyType
+
+// ContextWithStateWriter returns a new context carrying the given state writer.
+func ContextWithStateWriter(ctx context.Context, w io.Writer) context.Context {
+	return context.WithValue(ctx, stateWriterKey, w)
+}
+
+// StateWriterFromContext extracts the state writer from the context, if present.
+func StateWriterFromContext(ctx context.Context) io.Writer {
+	if w, ok := ctx.Value(stateWriterKey).(io.Writer); ok {
+		return w
+	}
+	return nil
+}
+
+type emitReviewerStateArgs struct {
+	Message   string `json:"message"`
+	FocusArea string `json:"focus_area,omitempty"`
+}
+
+func registerEmitReviewerState(r *Registry) {
+	def := llm.ToolDef{
+		Name:        "emit_reviewer_state",
+		Description: "Use this tool to narrate your review process, formulate plans, explain why you are pivoting your search, or record intermediate findings before making a final decision. Do not use raw text for internal monologue; always use this tool.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"message": map[string]any{
+					"type":        "string",
+					"description": "Your detailed rationale, thought process, or current status.",
+				},
+				"focus_area": map[string]any{
+					"type":        "string",
+					"description": "The specific file, function, or domain you are currently evaluating (e.g., 'auth/token.go', 'DB connection pooling').",
+				},
+			},
+			"required": []string{"message"},
+		},
+	}
+
+	RegisterToolWithArgs(r, def, func(ctx context.Context, args emitReviewerStateArgs) (string, error) {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+
+		writer := StateWriterFromContext(ctx)
+		if writer == nil {
+			writer = os.Stderr
+		}
+
+		var output string
+		if args.FocusArea != "" {
+			output = fmt.Sprintf("[focus on '%s'] %s\n", args.FocusArea, args.Message)
+		} else {
+			output = fmt.Sprintf("[reviewing] %s\n", args.Message)
+		}
+
+		_, _ = fmt.Fprint(writer, output)
+
+		return `{"status": "state_recorded"}`, nil
+	})
+}

--- a/tools/emit_reviewer_state_test.go
+++ b/tools/emit_reviewer_state_test.go
@@ -1,0 +1,125 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/menny/cassandra/llm"
+)
+
+func TestEmitReviewerState(t *testing.T) {
+	r := NewRegistry()
+	registerEmitReviewerState(r)
+
+	t.Run("without focus_area", func(t *testing.T) {
+		var buf bytes.Buffer
+		ctx := ContextWithStateWriter(context.Background(), &buf)
+
+		args, err := json.Marshal(map[string]any{
+			"message": "Analyzing repository structure to locate DB connection pooling",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := r.HandleCall(ctx, llm.ToolCall{
+			Name:      "emit_reviewer_state",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+
+		expectedAck := `{"status": "state_recorded"}`
+		if result != expectedAck {
+			t.Errorf("expected result %q, got %q", expectedAck, result)
+		}
+
+		expectedOutput := "[reviewing] Analyzing repository structure to locate DB connection pooling\n"
+		if buf.String() != expectedOutput {
+			t.Errorf("expected printed output %q, got %q", expectedOutput, buf.String())
+		}
+	})
+
+	t.Run("with focus_area", func(t *testing.T) {
+		var buf bytes.Buffer
+		ctx := ContextWithStateWriter(context.Background(), &buf)
+
+		args, err := json.Marshal(map[string]any{
+			"message":    "Refactoring DB connection limit bounds check",
+			"focus_area": "db/pool.go",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := r.HandleCall(ctx, llm.ToolCall{
+			Name:      "emit_reviewer_state",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+
+		expectedAck := `{"status": "state_recorded"}`
+		if result != expectedAck {
+			t.Errorf("expected result %q, got %q", expectedAck, result)
+		}
+
+		expectedOutput := "[focus on 'db/pool.go'] Refactoring DB connection limit bounds check\n"
+		if buf.String() != expectedOutput {
+			t.Errorf("expected printed output %q, got %q", expectedOutput, buf.String())
+		}
+	})
+
+	t.Run("default to os.Stderr if no writer provided", func(t *testing.T) {
+		args, err := json.Marshal(map[string]any{
+			"message": "Testing default writer fallback",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify it does not error or panic
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "emit_reviewer_state",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+
+		expectedAck := `{"status": "state_recorded"}`
+		if result != expectedAck {
+			t.Errorf("expected result %q, got %q", expectedAck, result)
+		}
+	})
+
+	t.Run("canceled context", func(t *testing.T) {
+		var buf bytes.Buffer
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		ctx = ContextWithStateWriter(ctx, &buf)
+
+		args, err := json.Marshal(map[string]any{
+			"message": "Should not write on canceled context",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = r.HandleCall(ctx, llm.ToolCall{
+			Name:      "emit_reviewer_state",
+			Arguments: string(args),
+		})
+		if err == nil {
+			t.Error("expected error due to canceled context, got nil")
+		}
+		if buf.Len() > 0 {
+			t.Errorf("expected no output on canceled context, got %q", buf.String())
+		}
+	})
+}

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -61,4 +61,5 @@ func RegisterLocalTools(r *Registry, root string, ignoredLockFiles []string, wis
 	registerLocalGlobFiles(r, root)
 	registerLocalGrepFiles(r, root, ignoredLockFiles)
 	registerWishlistTool(r, wishlistDir)
+	registerEmitReviewerState(r)
 }


### PR DESCRIPTION
This PR implements the new 'emit_reviewer_state' monologue tool, which acts as an internal monologue/state emission mechanism for the LLM during its ReAct loop. This allows the agent to stream its cognition, planning, and strategy pivots to stderr without breaking the tool-calling flow.