### PR TITLE
chore: add code coverage reporting via codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,14 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
-      - name: Build Codebase
-        run: bazel build //...
+      - name: Build & Run Tests with Coverage
+        run: bazel coverage --combined_report=lcov //...
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: bazel-out/_coverage/_coverage_report.dat
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
       - name: Run Linter
         run: bazel run @rules_go//go -- run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5 run ./...
       - name: Enforce Formatting

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ scratch/
 # Conductor
 conductor/plan.md
 conductor/tracks/**/plan.md
+
+# Codecov uploader files (downloaded during CI)
+codecov
+codecov.SHA256SUM
+codecov.SHA256SUM.sig

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > *The truth about your code. Seeing bugs before the fall of production. Ignore at your own peril.*
 
+[![codecov](https://codecov.io/gh/menny/cassandra/graph/badge.svg?branch=main)](https://codecov.io/gh/menny/cassandra)
+
 An autonomous code review tool built in Go. This tool provides structured, actionable code reviews using a configurable and adjustable feedback framework.
 
 ## Features


### PR DESCRIPTION
Configure the CI workflow to run tests with coverage enabled and upload reports to Codecov. Add the Codecov status badge to README.md tracking the main branch. Closes #108.