### PR TITLE
feat: add interactive post-review repl mode via huh

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -231,3 +231,23 @@ func (tc *ToolCall) UnmarshalArguments(dest any) error { ... }
 **Why:** Redundant comments are "noise" that hinders readability. High-value
 comments capture intent and design rationale that isn't immediately obvious
 from the code itself.
+
+## Idempotent Close/Teardown with sync.Once
+
+Use `sync.Once` to guarantee that cleanup or close logic (e.g., `Close() error`) is performed exactly once, even if called concurrently or from multiple paths.
+
+```go
+type myResource struct {
+	closeOnce sync.Once
+}
+
+func (r *myResource) Close() error {
+	r.closeOnce.Do(func() {
+		_ = r.teardown()
+	})
+	return nil
+}
+```
+
+**Why:** Avoids data races and duplicate teardown side-effects without error-prone manual boolean flags.
+

--- a/cassandra.toml
+++ b/cassandra.toml
@@ -3,7 +3,7 @@
 # Precedence: CLI Arguments > Configuration File > Defaults
 
 provider = "google"
-model = "gemini-3.5-flash"
+model = "gemini-3.1-pro-preview"
 allow-url-fetch = true
 
 # Path to an MCP configuration file.

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -186,9 +186,17 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		reporter = core.NewRawReporter(os.Stdout, stderr.Writer())
 	}
 
-	if closer, ok := reporter.(io.Closer); ok {
-		defer closer.Close()
+	var reporterClosed bool
+	closeReporter := func() {
+		if reporterClosed {
+			return
+		}
+		if closer, ok := reporter.(io.Closer); ok {
+			_ = closer.Close()
+		}
+		reporterClosed = true
 	}
+	defer closeReporter()
 
 	reporter.ReportConfig(cfg, targetDir)
 
@@ -338,6 +346,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	}
 
 	if cfg.InteractivePostReview {
+		closeReporter()
 		if err := reviewer.RunInteractivePostReview(sessionCtx); err != nil {
 			return fmt.Errorf("interactive post-review failed: %w", err)
 		}

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -61,6 +61,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	fs.StringVar(&cfg.MCPConfigFile, "mcp-config", "", "Path to an mcp.json file configuring custom tools for the reviewer")
 	fs.BoolVar(&cfg.AllowURLFetch, "allow-url-fetch", false, "Enable the mcp-server-fetch tool (requires uvx to be installed)")
 	fs.BoolVar(&cfg.AllowAskDeveloper, "allow-ask-developer", false, "Allow the AI reviewer to ask the developer questions")
+	fs.BoolVar(&cfg.InteractivePostReview, "interactive-post-review", false, "Start an interactive post-review chat session after the review pass")
 	fs.StringSliceVar(&cfg.IgnoredLockFiles, "ignored-lock-files", util.DefaultLockFiles, "Comma-separated list of lock files to ignore in diffs (overrides default)")
 	fs.StringVar(&cfg.ConfigFile, "config", "", "Path to a configuration file (toml)")
 	fs.StringVar(&cfg.WishlistDir, "wishlist-dir", "", "Path to a directory where AI-Reviewer feedback/wishlist will be stored")
@@ -103,6 +104,7 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	v.SetDefault("ignored-lock-files", util.DefaultLockFiles)
 	v.SetDefault("allow-url-fetch", false)
 	v.SetDefault("allow-ask-developer", false)
+	v.SetDefault("interactive-post-review", false)
 	v.SetDefault("render", "raw")
 
 	fs.VisitAll(func(f *flag.Flag) {
@@ -166,6 +168,10 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 
 	if cfg.AllowAskDeveloper && cfg.Render != "markdown" && cfg.Render != "tui" {
 		return fmt.Errorf("--allow-ask-developer can only be used when --render is 'markdown' or 'tui'")
+	}
+
+	if cfg.InteractivePostReview && cfg.Render != "markdown" && cfg.Render != "tui" {
+		return errors.New("--interactive-post-review can only be used when --render is 'markdown' or 'tui'")
 	}
 
 	sessionCtx, cancelSession := context.WithCancel(ctx)
@@ -329,6 +335,12 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 			return fmt.Errorf("failed to write structured review to %s: %w", cfg.OutputJSONFile, err)
 		}
 		reporter.ReportStructuredReviewWritten(cfg.OutputJSONFile)
+	}
+
+	if cfg.InteractivePostReview {
+		if err := reviewer.RunInteractivePostReview(sessionCtx); err != nil {
+			return fmt.Errorf("interactive post-review failed: %w", err)
+		}
 	}
 
 	return nil

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 
 	flag "github.com/spf13/pflag"
@@ -186,15 +187,13 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 		reporter = core.NewRawReporter(os.Stdout, stderr.Writer())
 	}
 
-	var reporterClosed bool
+	var closeOnce sync.Once
 	closeReporter := func() {
-		if reporterClosed {
-			return
-		}
-		if closer, ok := reporter.(io.Closer); ok {
-			_ = closer.Close()
-		}
-		reporterClosed = true
+		closeOnce.Do(func() {
+			if closer, ok := reporter.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		})
 	}
 	defer closeReporter()
 

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@com_github_charmbracelet_bubbles//viewport",
         "@com_github_charmbracelet_bubbletea//:bubbletea",
         "@com_github_charmbracelet_glamour//:glamour",
+        "@com_github_charmbracelet_huh//:huh",
         "@com_github_charmbracelet_lipgloss//:lipgloss",
         "@com_github_charmbracelet_lipgloss//table",
         "@org_golang_x_term//:term",
@@ -37,6 +38,7 @@ go_test(
         "main_test.go",
         "metrics_test.go",
         "review_types_test.go",
+        "reviewer_test.go",
     ],
     embed = [":core"],
     deps = [

--- a/core/agent.go
+++ b/core/agent.go
@@ -70,6 +70,7 @@ type Reporter interface {
 	ReportWarning(msg string, err error)
 	ReportError(err error)
 	NotifyUser()
+	ReportPostReviewReply(message string)
 }
 
 // AgentOption configures an Agent.
@@ -102,6 +103,7 @@ type Agent struct {
 	toolCalls  map[string]int
 	iterations int
 	stderr     io.Writer
+	history    []llm.Message
 }
 
 // NewAgent creates an Agent. Diagnostic / progress output goes to os.Stderr by
@@ -205,6 +207,11 @@ func (a *Agent) RunReview(ctx context.Context, stableSystem, dynamicSystem, requ
 				return "", fmt.Errorf("llm returned empty content on iteration %d after %d attempts", iter+1, emptyResponseMaxAttempts)
 			}
 			a.reporter.ReportFinalReview()
+			messages = append(messages, llm.Message{
+				Role: llm.RoleAssistant,
+				Text: resp.Text,
+			})
+			a.history = messages
 			return resp.Text, nil
 		}
 
@@ -419,6 +426,121 @@ func (a *Agent) handleCapReached(ctx context.Context, messages []llm.Message, ma
 	if resp.Text == "" {
 		return "", fmt.Errorf("llm returned empty content on forced-final review after %d attempts", emptyResponseMaxAttempts)
 	}
+	messages = append(messages, llm.Message{
+		Role: llm.RoleAssistant,
+		Text: resp.Text,
+	})
+	a.history = messages
+	return resp.Text, nil
+}
+
+// RunChatFlight executes the conversational ReAct loop for a single chat turn in the REPL.
+func (a *Agent) RunChatFlight(ctx context.Context, userText string, maxIterations, maxTokens int) (string, error) {
+	if maxIterations <= 0 {
+		maxIterations = AbsoluteMaxIter
+	}
+	if maxTokens <= 0 {
+		maxTokens = llm.DefaultMaxTokens
+	}
+
+	a.iterations = 0 // Reset iteration counter at the start of the flight
+	a.history = append(a.history, llm.Message{
+		Role: llm.RoleUser,
+		Text: userText,
+	})
+
+	tools := a.registry.ToTools()
+
+	defer func() {
+		a.reporter.ReportUsageSummary(a.totalUsage)
+	}()
+
+	for iter := range maxIterations {
+		a.iterations = iter + 1
+		a.reporter.ReportIteration(a.iterations)
+
+		resp, err := a.generateContentWithEmptyRetry(ctx, a.history, tools, maxTokens)
+		if err != nil {
+			return "", fmt.Errorf("llm call failed on chat iteration %d: %w", iter+1, err)
+		}
+
+		a.reporter.ReportUsage(resp.Usage)
+		a.totalUsage.Add(resp.Usage)
+
+		if resp.FinishReason == llm.FinishReasonLength {
+			a.reporter.ReportTruncated(maxTokens)
+		}
+
+		// No tool calls → LLM has produced its reply.
+		if len(resp.ToolCalls) == 0 {
+			if resp.Text == "" {
+				return "", fmt.Errorf("llm returned empty content on chat iteration %d after %d attempts", iter+1, emptyResponseMaxAttempts)
+			}
+			a.reporter.ReportFinalReview()
+			a.history = append(a.history, llm.Message{
+				Role: llm.RoleAssistant,
+				Text: resp.Text,
+			})
+			return resp.Text, nil
+		}
+
+		// Append the assistant's tool-call turn to history.
+		a.history = append(a.history, llm.Message{
+			Role:             llm.RoleAssistant,
+			Text:             resp.Text,
+			ToolCalls:        resp.ToolCalls,
+			Reasoning:        resp.Reasoning,
+			ProviderMetadata: resp.ProviderMetadata,
+		})
+
+		toolMsg := a.executeToolCalls(ctx, resp.ToolCalls)
+		if len(toolMsg.ToolResults) > 0 {
+			remaining := maxIterations - (iter + 1)
+			if remaining > 0 {
+				lastIdx := len(toolMsg.ToolResults) - 1
+				var note string
+				if remaining == 1 {
+					note = fmt.Sprintf(budgetNoteLastTurn, iter+1, maxIterations)
+				} else {
+					note = fmt.Sprintf(budgetNoteGeneral, iter+1, maxIterations, remaining)
+				}
+				toolMsg.ToolResults[lastIdx].Content += note
+			}
+		}
+		a.history = append(a.history, toolMsg)
+	}
+
+	return a.handleChatCapReached(ctx, maxIterations, maxTokens)
+}
+
+func (a *Agent) handleChatCapReached(ctx context.Context, maxIterations, maxTokens int) (string, error) {
+	capMsg := fmt.Sprintf(
+		"[SYSTEM] The maximum number of tool-call iterations (%d) has been reached. "+
+			"You MUST now produce your final response unconditionally, based on everything "+
+			"you have gathered so far. Do not request any additional tools.",
+		maxIterations,
+	)
+	a.reporter.ReportCapReached(maxIterations)
+
+	a.history = append(a.history, llm.Message{Role: llm.RoleUser, Text: capMsg})
+	a.reporter.ReportFinalReview()
+
+	resp, err := a.generateContentWithEmptyRetry(ctx, a.history, nil, maxTokens)
+	if err != nil {
+		return "", fmt.Errorf("llm call failed on forced-final chat response: %w", err)
+	}
+
+	a.reporter.ReportUsage(resp.Usage)
+	a.totalUsage.Add(resp.Usage)
+
+	if resp.Text == "" {
+		return "", fmt.Errorf("llm returned empty content on forced-final chat response after %d attempts", emptyResponseMaxAttempts)
+	}
+
+	a.history = append(a.history, llm.Message{
+		Role: llm.RoleAssistant,
+		Text: resp.Text,
+	})
 	return resp.Text, nil
 }
 

--- a/core/agent.go
+++ b/core/agent.go
@@ -476,7 +476,6 @@ func (a *Agent) RunChatFlight(ctx context.Context, userText string, maxIteration
 			if resp.Text == "" {
 				return "", fmt.Errorf("llm returned empty content on chat iteration %d after %d attempts", iter+1, emptyResponseMaxAttempts)
 			}
-			a.reporter.ReportFinalReview()
 			a.history = append(a.history, llm.Message{
 				Role: llm.RoleAssistant,
 				Text: resp.Text,
@@ -523,7 +522,6 @@ func (a *Agent) handleChatCapReached(ctx context.Context, maxIterations, maxToke
 	a.reporter.ReportCapReached(maxIterations)
 
 	a.history = append(a.history, llm.Message{Role: llm.RoleUser, Text: capMsg})
-	a.reporter.ReportFinalReview()
 
 	resp, err := a.generateContentWithEmptyRetry(ctx, a.history, nil, maxTokens)
 	if err != nil {

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -1160,3 +1160,157 @@ func TestTuiReporter(t *testing.T) {
 		t.Errorf("expected stderr to contain config table, got %q", stderr.String())
 	}
 }
+
+func TestRunChatFlight_DirectResponse(t *testing.T) {
+	lm := &mockLLM{responses: []*llm.Response{
+		textResponse("repl reply"),
+	}}
+	agent := newTestAgent(lm, newMockDispatcher())
+	got, err := agent.RunChatFlight(context.Background(), "user prompt", 5, 1024)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "repl reply" {
+		t.Errorf("got %q, want %q", got, "repl reply")
+	}
+	if len(lm.calls) != 1 {
+		t.Errorf("expected 1 LLM call, got %d", len(lm.calls))
+	}
+	// Verify history has user prompt and reply
+	if len(agent.history) != 2 {
+		t.Fatalf("expected history length 2, got %d", len(agent.history))
+	}
+	if agent.history[0].Text != "user prompt" || agent.history[0].Role != llm.RoleUser {
+		t.Errorf("unexpected first history message: %+v", agent.history[0])
+	}
+	if agent.history[1].Text != "repl reply" || agent.history[1].Role != llm.RoleAssistant {
+		t.Errorf("unexpected second history message: %+v", agent.history[1])
+	}
+}
+
+func TestRunChatFlight_SingleToolCall(t *testing.T) {
+	const wantResult = "file contents"
+	lm := &mockLLM{responses: []*llm.Response{
+		toolCallsResponse(makeToolCall("tc1", "read_file", map[string]any{"file_path": "foo.go"})),
+		textResponse("repl answer"),
+	}}
+	d := newMockDispatcher()
+	d.handlers["read_file"] = func(ctx context.Context, _ llm.ToolCall) (string, error) { return wantResult, nil }
+
+	agent := newTestAgent(lm, d)
+	got, err := agent.RunChatFlight(context.Background(), "do work", 5, 1024)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "repl answer" {
+		t.Errorf("got %q, want %q", got, "repl answer")
+	}
+	if len(lm.calls) != 2 {
+		t.Fatalf("expected 2 LLM calls, got %d", len(lm.calls))
+	}
+
+	// Verify history elements
+	if len(agent.history) != 4 {
+		t.Fatalf("expected history length 4, got %d", len(agent.history))
+	}
+	// Msg 0: user text
+	if agent.history[0].Text != "do work" {
+		t.Errorf("msg 0 text: got %q, want 'do work'", agent.history[0].Text)
+	}
+	// Msg 1: assistant tool call
+	if len(agent.history[1].ToolCalls) != 1 || agent.history[1].Role != llm.RoleAssistant {
+		t.Errorf("msg 1: expected 1 tool call, role assistant, got %+v", agent.history[1])
+	}
+	// Msg 2: tool result with budget note
+	if agent.history[2].Role != llm.RoleTool {
+		t.Errorf("msg 2 role: got %v, want RoleTool", agent.history[2].Role)
+	}
+	// Msg 3: assistant final response
+	if agent.history[3].Text != "repl answer" || agent.history[3].Role != llm.RoleAssistant {
+		t.Errorf("msg 3: expected repl answer, role assistant, got %+v", agent.history[3])
+	}
+}
+
+func TestRunChatFlight_CapReached(t *testing.T) {
+	alwaysTool := toolCallsResponse(makeToolCall("tc", "read_file", map[string]any{"file_path": "f.go"}))
+	lm := &mockLLM{responses: []*llm.Response{
+		alwaysTool,                  // iteration 1
+		alwaysTool,                  // iteration 2 (cap = 2)
+		textResponse("forced chat"), // forced-final call
+	}}
+	d := newMockDispatcher()
+	d.handlers["read_file"] = func(ctx context.Context, _ llm.ToolCall) (string, error) { return "x", nil }
+
+	agent := newTestAgent(lm, d)
+	got, err := agent.RunChatFlight(context.Background(), "chat query", 2, 1024)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "forced chat" {
+		t.Errorf("got %q, want %q", got, "forced chat")
+	}
+
+	// 2 loop iterations + 1 forced-final call = 3 total LLM calls
+	if len(lm.calls) != 3 {
+		t.Errorf("expected 3 LLM calls, got %d", len(lm.calls))
+	}
+
+	// The last message in history before the final assistant response must be the [SYSTEM] cap user turn.
+	if len(agent.history) < 2 {
+		t.Fatalf("expected at least 2 history elements, got %d", len(agent.history))
+	}
+	lastUser := agent.history[len(agent.history)-2]
+	if lastUser.Role != llm.RoleUser {
+		t.Errorf("cap message role: got %v, want RoleUser", lastUser.Role)
+	}
+	if !strings.Contains(lastUser.Text, "The maximum number of tool-call iterations") {
+		t.Errorf("expected cap message text, got %q", lastUser.Text)
+	}
+}
+
+func TestRunChatFlight_EmptyResponseRetry(t *testing.T) {
+	lm := &mockLLM{responses: []*llm.Response{
+		{Text: ""},                // empty — should trigger retry
+		textResponse("got reply"), // succeeds on second attempt
+	}}
+
+	spy := &spyReporter{}
+	agent := NewAgent(lm, newMockDispatcher(), WithReporter(spy))
+
+	got, err := agent.RunChatFlight(context.Background(), "hello", 5, 1024)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "got reply" {
+		t.Errorf("got %q, want %q", got, "got reply")
+	}
+
+	// 2 underlying calls
+	if lm.callIdx != 2 {
+		t.Errorf("expected 2 LLM calls, got %d", lm.callIdx)
+	}
+
+	// The retry should have been reported once
+	if len(spy.emptyResponseRetries) != 1 || spy.emptyResponseRetries[0] != 2 {
+		t.Errorf("expected emptyResponseRetries=[2], got %v", spy.emptyResponseRetries)
+	}
+}
+
+func TestRunChatFlight_EmptyResponseExhausted(t *testing.T) {
+	responses := make([]*llm.Response, emptyResponseMaxAttempts)
+	for i := range responses {
+		responses[i] = &llm.Response{Text: ""}
+	}
+	lm := &mockLLM{responses: responses}
+
+	agent := newTestAgent(lm, newMockDispatcher())
+
+	_, err := agent.RunChatFlight(context.Background(), "hello", 5, 1024)
+	if err == nil {
+		t.Fatal("expected error when empty-response retries are exhausted, got nil")
+	}
+
+	if lm.callIdx < emptyResponseMaxAttempts {
+		t.Errorf("expected at least %d LLM calls, got %d", emptyResponseMaxAttempts, lm.callIdx)
+	}
+}

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -194,6 +194,7 @@ func (s *spyReporter) ReportMetricsWritten(file string)                  {}
 func (s *spyReporter) ReportWarning(msg string, err error)               {}
 func (s *spyReporter) ReportError(err error)                             {}
 func (s *spyReporter) NotifyUser()                                       { s.notifiedUser++ }
+func (s *spyReporter) ReportPostReviewReply(message string)              {}
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Tests

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -44,18 +44,20 @@ type Config struct {
 	ProviderOptionsFile          string         `mapstructure:"provider-options-file"`
 	ProviderOptions              map[string]any `mapstructure:"-"`
 	Render                       string         `mapstructure:"render"`
+	InteractivePostReview        bool           `mapstructure:"interactive-post-review"`
 }
 
 // NewDefaultConfig returns a Config with default values populated.
 func NewDefaultConfig() *Config {
 	return &Config{
-		Base:              "main",
-		Head:              "HEAD",
-		MainGuidelines:    "general",
-		MaxTokens:         llm.DefaultMaxTokens,
-		IgnoredLockFiles:  util.DefaultLockFiles,
-		Render:            "raw",
-		AllowAskDeveloper: false,
+		Base:                  "main",
+		Head:                  "HEAD",
+		MainGuidelines:        "general",
+		MaxTokens:             llm.DefaultMaxTokens,
+		IgnoredLockFiles:      util.DefaultLockFiles,
+		Render:                "raw",
+		AllowAskDeveloper:     false,
+		InteractivePostReview: false,
 	}
 }
 
@@ -71,6 +73,7 @@ func Load(configFile string) (*Config, error) {
 	v.SetDefault("ignored-lock-files", util.DefaultLockFiles)
 	v.SetDefault("allow-url-fetch", false)
 	v.SetDefault("allow-ask-developer", false)
+	v.SetDefault("interactive-post-review", false)
 	v.SetDefault("render", "raw")
 
 	if configFile != "" {

--- a/core/console_reporter.go
+++ b/core/console_reporter.go
@@ -451,7 +451,7 @@ func (markdownFormatter) StyleStderr(plain, styled string, color string, bold bo
 }
 
 func (markdownFormatter) FormatPostReviewReply(message string) string {
-	return renderMarkdown(message, os.Stdout) + "\n"
+	return renderMarkdown(message, os.Stderr) + "\n"
 }
 
 func (markdownFormatter) FormatReviewHeader(files int, guidelines string, model string) string {

--- a/core/console_reporter.go
+++ b/core/console_reporter.go
@@ -128,7 +128,7 @@ func NewDefaultReporter(w io.Writer) Reporter {
 }
 
 func (r *consoleReporter) ReportPostReviewReply(message string) {
-	r.writer.WriteStdout(r.formatter.FormatPostReviewReply(message))
+	r.writer.WriteStderr(r.formatter.FormatPostReviewReply(message))
 }
 
 func (r *consoleReporter) NotifyUser() {

--- a/core/console_reporter.go
+++ b/core/console_reporter.go
@@ -97,6 +97,7 @@ type ConsoleFormatter interface {
 	FormatConfig(cfg *config.Config, targetDir string) string
 	FormatReview(result string) string
 	StyleStderr(plain, styled string, color string, bold bool) string
+	FormatPostReviewReply(message string) string
 }
 
 // consoleReporter formats semantic messages and delegates rendering to a consoleWriter.
@@ -124,6 +125,10 @@ func NewMarkdownReporter(stdout, stderr io.Writer) Reporter {
 // NewDefaultReporter creates a raw reporter for backward compatibility.
 func NewDefaultReporter(w io.Writer) Reporter {
 	return NewRawReporter(w, w)
+}
+
+func (r *consoleReporter) ReportPostReviewReply(message string) {
+	r.writer.WriteStdout(r.formatter.FormatPostReviewReply(message))
 }
 
 func (r *consoleReporter) NotifyUser() {
@@ -347,6 +352,10 @@ func (rawFormatter) StyleStderr(plain, styled string, color string, bold bool) s
 	return plain + "\n"
 }
 
+func (rawFormatter) FormatPostReviewReply(message string) string {
+	return message + "\n"
+}
+
 func (rawFormatter) FormatReviewHeader(files int, guidelines string, model string) string {
 	return fmt.Sprintf("\n✅ Review generated successfully.\n\n\n# 📝 Review for %d files using %s (%s)\n\n", files, guidelines, model)
 }
@@ -439,6 +448,10 @@ func (markdownFormatter) StyleStderr(plain, styled string, color string, bold bo
 		style = style.Bold(true)
 	}
 	return style.Render(styled) + "\n"
+}
+
+func (markdownFormatter) FormatPostReviewReply(message string) string {
+	return renderMarkdown(message, os.Stdout) + "\n"
 }
 
 func (markdownFormatter) FormatReviewHeader(files int, guidelines string, model string) string {

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -3,16 +3,23 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"sync"
+	"time"
 
+	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/menny/cassandra/core/config"
 	"github.com/menny/cassandra/core/prompts"
 	"github.com/menny/cassandra/llm"
 	"github.com/menny/cassandra/llm/factory"
 	"github.com/menny/cassandra/tools"
 	"github.com/menny/cassandra/tools/mcp"
+	"golang.org/x/term"
 )
 
 // Reviewer encapsulates an initialized Agent and its environment.
@@ -151,4 +158,194 @@ func (r *Reviewer) Run(ctx context.Context, changedFiles []string, requestText s
 
 	maxIterations := CalculateMaxIterations(len(changedFiles))
 	return r.Agent.RunReview(ctx, r.StablePrompt, dynamic, requestText, maxIterations, r.Config.MaxTokens)
+}
+
+const postReviewSystemInstruction = "You have completed the automated code review. " +
+	"You are now in an interactive post-review chat phase. " +
+	"Transition purely into a conversational assistant. Answer the developer's questions, " +
+	"defend your findings, or admit mistakes based on the user's input. " +
+	"Do NOT attempt to rewrite the code review or output a new structured code review payload."
+
+type (
+	replStdinKey  struct{}
+	replStderrKey struct{}
+)
+
+// WithTestREPLStreams wraps a context to override standard input/stderr of the interactive REPL.
+func WithTestREPLStreams(ctx context.Context, in io.Reader, err io.Writer) context.Context {
+	ctx = context.WithValue(ctx, replStdinKey{}, in)
+	return context.WithValue(ctx, replStderrKey{}, err)
+}
+
+type terminalSpinner struct {
+	mu       sync.Mutex
+	active   bool
+	frames   []string
+	delay    time.Duration
+	stopChan chan struct{}
+	writer   io.Writer
+}
+
+func newTerminalSpinner(w io.Writer) *terminalSpinner {
+	return &terminalSpinner{
+		frames:   []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
+		delay:    80 * time.Millisecond,
+		writer:   w,
+		stopChan: make(chan struct{}),
+	}
+}
+
+func (s *terminalSpinner) Start(message string) {
+	s.mu.Lock()
+	if s.active {
+		s.mu.Unlock()
+		return
+	}
+	s.active = true
+	s.stopChan = make(chan struct{})
+	s.mu.Unlock()
+
+	go func() {
+		ticker := time.NewTicker(s.delay)
+		defer ticker.Stop()
+		defer func() {
+			fmt.Fprintf(s.writer, "\r\033[K")
+		}()
+		i := 0
+		for {
+			select {
+			case <-s.stopChan:
+				return
+			case <-ticker.C:
+				s.mu.Lock()
+				if !s.active {
+					s.mu.Unlock()
+					return
+				}
+				frame := s.frames[i%len(s.frames)]
+				styledFrame := lipgloss.NewStyle().Foreground(lipgloss.Color("178")).Render(frame)
+				fmt.Fprintf(s.writer, "\r%s %s", styledFrame, message)
+				s.mu.Unlock()
+				i++
+			}
+		}
+	}()
+}
+
+func (s *terminalSpinner) Stop() {
+	s.mu.Lock()
+	if !s.active {
+		s.mu.Unlock()
+		return
+	}
+	s.active = false
+	close(s.stopChan)
+	s.mu.Unlock()
+}
+
+// RunInteractivePostReview starts a continuous chat loop with the developer.
+func (r *Reviewer) RunInteractivePostReview(ctx context.Context) error {
+	replCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var input io.Reader = os.Stdin
+	if in, ok := ctx.Value(replStdinKey{}).(io.Reader); ok {
+		input = in
+	}
+	var errWriter io.Writer = os.Stderr
+	if err, ok := ctx.Value(replStderrKey{}).(io.Writer); ok {
+		errWriter = err
+	}
+
+	// Defensive goroutine to unblock any blocking read in accessible mode / tests
+	// by closing the input stream if it implements io.Closer and is not os.Stdin.
+	if replCtx.Done() != nil {
+		go func() {
+			<-replCtx.Done()
+			if closer, ok := input.(io.Closer); ok && input != os.Stdin {
+				_ = closer.Close()
+			}
+		}()
+	}
+
+	// Append system instruction indicating conversational post-review phase
+	r.Agent.history = append(r.Agent.history, llm.Message{
+		Role: llm.RoleSystem,
+		Text: postReviewSystemInstruction,
+	})
+
+	maxIterations := CalculateMaxIterations(1)
+
+	accessible := !term.IsTerminal(int(os.Stdin.Fd()))
+	if ctx.Value(replStdinKey{}) != nil {
+		accessible = true
+	}
+
+	for {
+		if replCtx.Err() != nil {
+			return nil
+		}
+
+		if r.Config.Render == "tui" || r.Config.Render == "markdown" {
+			divider := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("\n" + strings.Repeat("─", 80) + "\n")
+			fmt.Fprint(errWriter, divider)
+		}
+
+		var userInput string
+		form := huh.NewForm(
+			huh.NewGroup(
+				huh.NewText().
+					Title("Ask Cassandra").
+					Value(&userInput).
+					Lines(8).
+					WithWidth(80),
+			),
+		).WithWidth(80)
+
+		theme := huh.ThemeCharm()
+		theme.Focused.Title = theme.Focused.Title.Foreground(lipgloss.Color("216")).Bold(true)
+		theme.Focused.Description = theme.Focused.Description.Foreground(lipgloss.Color("243"))
+		theme.Focused.Base = theme.Focused.Base.BorderLeft(true).BorderForeground(lipgloss.Color("107"))
+		theme.Focused.TextInput.Prompt = theme.Focused.TextInput.Prompt.Foreground(lipgloss.Color("178"))
+		theme.Focused.TextInput.Text = theme.Focused.TextInput.Text.Foreground(lipgloss.Color("223"))
+
+		form.WithTheme(theme).
+			WithInput(input).
+			WithOutput(errWriter).
+			WithAccessible(accessible)
+
+		err := form.RunWithContext(replCtx)
+		if err != nil {
+			if replCtx.Err() != nil || errors.Is(err, huh.ErrUserAborted) || errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return fmt.Errorf("interactive prompt failed: %w", err)
+		}
+
+		cleanInput := strings.TrimSpace(userInput)
+		lowerInput := strings.ToLower(cleanInput)
+		if lowerInput == "exit" || lowerInput == "bye" || lowerInput == "/exit" {
+			return nil
+		}
+
+		if cleanInput == "" {
+			continue
+		}
+
+		var spinner *terminalSpinner
+		if r.Config.Render == "tui" {
+			spinner = newTerminalSpinner(errWriter)
+			spinner.Start("Cassandra is thinking...")
+		}
+
+		reply, err := r.Agent.RunChatFlight(replCtx, cleanInput, maxIterations, r.Config.MaxTokens)
+		if spinner != nil {
+			spinner.Stop()
+		}
+		if err != nil {
+			return fmt.Errorf("chat flight failed: %w", err)
+		}
+
+		r.Agent.reporter.ReportPostReviewReply(reply)
+	}
 }

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -203,6 +203,7 @@ func (s *terminalSpinner) Start(message string) {
 	}
 	s.active = true
 	s.stopChan = make(chan struct{})
+	stopChan := s.stopChan
 	s.mu.Unlock()
 
 	go func() {
@@ -214,7 +215,7 @@ func (s *terminalSpinner) Start(message string) {
 		i := 0
 		for {
 			select {
-			case <-s.stopChan:
+			case <-stopChan:
 				return
 			case <-ticker.C:
 				s.mu.Lock()

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -183,6 +183,7 @@ type terminalSpinner struct {
 	frames   []string
 	delay    time.Duration
 	stopChan chan struct{}
+	doneChan chan struct{}
 	writer   io.Writer
 }
 
@@ -203,7 +204,9 @@ func (s *terminalSpinner) Start(message string) {
 	}
 	s.active = true
 	s.stopChan = make(chan struct{})
+	s.doneChan = make(chan struct{})
 	stopChan := s.stopChan
+	doneChan := s.doneChan
 	s.mu.Unlock()
 
 	go func() {
@@ -211,6 +214,7 @@ func (s *terminalSpinner) Start(message string) {
 		defer ticker.Stop()
 		defer func() {
 			fmt.Fprintf(s.writer, "\r\033[K")
+			close(doneChan)
 		}()
 		i := 0
 		for {
@@ -241,7 +245,10 @@ func (s *terminalSpinner) Stop() {
 	}
 	s.active = false
 	close(s.stopChan)
+	doneChan := s.doneChan
 	s.mu.Unlock()
+
+	<-doneChan
 }
 
 // RunInteractivePostReview starts a continuous chat loop with the developer.

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -286,8 +286,15 @@ func (r *Reviewer) RunInteractivePostReview(ctx context.Context) error {
 			return nil
 		}
 
+		width := 80
+		if f, ok := errWriter.(*os.File); ok {
+			if w, _, err := term.GetSize(int(f.Fd())); err == nil && w > 0 {
+				width = w
+			}
+		}
+
 		if r.Config.Render == "tui" || r.Config.Render == "markdown" {
-			divider := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("\n" + strings.Repeat("─", 80) + "\n")
+			divider := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("\n" + strings.Repeat("─", width) + "\n")
 			fmt.Fprint(errWriter, divider)
 		}
 
@@ -298,9 +305,9 @@ func (r *Reviewer) RunInteractivePostReview(ctx context.Context) error {
 					Title("Ask Cassandra").
 					Value(&userInput).
 					Lines(8).
-					WithWidth(80),
+					WithWidth(width),
 			),
-		).WithWidth(80)
+		).WithWidth(width)
 
 		theme := huh.ThemeCharm()
 		theme.Focused.Title = theme.Focused.Title.Foreground(lipgloss.Color("216")).Bold(true)

--- a/core/reviewer_test.go
+++ b/core/reviewer_test.go
@@ -1,0 +1,177 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/menny/cassandra/core/config"
+	"github.com/menny/cassandra/llm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReviewer_RunInteractivePostReview_ExitCommands(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"exit lowercase", "exit\n.\n"},
+		{"exit uppercase", "EXIT\n.\n"},
+		{"bye", "bye\n.\n"},
+		{"/exit", "/exit\n.\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewDefaultConfig()
+			cfg.Render = "markdown"
+
+			lm := &mockLLM{
+				responses: []*llm.Response{
+					textResponse("automated review content"),
+				},
+			}
+			dispatcher := newMockDispatcher()
+			spy := &spyReporter{}
+
+			reviewer := &Reviewer{
+				Agent:  NewAgent(lm, dispatcher, WithReporter(spy)),
+				Config: cfg,
+			}
+
+			// Pre-populate history as if RunReview had run
+			reviewer.Agent.history = []llm.Message{
+				{Role: llm.RoleSystem, Text: "stable system"},
+				{Role: llm.RoleUser, Text: "request review"},
+				{Role: llm.RoleAssistant, Text: "automated review content"},
+			}
+
+			inR, inW := io.Pipe()
+			var outBuf bytes.Buffer
+
+			ctx := WithTestREPLStreams(context.Background(), inR, &outBuf)
+
+			// Feed the exit command immediately
+			go func() {
+				defer inW.Close()
+				_, _ = inW.Write([]byte(tt.input))
+			}()
+
+			err := reviewer.RunInteractivePostReview(ctx)
+			require.NoError(t, err)
+
+			// History must contain the post-review system instruction
+			require.NotEmpty(t, reviewer.Agent.history)
+			var postReviewSystemSeen bool
+			for _, msg := range reviewer.Agent.history {
+				if msg.Role == llm.RoleSystem && msg.Text == postReviewSystemInstruction {
+					postReviewSystemSeen = true
+					break
+				}
+			}
+			require.True(t, postReviewSystemSeen, "postReviewSystemInstruction must be in history")
+		})
+	}
+}
+
+func TestReviewer_RunInteractivePostReview_ChatFlight(t *testing.T) {
+	cfg := config.NewDefaultConfig()
+	cfg.Render = "markdown"
+
+	lm := &mockLLM{
+		responses: []*llm.Response{
+			textResponse("Cassandra answer to query 1"),
+		},
+	}
+	dispatcher := newMockDispatcher()
+	spy := &spyReporter{}
+
+	reviewer := &Reviewer{
+		Agent:  NewAgent(lm, dispatcher, WithReporter(spy)),
+		Config: cfg,
+	}
+
+	// Pre-populate history
+	reviewer.Agent.history = []llm.Message{
+		{Role: llm.RoleSystem, Text: "stable system"},
+		{Role: llm.RoleUser, Text: "request review"},
+		{Role: llm.RoleAssistant, Text: "automated review content"},
+	}
+
+	inR, inW := io.Pipe()
+	var outBuf bytes.Buffer
+
+	ctx := WithTestREPLStreams(context.Background(), inR, &outBuf)
+
+	// Feed a query and then exit
+	go func() {
+		defer inW.Close()
+		_, _ = inW.Write([]byte("why did you flag this file?\n.\n"))
+		// Wait a bit to let it process, then send exit
+		time.Sleep(50 * time.Millisecond)
+		_, _ = inW.Write([]byte("exit\n.\n"))
+	}()
+
+	err := reviewer.RunInteractivePostReview(ctx)
+	require.NoError(t, err)
+
+	// Verify LLM calls were made with the query
+	require.Equal(t, 1, len(lm.calls))
+	lastCall := lm.calls[len(lm.calls)-1]
+
+	// Find the user query in the captured messages
+	var userQuerySeen bool
+	for _, msg := range lastCall {
+		if msg.Role == llm.RoleUser && msg.Text == "why did you flag this file?" {
+			userQuerySeen = true
+		}
+	}
+	require.True(t, userQuerySeen, "User query must be passed in LLM context")
+
+	// Verify history has both user query and Cassandra reply
+	var historyUserSeen bool
+	var historyAssistantSeen bool
+	for _, msg := range reviewer.Agent.history {
+		if msg.Role == llm.RoleUser && msg.Text == "why did you flag this file?" {
+			historyUserSeen = true
+		}
+		if msg.Role == llm.RoleAssistant && msg.Text == "Cassandra answer to query 1" {
+			historyAssistantSeen = true
+		}
+	}
+	require.True(t, historyUserSeen, "User query must be appended to history")
+	require.True(t, historyAssistantSeen, "Cassandra answer must be appended to history")
+}
+
+func TestReviewer_RunInteractivePostReview_Cancellation(t *testing.T) {
+	cfg := config.NewDefaultConfig()
+	cfg.Render = "markdown"
+
+	lm := &mockLLM{}
+	dispatcher := newMockDispatcher()
+	spy := &spyReporter{}
+
+	reviewer := &Reviewer{
+		Agent:  NewAgent(lm, dispatcher, WithReporter(spy)),
+		Config: cfg,
+	}
+
+	inR, inW := io.Pipe()
+	defer inW.Close()
+	var outBuf bytes.Buffer
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	ctx := WithTestREPLStreams(cancelCtx, inR, &outBuf)
+
+	// Cancel the context while running
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	err := reviewer.RunInteractivePostReview(ctx)
+	// Context cancellation should break the loop cleanly returning nil error
+	require.NoError(t, err)
+}

--- a/core/tui.go
+++ b/core/tui.go
@@ -465,7 +465,7 @@ func (r *tuiReporter) Close() error {
 }
 
 func (r *tuiReporter) ReportPostReviewReply(message string) {
-	fmt.Fprint(r.stdout, renderMarkdown(message, r.stdout)+"\n")
+	fmt.Fprint(r.stderr, renderMarkdown(message, r.stderr)+"\n")
 }
 
 func (r *tuiReporter) ReportConfig(cfg *config.Config, targetDir string) {

--- a/core/tui.go
+++ b/core/tui.go
@@ -387,14 +387,15 @@ func compactToolCallArgsString(args string) string {
 
 // tuiReporter implements Reporter to drive Bubble Tea UI.
 type tuiReporter struct {
-	mu      sync.Mutex
-	program *tea.Program
-	model   *tuiModel
-	stdout  io.Writer
-	stderr  io.Writer
-	done    chan struct{}
-	cancel  context.CancelFunc
-	closed  bool
+	mu        sync.Mutex
+	program   *tea.Program
+	model     *tuiModel
+	stdout    io.Writer
+	stderr    io.Writer
+	done      chan struct{}
+	cancel    context.CancelFunc
+	closed    bool
+	closeOnce sync.Once
 }
 
 // NewTuiReporter constructs a TUI reporter.
@@ -444,23 +445,25 @@ func (r *tuiReporter) send(msg tea.Msg) {
 }
 
 func (r *tuiReporter) Close() error {
-	r.mu.Lock()
-	r.closed = true
-	prog := r.program
-	r.mu.Unlock()
-
-	if prog != nil {
-		prog.Send(quitMsg{})
-		<-r.done
-
-		// Print the final complete TUI progress content to stderr, bypassing the viewport
-		title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("107")).Render("🛸 Cassandra AI Reviewer") + "\n\n"
-		fmt.Fprint(r.stderr, title+r.model.renderContent()+"\n")
-
+	r.closeOnce.Do(func() {
 		r.mu.Lock()
-		r.program = nil
+		r.closed = true
+		prog := r.program
 		r.mu.Unlock()
-	}
+
+		if prog != nil {
+			prog.Send(quitMsg{})
+			<-r.done
+
+			// Print the final complete TUI progress content to stderr, bypassing the viewport
+			title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("107")).Render("🛸 Cassandra AI Reviewer") + "\n\n"
+			fmt.Fprint(r.stderr, title+r.model.renderContent()+"\n")
+
+			r.mu.Lock()
+			r.program = nil
+			r.mu.Unlock()
+		}
+	})
 	return nil
 }
 

--- a/core/tui.go
+++ b/core/tui.go
@@ -394,6 +394,7 @@ type tuiReporter struct {
 	stderr  io.Writer
 	done    chan struct{}
 	cancel  context.CancelFunc
+	closed  bool
 }
 
 // NewTuiReporter constructs a TUI reporter.
@@ -433,6 +434,9 @@ func (r *tuiReporter) startLocked() {
 func (r *tuiReporter) send(msg tea.Msg) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.closed {
+		return
+	}
 	if r.program == nil {
 		r.startLocked()
 	}
@@ -441,6 +445,7 @@ func (r *tuiReporter) send(msg tea.Msg) {
 
 func (r *tuiReporter) Close() error {
 	r.mu.Lock()
+	r.closed = true
 	prog := r.program
 	r.mu.Unlock()
 
@@ -457,6 +462,10 @@ func (r *tuiReporter) Close() error {
 		r.mu.Unlock()
 	}
 	return nil
+}
+
+func (r *tuiReporter) ReportPostReviewReply(message string) {
+	fmt.Fprint(r.stdout, renderMarkdown(message, r.stdout)+"\n")
 }
 
 func (r *tuiReporter) ReportConfig(cfg *config.Config, targetDir string) {


### PR DESCRIPTION
This PR implements feature request #119. It introduces a new CLI flag `--interactive-post-review` to optionally enter an interactive conversational REPL session with the LLM via `huh` after the initial review completes successfully.