### PR TITLE
fix: harden grep_files and add glob support

### DIFF
--- a/tools/local_tools.go
+++ b/tools/local_tools.go
@@ -179,7 +179,7 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 				},
 				"directory": map[string]any{
 					"type":        "string",
-					"description": "Optional directory to search in (relative to repository root).",
+					"description": "Optional directory or glob pattern to search in (relative to repository root), e.g., 'dir/**/*.go'.",
 				},
 				"case_insensitive": map[string]any{
 					"type":        "boolean",
@@ -204,22 +204,49 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 		cmdArgs = append(cmdArgs, "-e", args.Query)
 
 		if args.Directory != "" {
-			dir := args.Directory
-			if root != "" {
-				var err error
-				dir, err = util.ValidateAndRel(root, args.Directory)
-				if err != nil {
-					return "", fmt.Errorf("grep_files failed: %w", err)
+			// Prevent path traversal sequences (like "..") anywhere in the path.
+			for _, part := range strings.FieldsFunc(args.Directory, func(r rune) bool { return r == '/' || r == '\\' }) {
+				if part == ".." {
+					return "", fmt.Errorf("grep_files failed: path traversal ('..') not allowed in directory path: %q", args.Directory)
 				}
 			}
-			cmdArgs = append(cmdArgs, "--", dir)
+
+			base, pattern := splitGlob(args.Directory)
+			var relBase string
+			if base != "" {
+				if root != "" {
+					var err error
+					relBase, err = util.ValidateAndRel(root, base)
+					if err != nil {
+						return "", fmt.Errorf("grep_files failed: %w", err)
+					}
+				} else {
+					relBase = base
+				}
+			}
+
+			var pathspec string
+			if pattern != "" {
+				if relBase != "" {
+					pathspec = filepath.Join(relBase, pattern)
+				} else {
+					pathspec = pattern
+				}
+			} else {
+				pathspec = relBase
+			}
+			pathspec = filepath.ToSlash(pathspec)
+			cmdArgs = append(cmdArgs, "--", pathspec)
 		} else {
 			cmdArgs = append(cmdArgs, "--", ".")
 		}
 
 		cmdArgs = util.AppendGitExcludeArgs(cmdArgs, ignoredLockFiles)
 
-		out, err := util.RunGit(ctx, root, cmdArgs...)
+		const maxScanBytes = 100000
+		const maxReturnBytes = 40000
+
+		out, scannedTruncated, err := util.RunGitWithLimit(ctx, root, maxScanBytes, cmdArgs...)
 		if err != nil {
 			var exitErr *exec.ExitError
 			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && len(out) == 0 {
@@ -228,13 +255,55 @@ func registerLocalGrepFiles(r *Registry, root string, ignoredLockFiles []string)
 			return "", fmt.Errorf("grep_files failed: %w\nOutput: %s", err, string(out))
 		}
 
-		output := string(out)
-		lines := strings.Split(strings.TrimSpace(output), "\n")
-		const maxLines = 100
-		if len(lines) > maxLines {
-			output = strings.Join(lines[:maxLines], "\n") + fmt.Sprintf("\n... (truncated, %d more matches)", len(lines)-maxLines)
+		if len(out) == 0 {
+			return "No matches found.", nil
 		}
 
-		return strings.TrimSpace(output), nil
+		output := string(out)
+		if len(output) <= maxReturnBytes {
+			return strings.TrimSpace(output), nil
+		}
+
+		// Truncate output to 40k bytes.
+		// Find the last newline in the first maxReturnBytes.
+		cutoff := maxReturnBytes
+		if lastNL := strings.LastIndex(output[:maxReturnBytes], "\n"); lastNL != -1 {
+			cutoff = lastNL + 1
+		}
+
+		truncatedPart := output[cutoff:]
+		truncatedPart = strings.TrimSpace(truncatedPart)
+		var moreMatches int
+		if len(truncatedPart) > 0 {
+			moreMatches = strings.Count(truncatedPart, "\n") + 1
+		}
+
+		result := strings.TrimSpace(output[:cutoff])
+		if scannedTruncated {
+			result += "\n... (truncated to 40k bytes, there are many more matches. Please refine your query)"
+		} else {
+			result += fmt.Sprintf("\n... (truncated to 40k bytes, there are %d more matches. Please refine your query)", moreMatches)
+		}
+		return result, nil
 	})
+}
+
+// splitGlob splits a pathspec into a literal base directory and a glob pattern.
+// It finds the first occurrence of any wildcard character (*, ?, [) and splits the path
+// at the last directory separator before that wildcard.
+func splitGlob(path string) (string, string) {
+	idx := strings.IndexAny(path, "*?[")
+	if idx == -1 {
+		return path, ""
+	}
+	// Find the last path separator before the wildcard.
+	// We handle both '/' and '\\' separators.
+	lastSlash := strings.LastIndex(path[:idx], "/")
+	if lastSlashWin := strings.LastIndex(path[:idx], "\\"); lastSlashWin > lastSlash {
+		lastSlash = lastSlashWin
+	}
+	if lastSlash == -1 {
+		return "", path
+	}
+	return path[:lastSlash], path[lastSlash+1:]
 }

--- a/tools/local_tools_safety_test.go
+++ b/tools/local_tools_safety_test.go
@@ -219,3 +219,75 @@ func TestLocalReadFile_SymlinkEscape(t *testing.T) {
 		}
 	})
 }
+
+func TestLocalGrepFiles_SymlinkEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	workspaceRoot := filepath.Join(tmpDir, "workspace")
+	if err := os.Mkdir(workspaceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry()
+	RegisterLocalTools(r, workspaceRoot, nil, "")
+
+	// Create a file OUTSIDE the workspace root
+	secretDir := filepath.Join(tmpDir, "outside")
+	if err := os.Mkdir(secretDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	secretFile := filepath.Join(secretDir, "secret.txt")
+	if err := os.WriteFile(secretFile, []byte("SENSITIVE DATA"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Valid symlink pointing outside workspace root
+	evilSymlink := filepath.Join(workspaceRoot, "evil_symlink")
+	if err := os.Symlink(secretDir, evilSymlink); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Broken symlink
+	brokenSymlink := filepath.Join(workspaceRoot, "broken_symlink")
+	if err := os.Symlink(filepath.Join(tmpDir, "nonexistent"), brokenSymlink); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. Trampoline/circular symlink
+	trampolineSymlink := filepath.Join(workspaceRoot, "trampoline")
+	if err := os.Symlink(trampolineSymlink, trampolineSymlink); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("valid symlink pointing outside should be blocked", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"query": "SENSITIVE", "directory": "evil_symlink/*.txt"})
+		_, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "grep_files",
+			Arguments: string(args),
+		})
+		if err == nil {
+			t.Error("expected error when querying through outside symlink base directory, got nil")
+		}
+	})
+
+	t.Run("broken symlink should be blocked", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"query": "SENSITIVE", "directory": "broken_symlink/*.txt"})
+		_, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "grep_files",
+			Arguments: string(args),
+		})
+		if err == nil {
+			t.Error("expected error when querying through broken symlink base directory, got nil")
+		}
+	})
+
+	t.Run("trampoline symlink should be blocked", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"query": "SENSITIVE", "directory": "trampoline/*.txt"})
+		_, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "grep_files",
+			Arguments: string(args),
+		})
+		if err == nil {
+			t.Error("expected error when querying through circular trampoline symlink base directory, got nil")
+		}
+	})
+}

--- a/tools/local_tools_test.go
+++ b/tools/local_tools_test.go
@@ -342,7 +342,7 @@ func TestLocalGrepFiles(t *testing.T) {
 	t.Run("truncation limit", func(t *testing.T) {
 		truncFile := filepath.Join(tmpDir, "truncation.txt")
 		var sb strings.Builder
-		for i := 0; i < 110; i++ {
+		for i := 0; i < 2000; i++ {
 			sb.WriteString(fmt.Sprintf("TruncMatch line %d\n", i))
 		}
 		if err := os.WriteFile(truncFile, []byte(sb.String()), 0o644); err != nil {
@@ -352,6 +352,57 @@ func TestLocalGrepFiles(t *testing.T) {
 
 		args, _ := json.Marshal(map[string]any{"query": "TruncMatch"})
 		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name: "grep_files",
+
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify result is truncated to 40k bytes (plus message)
+		if len(result) > 42000 {
+			t.Errorf("result is too large: %d bytes", len(result))
+		}
+		if !strings.Contains(result, "truncated to 40k bytes") {
+			t.Errorf("expected truncation message, got: %s", result)
+		}
+
+		lines := strings.Split(strings.TrimSpace(result), "\n")
+		if len(lines) < 2 {
+			t.Fatalf("expected multiple lines, got: %v", lines)
+		}
+		matchLines := lines[:len(lines)-1]
+
+		// Parse the remaining matches from the truncation message:
+		// "... (truncated to 40k bytes, there are 84 more matches. Please refine your query)"
+		lastLine := lines[len(lines)-1]
+		var remainingMatches int
+		_, err = fmt.Sscanf(lastLine, "... (truncated to 40k bytes, there are %d more matches. Please refine your query)", &remainingMatches)
+		if err != nil {
+			t.Fatalf("failed to parse remaining matches from last line %q: %v", lastLine, err)
+		}
+
+		totalMatches := len(matchLines) + remainingMatches
+		if totalMatches != 2000 {
+			t.Errorf("expected total matches to sum to 2000, got %d (returned) + %d (remaining) = %d", len(matchLines), remainingMatches, totalMatches)
+		}
+	})
+
+	t.Run("scan truncation limit", func(t *testing.T) {
+		truncFile := filepath.Join(tmpDir, "scan_truncation.txt")
+		var sb strings.Builder
+		// Write 6000 lines of ~25 bytes each (~150 KB), exceeding the 100 KB scan limit.
+		for i := 0; i < 6000; i++ {
+			sb.WriteString(fmt.Sprintf("ScanTruncMatch line %d\n", i))
+		}
+		if err := os.WriteFile(truncFile, []byte(sb.String()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runGitCmd(t, tmpDir, "add", "scan_truncation.txt")
+
+		args, _ := json.Marshal(map[string]any{"query": "ScanTruncMatch"})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
 			Name:      "grep_files",
 			Arguments: string(args),
 		})
@@ -359,13 +410,90 @@ func TestLocalGrepFiles(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		lines := strings.Split(strings.TrimSpace(result), "\n")
-		// 100 lines of matches + 1 line for "truncated" message
-		if len(lines) != 101 {
-			t.Errorf("expected 101 lines, got %d", len(lines))
-		}
-		if !strings.Contains(result, "... (truncated, 10 more matches)") {
-			t.Errorf("expected truncation message, got: %s", result)
+		if !strings.Contains(result, "there are many more matches") {
+			t.Errorf("expected 'there are many more matches' in truncation message indicating scan limit was reached, got: %s", result)
 		}
 	})
+
+	t.Run("grep with glob pattern", func(t *testing.T) {
+		subdir := filepath.Join(tmpDir, "globdir")
+		if err := os.Mkdir(subdir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		matchFile := filepath.Join(subdir, "match.txt")
+		if err := os.WriteFile(matchFile, []byte("GlobMatch here"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		noMatchFile := filepath.Join(subdir, "nomatch.go")
+		if err := os.WriteFile(noMatchFile, []byte("GlobMatch here too but wrong ext"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runGitCmd(t, tmpDir, "add", "globdir/match.txt", "globdir/nomatch.go")
+
+		args, _ := json.Marshal(map[string]any{"query": "GlobMatch", "directory": "globdir/*.txt"})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "grep_files",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+		if !strings.Contains(result, "globdir/match.txt") {
+			t.Errorf("expected match in globdir/match.txt, got: %s", result)
+		}
+		if strings.Contains(result, "globdir/nomatch.go") {
+			t.Errorf("expected no match in globdir/nomatch.go, got: %s", result)
+		}
+	})
+
+	t.Run("grep with glob pattern and no directory base", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"query": "GlobMatch", "directory": "*.txt"})
+		result, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "grep_files",
+			Arguments: string(args),
+		})
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+		if !strings.Contains(result, "globdir/match.txt") {
+			t.Errorf("expected match in globdir/match.txt, got: %s", result)
+		}
+	})
+
+	t.Run("grep path traversal prevention with glob", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]any{"query": "GlobMatch", "directory": "../**/*.txt"})
+		_, err := r.HandleCall(context.Background(), llm.ToolCall{
+			Name:      "grep_files",
+			Arguments: string(args),
+		})
+		if err == nil {
+			t.Error("expected error for path traversal directory glob pattern, got nil")
+		}
+	})
+}
+
+func TestSplitGlob(t *testing.T) {
+	tests := []struct {
+		input       string
+		wantBase    string
+		wantPattern string
+	}{
+		{"", "", ""},
+		{"dir/sub", "dir/sub", ""},
+		{"*.go", "", "*.go"},
+		{"dir/**/*.go", "dir", "**/*.go"},
+		{"dir/file[0-9].txt", "dir", "file[0-9].txt"},
+		{"[abc]/file", "", "[abc]/file"},
+		{"dir\\sub\\*.go", "dir\\sub", "*.go"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			gotBase, gotPattern := splitGlob(tc.input)
+			if gotBase != tc.wantBase || gotPattern != tc.wantPattern {
+				t.Errorf("splitGlob(%q) = (%q, %q); want (%q, %q)",
+					tc.input, gotBase, gotPattern, tc.wantBase, tc.wantPattern)
+			}
+		})
+	}
 }

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -16,6 +16,7 @@ go_test(
     name = "util_test",
     srcs = [
         "fs_test.go",
+        "git_test.go",
         "lockfiles_test.go",
     ],
     embed = [":util"],

--- a/util/git.go
+++ b/util/git.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 )
 
@@ -17,6 +18,55 @@ func RunGit(ctx context.Context, dir string, args ...string) ([]byte, error) {
 		cmd.Dir = dir
 	}
 	return cmd.CombinedOutput()
+}
+
+// MaxGitLimitBytes defines the hard ceiling (10 MB) for RunGitWithLimit to prevent
+// excessive memory allocation.
+const MaxGitLimitBytes = 10 * 1024 * 1024
+
+// RunGitWithLimit invokes `git <args>` in the given working directory, capturing
+// combined stdout+stderr up to limit bytes. If the output exceeds limit, it kills
+// the command process to stop further execution and returns the read bytes and truncated=true.
+// The limit must be non-negative and <= MaxGitLimitBytes (10 MB).
+func RunGitWithLimit(ctx context.Context, dir string, limit int64, args ...string) ([]byte, bool, error) {
+	if limit < 0 || limit > MaxGitLimitBytes {
+		return nil, false, fmt.Errorf("limit must be between 0 and %d bytes (got %d)", MaxGitLimitBytes, limit)
+	}
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, false, err
+	}
+	cmd.Stderr = cmd.Stdout // Redirect stderr to stdout to capture combined output.
+
+	if err := cmd.Start(); err != nil {
+		return nil, false, err
+	}
+
+	// Read up to limit + 1 bytes.
+	lr := io.LimitReader(stdout, limit+1)
+	out, err := io.ReadAll(lr)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, false, err
+	}
+
+	if int64(len(out)) > limit {
+		// Output exceeded limit, kill the process to stop further output generation.
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return out[:limit], true, nil
+	}
+
+	// If not truncated, wait for normal completion.
+	err = cmd.Wait()
+	return out, false, err
 }
 
 // AppendGitExcludeArgs appends git pathspec exclude arguments for each entry in

--- a/util/git_test.go
+++ b/util/git_test.go
@@ -1,0 +1,88 @@
+package util
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runGitCmd(t *testing.T, dir string, args ...string) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\nOutput: %s", args, err, string(out))
+	}
+}
+
+func TestRunGitWithLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+	runGitCmd(t, tmpDir, "init", "-b", "main")
+	runGitCmd(t, tmpDir, "config", "user.email", "test@example.com")
+	runGitCmd(t, tmpDir, "config", "user.name", "Test User")
+	runGitCmd(t, tmpDir, "config", "commit.gpgsign", "false")
+
+	// Create a file with multiple lines
+	testFile := filepath.Join(tmpDir, "large.txt")
+	var sb strings.Builder
+	for i := 0; i < 500; i++ {
+		sb.WriteString("some random data line\n")
+	}
+	if err := os.WriteFile(testFile, []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runGitCmd(t, tmpDir, "add", "large.txt")
+
+	t.Run("no truncation", func(t *testing.T) {
+		out, truncated, err := RunGitWithLimit(context.Background(), tmpDir, 100000, "grep", "some random data", "large.txt")
+		if err != nil {
+			t.Fatalf("expected success, got err: %v", err)
+		}
+		if truncated {
+			t.Error("expected truncated=false, got true")
+		}
+		if len(out) == 0 {
+			t.Error("expected output, got empty")
+		}
+	})
+
+	t.Run("with truncation", func(t *testing.T) {
+		out, truncated, err := RunGitWithLimit(context.Background(), tmpDir, 100, "grep", "some random data", "large.txt")
+		if err != nil {
+			t.Fatalf("expected success, got err: %v", err)
+		}
+		if !truncated {
+			t.Error("expected truncated=true, got false")
+		}
+		if len(out) != 100 {
+			t.Errorf("expected output length to be exactly 100, got %d", len(out))
+		}
+	})
+
+	t.Run("ceiling limit exceeded", func(t *testing.T) {
+		_, _, err := RunGitWithLimit(context.Background(), tmpDir, MaxGitLimitBytes+1, "grep", "some random data", "large.txt")
+		if err == nil {
+			t.Error("expected error for exceeding MaxGitLimitBytes, got nil")
+		}
+	})
+
+	t.Run("negative limit", func(t *testing.T) {
+		_, _, err := RunGitWithLimit(context.Background(), tmpDir, -1, "grep", "some random data", "large.txt")
+		if err == nil {
+			t.Error("expected error for negative limit, got nil")
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, _, err := RunGitWithLimit(ctx, tmpDir, 1000, "grep", "some random data", "large.txt")
+		if err == nil {
+			t.Error("expected error for cancelled context, got nil")
+		}
+	})
+}


### PR DESCRIPTION
Harden the grep_files tool to prevent large outputs from filling the context window, and add support for glob patterns in the directory argument.

- Read up to a hard limit of 100,000 bytes during git grep scanning and terminate the process early on overflow.
- Return at most 40,000 bytes of output to the agent (matching the capping in AGENTS.md), truncated on newline boundaries.
- Include a clear message informing the agent of truncation and either the remaining match count, or a notice of many remaining matches if the scan limit is exceeded.
- Split the directory argument into a literal base and a wildcard glob.
- Validate the directory argument for path traversal safety, preventing use of '..' sequences in both the base and pattern components.
- Validate that base directory glob paths do not escape the root via symlinks, broken symlinks, or trampoline symlinks.
- Guard memory allocation in RunGitWithLimit with a 10 MB ceiling.
- Add context-cancellation and ceiling unit tests for RunGitWithLimit.