### PR TITLE
feat: add pre-review summary stage and phase-specific metrics

### DIFF
--- a/.cassandra/pre-review-summary.md
+++ b/.cassandra/pre-review-summary.md
@@ -1,0 +1,43 @@
+**Role & Objective**
+You are an expert, objective Code Review Assistant. Your sole purpose is to map and summarize code changes for human reviewers. You act as a neutral cartographer: you explain *what* happened, *why* it happened, and *what it affects*. 
+**You must absolutely never provide feedback, critique, or suggestions on the quality, style, or logic of the code.** Leave the actual code review to the human.
+
+**Available Tools & Strategy**
+You have access to various tools. Use them strategically to understand the "blast radius" of this change. For example:
+* If a utility or interface is modified, use `grep_files` to find where it is consumed to accurately report the affected areas.
+* If the provided file change is sparse, use `read_file` to understand the context.
+* etc.
+
+**Input Sources**
+You will be provided with:
+* The git diff of the changes to analyze.
+* The commit messages representing the developer's recorded history of changes.
+* PR Metadata (if available), including title, description, author, and comments.
+* Workspace-specific guidelines (`AGENTS.md` and `REVIEWERS.md` files) loaded dynamically based on the changed files.
+
+**Output Format**
+You must output a highly scannable Markdown summary using the exact structure below. Be concise. Do not use corporate filler language.
+
+### Abstract
+Provide a 1-2 sentence high-level summary of the entire change. (e.g., "Replaces the legacy authentication middleware with a new JWT-based implementation and updates downstream consumer services.")
+
+### Purpose
+Explain the goal of this change based on the PR description, commit messages, and issue trackers (if provided). What problem does this solve?
+
+### Discrepancy Report
+Compare the Developer's Intent (PR description/commits) against the Actual Code Reality (the diff).
+* **Match:** If the code perfectly matches the description, state: "No discrepancies found. The diff aligns with the PR description."
+* **Discrepancy:** If you find changes in the diff that are NOT mentioned in the description (e.g., unrelated dependency bumps, "drive-by" refactors in unrelated files, or missing implementations), you MUST highlight them here clearly. (e.g., "The PR description focuses on the auth bug, but the diff includes an undocumented refactor of the `payment_gateway.go` file.")
+
+### Impacted Areas
+Based on the diff and your tool usage, list the architectural areas affected.
+* **Changes affect:** [List the modules, services, or UI components directly modified]
+* **Downstream impacts:** [List the modules/services that consume the changed code and might be indirectly affected]
+
+### Detailed Changes
+Break down the changes using a concise, bulleted list grouped by domain or file-type (whichever makes more logical sense for this specific diff). Do not list every single minor line change; group them logically.
+* **Domain/Area 1:**
+    * Detail what changed (e.g., "Added `validateToken` function to `auth.ts`").
+    * Detail what changed.
+* **Domain/Area 2:**
+    * Detail what changed.

--- a/.cassandra/pre-review-summary.md
+++ b/.cassandra/pre-review-summary.md
@@ -1,12 +1,11 @@
 **Role & Objective**
-You are an expert, objective Code Review Assistant. Your sole purpose is to map and summarize code changes for human reviewers. You act as a neutral cartographer: you explain *what* happened, *why* it happened, and *what it affects*. 
+You are an expert, objective Code Review Assistant. Your sole purpose is to map and summarize code changes for human reviewers. You act as a neutral cartographer: you explain *what* happened, *why* it happened, and *what it affects*.
 **You must absolutely never provide feedback, critique, or suggestions on the quality, style, or logic of the code.** Leave the actual code review to the human.
 
 **Available Tools & Strategy**
 You have access to various tools. Use them strategically to understand the "blast radius" of this change. For example:
 * If a utility or interface is modified, use `grep_files` to find where it is consumed to accurately report the affected areas.
 * If the provided file change is sparse, use `read_file` to understand the context.
-* etc.
 
 **Input Sources**
 You will be provided with:
@@ -16,28 +15,24 @@ You will be provided with:
 * Workspace-specific guidelines (`AGENTS.md` and `REVIEWERS.md` files) loaded dynamically based on the changed files.
 
 **Output Format**
-You must output a highly scannable Markdown summary using the exact structure below. Be concise. Do not use corporate filler language.
+Produce a short, scannable Markdown summary using exactly the four sections below. Be ruthlessly concise — a reviewer who wants more detail will read the PR description. Do not use corporate filler language. Do not pad any section.
 
-### Abstract
-Provide a 1-2 sentence high-level summary of the entire change. (e.g., "Replaces the legacy authentication middleware with a new JWT-based implementation and updates downstream consumer services.")
+### TL;DR
+One sentence. What is this change, in plain language?
+*(e.g., "Replaces the legacy auth middleware with a JWT-based implementation and updates all downstream consumers.")*
 
 ### Purpose
-Explain the goal of this change based on the PR description, commit messages, and issue trackers (if provided). What problem does this solve?
+1–2 sentences maximum. Why does this change exist — what problem does it solve or what goal does it serve? Base this on the PR description and commit messages.
 
-### Discrepancy Report
-Compare the Developer's Intent (PR description/commits) against the Actual Code Reality (the diff).
-* **Match:** If the code perfectly matches the description, state: "No discrepancies found. The diff aligns with the PR description."
-* **Discrepancy:** If you find changes in the diff that are NOT mentioned in the description (e.g., unrelated dependency bumps, "drive-by" refactors in unrelated files, or missing implementations), you MUST highlight them here clearly. (e.g., "The PR description focuses on the auth bug, but the diff includes an undocumented refactor of the `payment_gateway.go` file.")
+### Heads Up
+Bullets only. List only things that are surprising, non-obvious, or that a reviewer might otherwise miss:
+- Changes in the diff that are **not mentioned** in the PR description (undocumented drive-bys, unrelated refactors, missing implementations).
+- Non-obvious side-effects, risky assumptions, or subtle behavioral changes.
+- If nothing is surprising, write a single line: *"Diff aligns with PR description — nothing unexpected."*
 
-### Impacted Areas
-Based on the diff and your tool usage, list the architectural areas affected.
-* **Changes affect:** [List the modules, services, or UI components directly modified]
-* **Downstream impacts:** [List the modules/services that consume the changed code and might be indirectly affected]
+### Scope
+One line. Two compact lists separated by `→`:
+`Modified: <areas>  →  Downstream: <consumers>` (omit "Downstream" if none).
 
-### Detailed Changes
-Break down the changes using a concise, bulleted list grouped by domain or file-type (whichever makes more logical sense for this specific diff). Do not list every single minor line change; group them logically.
-* **Domain/Area 1:**
-    * Detail what changed (e.g., "Added `validateToken` function to `auth.ts`").
-    * Detail what changed.
-* **Domain/Area 2:**
-    * Detail what changed.
+### Key Changes
+3–5 bullets maximum. List only the most important or non-obvious individual changes — the ones a reviewer should consciously look for. Skip trivial renames, formatting, and changes already obvious from the TL;DR. If fewer than 3 meaningful items exist, use fewer bullets.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The following settings can be provided via CLI flags, environment variables, or 
 | `--main-guidelines` | Path to a file or a named prompt from the library (`general`, `asana-do-try-consider`, `google`, `conventional-comments`, `palantir`, `minimalist`, `security-first`) | `general` |
 | `--supplemental-guidelines` | Additive paths or named library prompts for supplemental guidelines (can be used multiple times) | |
 | `--approval-evaluation-prompt-file` | Path to a file containing custom approval evaluation guidelines | |
+| `--pre-review-prompt` | Path to a file containing the system prompt for the pre-review summary agent | |
+| `--pre-review-model` | Optional model override for the pre-review summary agent | |
 | `--review-output-file` | Path to a file where the final review will be written | |
 | `--output-json` | Path to a file where the structured JSON review will be written | |
 | `--metrics-json` | Path to a file where the session metrics (tokens, tool calls, iterations) will be written | |
@@ -89,6 +91,8 @@ The following settings can be provided via CLI flags, environment variables, or 
 | `main_guidelines` | Path to a file or a named prompt from the library (`general`, `asana-do-try-consider`, `google`, `conventional-comments`, `palantir`, `minimalist`, `security-first`) | `general` | No |
 | `supplemental_guidelines` | Additive guidelines to supplement the main guidelines. Multiline string where each line is a path or library prompt name. | | No |
 | `approval_evaluation_prompt_file` | Path to a file containing custom approval evaluation guidelines | | No |
+| `pre_review_prompt` | Path to a file containing the system prompt for the pre-review summary agent | | No |
+| `pre_review_model` | Optional model override for the pre-review summary agent | | No |
 | `metadata_tag` | Tag to identify Cassandra comments (inner text only, will be wrapped in `<!-- ... -->`) | `cassandra-ai-review-${{ github.workflow }}` | No |
 | `reaction_icon` | The reaction icon to add to the PR description while the review is in progress (e.g., `eyes`, `rocket`, `heart`) | `eyes` | No |
 | `reviewer_github_token` | GitHub token for posting comments and reactions | `${{ github.token }}` | No |
@@ -172,6 +176,29 @@ main-guidelines = "security-first"
 supplemental-guidelines = [
   ".cassandra/haiku-praise.md"
 ]
+```
+
+## Pre-Review Stage
+
+Before the main AI code review runs, Cassandra can run an optional **Pre-Review Stage** using a separate LLM Agent. This stage maps and summarizes the code changes (including git diff, commits, and PR metadata) to output a scannable summary report. This report is displayed in the progress logs and is prepended directly to the main reviewer's context, providing high-signal background context about the change.
+
+### Configuration
+
+You can configure the pre-review stage using your `cassandra.toml` file, CLI flags, or GitHub Action inputs:
+
+- **`pre-review-prompt`** (CLI: `--pre-review-prompt`, Action: `pre_review_prompt`): Path to a file containing the system instructions/prompt for the pre-review LLM Agent.
+- **`pre-review-model`** (CLI: `--pre-review-model`, Action: `pre_review_model`): Optional model override to use for the pre-review agent (e.g., using a faster model like `gemini-2.5-flash` for the summary stage, while using `gemini-3.1-pro-preview` for the main review). If not specified, it defaults to the main `model`.
+
+### Example `cassandra.toml` with Pre-Review
+
+```toml
+provider = "google"
+model = "gemini-3.1-pro-preview"
+main-guidelines = "security-first"
+
+# Pre-Review summary stage configuration
+pre-review-prompt = ".cassandra/pre-review-summary.md"
+pre-review-model = "gemini-3.1-flash-lite"  # Optional model override
 ```
 
 ### Supported Models

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,14 @@ inputs:
     description: 'Optional path to a file containing custom approval evaluation guidelines'
     required: false
     default: ''
+  pre_review_prompt:
+    description: 'Optional path to a file containing a prompt to an LLM Agent for pre-review summary'
+    required: false
+    default: ''
+  pre_review_model:
+    description: 'Optional model override for the pre-review summary phase (defaults to main model)'
+    required: false
+    default: ''
   metadata_tag:
     description: 'Tag to identify Cassandra comments (inner text only, will be wrapped in <!-- ... -->)'
     required: false
@@ -281,6 +289,8 @@ runs:
         MAIN_GUIDELINES: ${{ inputs.main_guidelines }}
         SUPPLEMENTAL_GUIDELINES: ${{ inputs.supplemental_guidelines }}
         APPROVAL_EVALUATION_PROMPT_FILE: ${{ inputs.approval_evaluation_prompt_file }}
+        PRE_REVIEW_PROMPT: ${{ inputs.pre_review_prompt }}
+        PRE_REVIEW_MODEL: ${{ inputs.pre_review_model }}
         MCP_CONFIG: ${{ inputs.mcp_config }}
         ALLOW_URL_FETCH: ${{ inputs.allow_url_fetch }}
         IGNORED_LOCK_FILES: ${{ inputs.ignored_lock_files }}
@@ -399,6 +409,20 @@ runs:
             # Try it as a relative path or literal if not found in the workspace
             ARGS+=(--approval-evaluation-prompt-file "$APPROVAL_EVALUATION_PROMPT_FILE")
           fi
+        fi
+
+        if [[ -n "$PRE_REVIEW_PROMPT" ]]; then
+          PRE_PROMPT="${{ github.workspace }}/$WORKING_DIRECTORY/$PRE_REVIEW_PROMPT"
+          if [[ -f "$PRE_PROMPT" ]]; then
+            ARGS+=(--pre-review-prompt "$PRE_PROMPT")
+          else
+            # Try it as a relative path or literal if not found in the workspace
+            ARGS+=(--pre-review-prompt "$PRE_REVIEW_PROMPT")
+          fi
+        fi
+
+        if [[ -n "$PRE_REVIEW_MODEL" ]]; then
+          ARGS+=(--pre-review-model "$PRE_REVIEW_MODEL")
         fi
 
         if [[ -n "$MAIN_GUIDELINES" ]]; then

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -48,6 +48,8 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 	fs.StringVar(&cfg.MainGuidelines, "main-guidelines", "", "Path to a file or a named prompt from the library (defaults to 'general')")
 	fs.StringArrayVar(&cfg.SupplementalGuidelines, "supplemental-guidelines", nil, "Optional additive paths or named library prompts for supplemental guidelines (can be used multiple times)")
 	fs.StringVar(&cfg.ApprovalEvaluationPromptFile, "approval-evaluation-prompt-file", "", "Optional path to a file containing custom approval evaluation guidelines")
+	fs.StringVar(&cfg.PreReviewPromptFile, "pre-review-prompt", "", "Optional path to a file containing a prompt to an LLM Agent for pre-review summary")
+	fs.StringVar(&cfg.PreReviewModel, "pre-review-model", "", "Optional model override for the pre-review summary phase (defaults to main model)")
 	fs.IntVar(&cfg.MaxTokens, "max-tokens", llm.DefaultMaxTokens, "Max tokens for the LLM response (defaults to provider specific default)")
 	fs.StringVar(&cfg.Base, "base", "main", "Base commit/branch for diff (defaults to 'main')")
 	fs.StringVar(&cfg.Head, "head", "HEAD", "Head commit/branch for diff (defaults to 'HEAD')")

--- a/cmd/ai_reviewer/main.go
+++ b/cmd/ai_reviewer/main.go
@@ -209,8 +209,8 @@ func run(ctx context.Context, args []string, stderr *log.Logger) error {
 
 	if cfg.MetricsJSONFile != "" {
 		defer func() {
-			metrics := reviewer.Agent.GetMetrics()
-			jsonBytes, err := json.MarshalIndent(map[string]any{"metrics": metrics}, "", "  ")
+			metrics := reviewer.GetMetrics()
+			jsonBytes, err := json.MarshalIndent(metrics, "", "  ")
 			if err != nil {
 				reporter.ReportWarning("Failed to marshal metrics", err)
 				return

--- a/core/agent.go
+++ b/core/agent.go
@@ -45,10 +45,12 @@ type ToolDispatcher interface {
 // Reporter defines how the Agent reports progress and diagnostics.
 type Reporter interface {
 	ReportIteration(iter int)
+	ReportStageIteration(stage string, iter int)
 	ReportToolCalls(tcs []llm.ToolCall)
 	ReportUsage(usage llm.Usage)
 	ReportUsageSummary(usage llm.Usage)
 	ReportFinalReview()
+	ReportStageFinalReview(stage string)
 	ReportExtraction()
 	ReportExtractionRetry(attempt int)
 	ReportEmptyResponseRetry(attempt int)
@@ -64,6 +66,7 @@ type Reporter interface {
 	ReportFetchingCommits()
 	ReportNoChanges()
 	ReportReview(result string) error
+	ReportStageReview(stage, result string) error
 	ReportReviewWritten(file string)
 	ReportStructuredReviewWritten(file string)
 	ReportMetricsWritten(file string)
@@ -104,6 +107,7 @@ type Agent struct {
 	iterations int
 	stderr     io.Writer
 	history    []llm.Message
+	Stage      string
 }
 
 // NewAgent creates an Agent. Diagnostic / progress output goes to os.Stderr by
@@ -187,7 +191,11 @@ func (a *Agent) RunReview(ctx context.Context, stableSystem, dynamicSystem, requ
 
 	for iter := range maxIterations {
 		a.iterations = iter + 1
-		a.reporter.ReportIteration(a.iterations)
+		if a.Stage != "" {
+			a.reporter.ReportStageIteration(a.Stage, a.iterations)
+		} else {
+			a.reporter.ReportIteration(a.iterations)
+		}
 
 		resp, err := a.generateContentWithEmptyRetry(ctx, messages, tools, maxTokens)
 		if err != nil {
@@ -206,7 +214,11 @@ func (a *Agent) RunReview(ctx context.Context, stableSystem, dynamicSystem, requ
 			if resp.Text == "" {
 				return "", fmt.Errorf("llm returned empty content on iteration %d after %d attempts", iter+1, emptyResponseMaxAttempts)
 			}
-			a.reporter.ReportFinalReview()
+			if a.Stage != "" {
+				a.reporter.ReportStageFinalReview(a.Stage)
+			} else {
+				a.reporter.ReportFinalReview()
+			}
 			messages = append(messages, llm.Message{
 				Role: llm.RoleAssistant,
 				Text: resp.Text,
@@ -411,7 +423,11 @@ func (a *Agent) handleCapReached(ctx context.Context, messages []llm.Message, ma
 	a.reporter.ReportCapReached(maxIterations)
 
 	messages = append(messages, llm.Message{Role: llm.RoleUser, Text: capMsg})
-	a.reporter.ReportFinalReview()
+	if a.Stage != "" {
+		a.reporter.ReportStageFinalReview(a.Stage)
+	} else {
+		a.reporter.ReportFinalReview()
+	}
 
 	// Pass nil tools so the provider cannot issue further tool calls even if
 	// it ignores the cap instruction in the prompt.

--- a/core/agent.go
+++ b/core/agent.go
@@ -158,6 +158,13 @@ func (a *Agent) GetMetrics() SessionMetrics {
 	}
 }
 
+// ResetMetrics clears all collected metrics (usage, tool calls, iterations) on the Agent.
+func (a *Agent) ResetMetrics() {
+	a.totalUsage = llm.Usage{}
+	a.toolCalls = make(map[string]int)
+	a.iterations = 0
+}
+
 // RunReview executes the ReAct loop.
 // stableSystem is the stable prompt prefix (Zones 1+2); dynamicSystem is the
 // per-PR dynamic suffix (Zone 3, e.g. AGENTS.md / REVIEWERS.md content).

--- a/core/agent.go
+++ b/core/agent.go
@@ -74,6 +74,7 @@ type Reporter interface {
 	ReportError(err error)
 	NotifyUser()
 	ReportPostReviewReply(message string)
+	ReportPostReviewUserQuery(query string)
 }
 
 // AgentOption configures an Agent.

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -212,6 +212,7 @@ func (s *spyReporter) ReportWarning(msg string, err error)               {}
 func (s *spyReporter) ReportError(err error)                             {}
 func (s *spyReporter) NotifyUser()                                       { s.notifiedUser++ }
 func (s *spyReporter) ReportPostReviewReply(message string)              {}
+func (s *spyReporter) ReportPostReviewUserQuery(query string)            {}
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Tests

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -1144,6 +1144,9 @@ func TestTuiReporter(t *testing.T) {
 	var stderr bytes.Buffer
 
 	reporter := NewTuiReporter(&stdout, &stderr, func() {})
+	defer func() {
+		_ = reporter.(*tuiReporter).Close()
+	}()
 
 	cfg := &config.Config{
 		Provider: "google",
@@ -1330,5 +1333,40 @@ func TestRunChatFlight_EmptyResponseExhausted(t *testing.T) {
 
 	if lm.callIdx < emptyResponseMaxAttempts {
 		t.Errorf("expected at least %d LLM calls, got %d", emptyResponseMaxAttempts, lm.callIdx)
+	}
+}
+
+func TestAgent_StageReporting(t *testing.T) {
+	spy := &spyReporter{}
+	lm := &mockLLM{responses: []*llm.Response{
+		toolCallsResponse(makeToolCall("tc1", "read_file", map[string]any{"file_path": "foo.go"})),
+		textResponse("stage review done"),
+	}}
+	d := newMockDispatcher()
+	d.handlers["read_file"] = func(ctx context.Context, _ llm.ToolCall) (string, error) { return "ok", nil }
+
+	agent := NewAgent(lm, d, WithReporter(spy))
+	agent.Stage = "Pre-Review Summary"
+
+	got, err := agent.RunReview(context.Background(), "sys", "", "req", 5, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "stage review done" {
+		t.Errorf("got %q, want %q", got, "stage review done")
+	}
+
+	if len(spy.stageIterations) != 2 {
+		t.Fatalf("expected 2 stage iterations reported, got %d", len(spy.stageIterations))
+	}
+	if spy.stageIterations[0].stage != "Pre-Review Summary" || spy.stageIterations[0].iter != 1 {
+		t.Errorf("unexpected stage iteration 0: %+v", spy.stageIterations[0])
+	}
+	if spy.stageIterations[1].stage != "Pre-Review Summary" || spy.stageIterations[1].iter != 2 {
+		t.Errorf("unexpected stage iteration 1: %+v", spy.stageIterations[1])
+	}
+
+	if len(spy.stageFinalReviews) != 1 || spy.stageFinalReviews[0] != "Pre-Review Summary" {
+		t.Errorf("expected stage final review to be Pre-Review Summary, got %v", spy.stageFinalReviews)
 	}
 }

--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -114,9 +114,11 @@ func newTestAgent(model llm.Model, d ToolDispatcher) *Agent {
 // spyReporter records method calls for verification.
 type spyReporter struct {
 	iterations           []int
+	stageIterations      []stageIterationInfo
 	toolCalls            []llm.ToolCall
 	usage                []llm.Usage
 	finalReviews         int
+	stageFinalReviews    []string
 	extractions          int
 	extractionRetries    []int
 	emptyResponseRetries []int
@@ -126,6 +128,11 @@ type spyReporter struct {
 	toolStatuses         []toolStatus
 	reviewHeaders        []reviewHeaderInfo
 	notifiedUser         int
+}
+
+type stageIterationInfo struct {
+	stage string
+	iter  int
 }
 
 type mcpStatus struct {
@@ -150,6 +157,11 @@ func (s *spyReporter) ReportIteration(iter int) {
 	s.iterations = append(s.iterations, iter)
 }
 
+func (s *spyReporter) ReportStageIteration(stage string, iter int) {
+	s.stageIterations = append(s.stageIterations, stageIterationInfo{stage: stage, iter: iter})
+	s.ReportIteration(iter)
+}
+
 func (s *spyReporter) ReportToolCalls(tcs []llm.ToolCall) {
 	s.toolCalls = append(s.toolCalls, tcs...)
 }
@@ -159,7 +171,11 @@ func (s *spyReporter) ReportUsage(usage llm.Usage) {
 }
 func (s *spyReporter) ReportUsageSummary(_ llm.Usage) {}
 func (s *spyReporter) ReportFinalReview()             { s.finalReviews++ }
-func (s *spyReporter) ReportExtraction()              { s.extractions++ }
+func (s *spyReporter) ReportStageFinalReview(stage string) {
+	s.stageFinalReviews = append(s.stageFinalReviews, stage)
+	s.ReportFinalReview()
+}
+func (s *spyReporter) ReportExtraction() { s.extractions++ }
 func (s *spyReporter) ReportExtractionRetry(attempt int) {
 	s.extractionRetries = append(s.extractionRetries, attempt)
 }
@@ -188,6 +204,7 @@ func (s *spyReporter) ReportFetchingDiff()                               {}
 func (s *spyReporter) ReportFetchingCommits()                            {}
 func (s *spyReporter) ReportNoChanges()                                  {}
 func (s *spyReporter) ReportReview(result string) error                  { return nil }
+func (s *spyReporter) ReportStageReview(stage, result string) error      { return nil }
 func (s *spyReporter) ReportReviewWritten(file string)                   {}
 func (s *spyReporter) ReportStructuredReviewWritten(file string)         {}
 func (s *spyReporter) ReportMetricsWritten(file string)                  {}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	ExtractionModel              string         `mapstructure:"extraction-model"`
 	MetadataJSONFile             string         `mapstructure:"metadata-json"`
 	ApprovalEvaluationPromptFile string         `mapstructure:"approval-evaluation-prompt-file"`
+	PreReviewPromptFile          string         `mapstructure:"pre-review-prompt"`
+	PreReviewModel               string         `mapstructure:"pre-review-model"`
 	DiffFile                     string         `mapstructure:"diff-file"`
 	FilesListFile                string         `mapstructure:"files-list-file"`
 	CommitsFile                  string         `mapstructure:"commits-file"`

--- a/core/console_reporter.go
+++ b/core/console_reporter.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
@@ -83,10 +84,39 @@ func (mr *markdownRenderer) Render(s string, writer io.Writer) string {
 	return rendered
 }
 
+func (mr *markdownRenderer) RenderWithWidth(s string, width int) string {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+
+	if mr.r == nil || mr.width != width {
+		r, err := glamour.NewTermRenderer(
+			glamour.WithAutoStyle(),
+			glamour.WithWordWrap(width),
+		)
+		if err != nil {
+			return s
+		}
+		mr.r = r
+		mr.width = width
+	}
+
+	rendered, err := mr.r.Render(s)
+	if err != nil {
+		return s
+	}
+	rendered = strings.TrimPrefix(rendered, "\n")
+	rendered = strings.TrimSuffix(rendered, "\n")
+	return rendered
+}
+
 var mdRenderer = &markdownRenderer{}
 
 func renderMarkdown(s string, writer io.Writer) string {
 	return mdRenderer.Render(s, writer)
+}
+
+func renderMarkdownWithWidth(s string, width int) string {
+	return mdRenderer.RenderWithWidth(s, width)
 }
 
 // ConsoleFormatter abstracts formatting and styling for console output.
@@ -98,7 +128,7 @@ type ConsoleFormatter interface {
 	FormatReview(result string) string
 	StyleStderr(plain, styled string, color string, bold bool) string
 	FormatPostReviewReply(message string) string
-	FormatPostReviewUserQuery(query string) string
+	FormatPostReviewUserQuery(query string, width int) string
 }
 
 // consoleReporter formats semantic messages and delegates rendering to a consoleWriter.
@@ -133,7 +163,11 @@ func (r *consoleReporter) ReportPostReviewReply(message string) {
 }
 
 func (r *consoleReporter) ReportPostReviewUserQuery(query string) {
-	r.writer.WriteStderr(r.formatter.FormatPostReviewUserQuery(query))
+	width := 80
+	if w, _, err := term.GetSize(int(os.Stderr.Fd())); err == nil && w > 0 {
+		width = w
+	}
+	r.writer.WriteStderr(r.formatter.FormatPostReviewUserQuery(query, width))
 }
 
 func (r *consoleReporter) NotifyUser() {
@@ -397,7 +431,7 @@ func (rawFormatter) FormatPostReviewReply(message string) string {
 	return message + "\n"
 }
 
-func (rawFormatter) FormatPostReviewUserQuery(query string) string {
+func (rawFormatter) FormatPostReviewUserQuery(query string, _ int) string {
 	return fmt.Sprintf("\n💬 User:\n%s\n", query)
 }
 
@@ -499,9 +533,21 @@ func (markdownFormatter) FormatPostReviewReply(message string) string {
 	return renderMarkdown(message, os.Stderr) + "\n"
 }
 
-func (markdownFormatter) FormatPostReviewUserQuery(query string) string {
+func (markdownFormatter) FormatPostReviewUserQuery(query string, width int) string {
+	wrapWidth := width - 8
+	if wrapWidth < 40 {
+		wrapWidth = 40
+	}
+	rendered := renderMarkdownWithWidth(query, wrapWidth)
+
+	// Trim trailing spaces from each line to prevent box stretching
+	lines := strings.Split(rendered, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRightFunc(line, unicode.IsSpace)
+	}
+	content := strings.TrimSpace(strings.Join(lines, "\n"))
+
 	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("108")).Render("💬 User:")
-	content := strings.TrimSpace(renderMarkdown(query, os.Stderr))
 	boxContent := title + "\n" + content
 	styledBox := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).

--- a/core/console_reporter.go
+++ b/core/console_reporter.go
@@ -150,6 +150,15 @@ func (r *consoleReporter) ReportIteration(iter int) {
 	)
 }
 
+func (r *consoleReporter) ReportStageIteration(stage string, iter int) {
+	r.writeStyledStderr(
+		fmt.Sprintf("🔍 [%s - Iter %d] Reviewing...", stage, iter),
+		fmt.Sprintf("🔍 [%s - Iteration %d]", stage, iter),
+		"178",
+		true,
+	)
+}
+
 func (r *consoleReporter) ReportToolCalls(tcs []llm.ToolCall) {
 	formatted := r.formatter.FormatToolCalls(tcs)
 	if len(formatted) > 0 {
@@ -184,6 +193,16 @@ func (r *consoleReporter) ReportFinalReview() {
 	r.writeStyledStderr(
 		"📝 Formulating final review...",
 		"📝 Formulating final review...",
+		"178",
+		true,
+	)
+}
+
+func (r *consoleReporter) ReportStageFinalReview(stage string) {
+	msg := fmt.Sprintf("📝 Formulating final %s...", strings.ToLower(stage))
+	r.writeStyledStderr(
+		msg,
+		msg,
 		"178",
 		true,
 	)
@@ -275,6 +294,12 @@ func buildConfigTable(cfg *config.Config, targetDir string) *table.Table {
 	if cfg.ApprovalEvaluationPromptFile != "" {
 		t.Row("Approval Evaluation Prompt File", cfg.ApprovalEvaluationPromptFile)
 	}
+	if cfg.PreReviewPromptFile != "" {
+		t.Row("Pre-Review Prompt File", cfg.PreReviewPromptFile)
+	}
+	if cfg.PreReviewModel != "" {
+		t.Row("Pre-Review Model", cfg.PreReviewModel)
+	}
 	t.Row("API Key", "[PROVIDED]")
 	return t
 }
@@ -312,6 +337,17 @@ func (r *consoleReporter) ReportNoChanges() {
 
 func (r *consoleReporter) ReportReview(result string) error {
 	r.writer.WriteStdout(r.formatter.FormatReview(result))
+	return nil
+}
+
+func (r *consoleReporter) ReportStageReview(stage, result string) error {
+	var output string
+	if _, ok := r.formatter.(markdownFormatter); ok {
+		output = "\n" + renderMarkdown(fmt.Sprintf("# 📋 %s\n\n%s", stage, result), os.Stderr) + "\n\n"
+	} else {
+		output = fmt.Sprintf("\n# 📋 %s\n\n%s\n", stage, result)
+	}
+	r.writer.WriteStderr(output)
 	return nil
 }
 

--- a/core/console_reporter.go
+++ b/core/console_reporter.go
@@ -98,6 +98,7 @@ type ConsoleFormatter interface {
 	FormatReview(result string) string
 	StyleStderr(plain, styled string, color string, bold bool) string
 	FormatPostReviewReply(message string) string
+	FormatPostReviewUserQuery(query string) string
 }
 
 // consoleReporter formats semantic messages and delegates rendering to a consoleWriter.
@@ -129,6 +130,10 @@ func NewDefaultReporter(w io.Writer) Reporter {
 
 func (r *consoleReporter) ReportPostReviewReply(message string) {
 	r.writer.WriteStderr(r.formatter.FormatPostReviewReply(message))
+}
+
+func (r *consoleReporter) ReportPostReviewUserQuery(query string) {
+	r.writer.WriteStderr(r.formatter.FormatPostReviewUserQuery(query))
 }
 
 func (r *consoleReporter) NotifyUser() {
@@ -392,6 +397,10 @@ func (rawFormatter) FormatPostReviewReply(message string) string {
 	return message + "\n"
 }
 
+func (rawFormatter) FormatPostReviewUserQuery(query string) string {
+	return fmt.Sprintf("\n💬 User:\n%s\n", query)
+}
+
 func (rawFormatter) FormatReviewHeader(files int, guidelines string, model string) string {
 	return fmt.Sprintf("\n✅ Review generated successfully.\n\n\n# 📝 Review for %d files using %s (%s)\n\n", files, guidelines, model)
 }
@@ -488,6 +497,18 @@ func (markdownFormatter) StyleStderr(plain, styled string, color string, bold bo
 
 func (markdownFormatter) FormatPostReviewReply(message string) string {
 	return renderMarkdown(message, os.Stderr) + "\n"
+}
+
+func (markdownFormatter) FormatPostReviewUserQuery(query string) string {
+	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("108")).Render("💬 User:")
+	content := strings.TrimSpace(renderMarkdown(query, os.Stderr))
+	boxContent := title + "\n" + content
+	styledBox := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("108")).
+		Padding(0, 1).
+		Render(boxContent)
+	return "\n" + styledBox + "\n"
 }
 
 func (markdownFormatter) FormatReviewHeader(files int, guidelines string, model string) string {

--- a/core/console_reporter_test.go
+++ b/core/console_reporter_test.go
@@ -74,6 +74,50 @@ func TestConsoleReporter_Raw(t *testing.T) {
 		require.Contains(t, stderr.String(), "[Reviewer state] focus area: security")
 		require.Contains(t, stderr.String(), "Analyzing files")
 	})
+
+	t.Run("ReportStageIteration prints stage name", func(t *testing.T) {
+		stderr.Reset()
+		r.ReportStageIteration("Pre-Review Summary", 2)
+		require.Equal(t, "🔍 [Pre-Review Summary - Iter 2] Reviewing...\n", stderr.String())
+	})
+
+	t.Run("ReportStageFinalReview prints stage name", func(t *testing.T) {
+		stderr.Reset()
+		r.ReportStageFinalReview("Pre-Review Summary")
+		require.Equal(t, "📝 Formulating final pre-review summary...\n", stderr.String())
+	})
+
+	t.Run("ReportStageReview prints header and result", func(t *testing.T) {
+		stderr.Reset()
+		err := r.ReportStageReview("Pre-Review Summary", "Summary content")
+		require.NoError(t, err)
+		require.Contains(t, stderr.String(), "# 📋 Pre-Review Summary")
+		require.Contains(t, stderr.String(), "Summary content")
+	})
+
+	t.Run("ReportPostReviewUserQuery prints user query", func(t *testing.T) {
+		stderr.Reset()
+		r.ReportPostReviewUserQuery("How does auth work?")
+		require.Contains(t, stderr.String(), "💬 User:\nHow does auth work?")
+	})
+
+	t.Run("ReportPostReviewReply prints reply", func(t *testing.T) {
+		stderr.Reset()
+		r.ReportPostReviewReply("Auth uses JWT tokens.")
+		require.Equal(t, "Auth uses JWT tokens.\n", stderr.String())
+	})
+
+	t.Run("ReportConfig prints pre-review prompt and model", func(t *testing.T) {
+		stderr.Reset()
+		cfg := config.NewDefaultConfig()
+		cfg.PreReviewPromptFile = ".cassandra/pre-review-summary.md"
+		cfg.PreReviewModel = "gemini-2.0-flash"
+		r.ReportConfig(cfg, "/workspace")
+		require.Contains(t, stderr.String(), "Pre-Review Prompt File")
+		require.Contains(t, stderr.String(), ".cassandra/pre-review-summary.md")
+		require.Contains(t, stderr.String(), "Pre-Review Model")
+		require.Contains(t, stderr.String(), "gemini-2.0-flash")
+	})
 }
 
 func TestConsoleReporter_Markdown(t *testing.T) {
@@ -131,5 +175,37 @@ func TestConsoleReporter_Markdown(t *testing.T) {
 		})
 		require.Contains(t, stderr.String(), "Reviewer state")
 		require.Contains(t, stderr.String(), "security")
+	})
+
+	t.Run("ReportStageIteration prints styled stage text", func(t *testing.T) {
+		stderr.Reset()
+		r.ReportStageIteration("Pre-Review Summary", 2)
+		require.Contains(t, stderr.String(), "[Pre-Review Summary - Iteration 2]")
+	})
+
+	t.Run("ReportStageFinalReview prints styled stage final review text", func(t *testing.T) {
+		stderr.Reset()
+		r.ReportStageFinalReview("Pre-Review Summary")
+		require.Contains(t, stderr.String(), "Formulating final pre-review summary...")
+	})
+
+	t.Run("ReportStageReview prints styled stage review markdown", func(t *testing.T) {
+		stderr.Reset()
+		err := r.ReportStageReview("Pre-Review Summary", "Summary content")
+		require.NoError(t, err)
+		require.Contains(t, stderr.String(), "Pre-Review Summary")
+	})
+
+	t.Run("ReportPostReviewUserQuery prints styled user query box", func(t *testing.T) {
+		stderr.Reset()
+		r.ReportPostReviewUserQuery("How does auth work?")
+		require.Contains(t, stderr.String(), "User:")
+		require.Contains(t, stderr.String(), "How does auth work?")
+	})
+
+	t.Run("ReportPostReviewReply prints styled reply markdown", func(t *testing.T) {
+		stderr.Reset()
+		r.ReportPostReviewReply("Auth uses JWT tokens.")
+		require.Contains(t, stderr.String(), "Auth uses JWT tokens.")
 	})
 }

--- a/core/review_types.go
+++ b/core/review_types.go
@@ -21,6 +21,17 @@ type SessionMetrics struct {
 	ToolCalls  ToolCallMetrics `json:"tool_calls"`
 }
 
+// PhaseMetrics captures the metrics for a specific review phase.
+type PhaseMetrics struct {
+	Phase   string         `json:"phase"`
+	Metrics SessionMetrics `json:"metrics"`
+}
+
+// ReviewMetrics captures the list of phase-specific metrics.
+type ReviewMetrics struct {
+	Phases []PhaseMetrics `json:"metrics"`
+}
+
 // TokenMetrics breaks down token consumption by category.
 type TokenMetrics struct {
 	Input       int `json:"input"`

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -35,6 +35,7 @@ type Reviewer struct {
 	llmFactory               func(ctx context.Context, provider, modelName, apiKey, baseURL string, options map[string]any) (llm.Model, error)
 	PreReviewMetrics         *SessionMetrics
 	CodeReviewMetrics        SessionMetrics
+	DiscussionMetrics        *SessionMetrics
 }
 
 // NewReviewer instantiates a Reviewer based on the provided configuration.
@@ -339,6 +340,9 @@ func (r *Reviewer) RunInteractivePostReview(ctx context.Context) error {
 		}()
 	}
 
+	// Reset metrics to isolate the interactive post-review discussion phase
+	r.Agent.ResetMetrics()
+
 	// Append system instruction indicating conversational post-review phase
 	r.Agent.history = append(r.Agent.history, llm.Message{
 		Role: llm.RoleSystem,
@@ -425,6 +429,27 @@ func (r *Reviewer) RunInteractivePostReview(ctx context.Context) error {
 		}
 
 		r.Agent.reporter.ReportPostReviewReply(reply)
+
+		turnMetrics := r.Agent.GetMetrics()
+		if r.DiscussionMetrics == nil {
+			r.DiscussionMetrics = &turnMetrics
+		} else {
+			r.DiscussionMetrics.Tokens.Input += turnMetrics.Tokens.Input
+			r.DiscussionMetrics.Tokens.Output += turnMetrics.Tokens.Output
+			r.DiscussionMetrics.Tokens.Thinking += turnMetrics.Tokens.Thinking
+			r.DiscussionMetrics.Tokens.Cached += turnMetrics.Tokens.Cached
+			r.DiscussionMetrics.Tokens.TotalInput += turnMetrics.Tokens.TotalInput
+			r.DiscussionMetrics.Tokens.TotalOutput += turnMetrics.Tokens.TotalOutput
+			r.DiscussionMetrics.Iterations += turnMetrics.Iterations
+			r.DiscussionMetrics.ToolCalls.Total += turnMetrics.ToolCalls.Total
+			if r.DiscussionMetrics.ToolCalls.ByTool == nil {
+				r.DiscussionMetrics.ToolCalls.ByTool = make(map[string]int)
+			}
+			for k, v := range turnMetrics.ToolCalls.ByTool {
+				r.DiscussionMetrics.ToolCalls.ByTool[k] += v
+			}
+		}
+		r.Agent.ResetMetrics()
 	}
 }
 
@@ -441,6 +466,12 @@ func (r *Reviewer) GetMetrics() ReviewMetrics {
 		Phase:   "review",
 		Metrics: r.CodeReviewMetrics,
 	})
+	if r.DiscussionMetrics != nil {
+		phases = append(phases, PhaseMetrics{
+			Phase:   "review_discussion",
+			Metrics: *r.DiscussionMetrics,
+		})
+	}
 	return ReviewMetrics{
 		Phases: phases,
 	}

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -34,7 +34,7 @@ type Reviewer struct {
 	mcpManager               *mcp.Manager
 	llmFactory               func(ctx context.Context, provider, modelName, apiKey, baseURL string, options map[string]any) (llm.Model, error)
 	PreReviewMetrics         *SessionMetrics
-	CodeReviewMetrics        SessionMetrics
+	CodeReviewMetrics        *SessionMetrics
 	DiscussionMetrics        *SessionMetrics
 }
 
@@ -188,12 +188,11 @@ func (r *Reviewer) Run(ctx context.Context, changedFiles []string, requestText s
 		r.Agent.ResetMetrics()
 		maxIterations := CalculateMaxIterations(len(changedFiles))
 		summary, err := r.Agent.RunReview(ctx, preReviewPrompt, dynamic, requestText, maxIterations, r.Config.MaxTokens)
+		preMetrics := r.Agent.GetMetrics()
+		r.PreReviewMetrics = &preMetrics
 		if err != nil {
 			return "", fmt.Errorf("pre-review summary phase failed: %w", err)
 		}
-
-		preMetrics := r.Agent.GetMetrics()
-		r.PreReviewMetrics = &preMetrics
 
 		if err := r.Agent.reporter.ReportStageReview("Pre-Review Summary", summary); err != nil {
 			r.Agent.reporter.ReportWarning("Failed to display pre-review summary", err)
@@ -217,10 +216,11 @@ func (r *Reviewer) Run(ctx context.Context, changedFiles []string, requestText s
 	r.Agent.ResetMetrics()
 	maxIterations := CalculateMaxIterations(len(changedFiles))
 	reviewResult, err := r.Agent.RunReview(ctx, r.StablePrompt, dynamic, requestText, maxIterations, r.Config.MaxTokens)
+	reviewMetrics := r.Agent.GetMetrics()
+	r.CodeReviewMetrics = &reviewMetrics
 	if err != nil {
 		return "", err
 	}
-	r.CodeReviewMetrics = r.Agent.GetMetrics()
 	return reviewResult, nil
 }
 
@@ -426,11 +426,6 @@ func (r *Reviewer) RunInteractivePostReview(ctx context.Context) error {
 		if spinner != nil {
 			spinner.Stop()
 		}
-		if err != nil {
-			return fmt.Errorf("chat flight failed: %w", err)
-		}
-
-		r.Agent.reporter.ReportPostReviewReply(reply)
 
 		turnMetrics := r.Agent.GetMetrics()
 		if r.DiscussionMetrics == nil {
@@ -452,6 +447,12 @@ func (r *Reviewer) RunInteractivePostReview(ctx context.Context) error {
 			}
 		}
 		r.Agent.ResetMetrics()
+
+		if err != nil {
+			return fmt.Errorf("chat flight failed: %w", err)
+		}
+
+		r.Agent.reporter.ReportPostReviewReply(reply)
 	}
 }
 
@@ -464,10 +465,12 @@ func (r *Reviewer) GetMetrics() ReviewMetrics {
 			Metrics: *r.PreReviewMetrics,
 		})
 	}
-	phases = append(phases, PhaseMetrics{
-		Phase:   "review",
-		Metrics: r.CodeReviewMetrics,
-	})
+	if r.CodeReviewMetrics != nil {
+		phases = append(phases, PhaseMetrics{
+			Phase:   "review",
+			Metrics: *r.CodeReviewMetrics,
+		})
+	}
 	if r.DiscussionMetrics != nil {
 		phases = append(phases, PhaseMetrics{
 			Phase:   "review_discussion",

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -32,6 +32,7 @@ type Reviewer struct {
 	SupplementalGuidelines   []string
 	ApprovalEvaluationPrompt string
 	mcpManager               *mcp.Manager
+	llmFactory               func(ctx context.Context, provider, modelName, apiKey, baseURL string, options map[string]any) (llm.Model, error)
 }
 
 // NewReviewer instantiates a Reviewer based on the provided configuration.
@@ -138,6 +139,7 @@ func NewReviewer(ctx context.Context, cfg *config.Config, targetDir string, repo
 		SupplementalGuidelines:   supplementalGuidelines,
 		ApprovalEvaluationPrompt: approvalEvaluationPrompt,
 		mcpManager:               mcpManager,
+		llmFactory:               factory.New,
 	}, nil
 }
 
@@ -156,6 +158,55 @@ func (r *Reviewer) Run(ctx context.Context, changedFiles []string, requestText s
 		return "", fmt.Errorf("failed to build dynamic system prompt: %w", err)
 	}
 
+	if r.Config.PreReviewPromptFile != "" {
+		preReviewPromptBytes, err := os.ReadFile(r.Config.PreReviewPromptFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to read pre-review prompt file %q: %w", r.Config.PreReviewPromptFile, err)
+		}
+		preReviewPrompt := string(preReviewPromptBytes)
+
+		originalLLM := r.Agent.llm
+		if r.Config.PreReviewModel != "" && r.Config.PreReviewModel != r.Config.Model {
+			newFactory := r.llmFactory
+			if newFactory == nil {
+				newFactory = factory.New
+			}
+			preLLM, err := newFactory(ctx, r.Config.Provider, r.Config.PreReviewModel, r.Config.ProviderAPIKey, r.Config.ProviderURL, r.Config.ProviderOptions)
+			if err != nil {
+				return "", fmt.Errorf("failed to initialize pre-review LLM: %w", err)
+			}
+			r.Agent.llm = preLLM
+		}
+		defer func() {
+			r.Agent.llm = originalLLM
+		}()
+
+		r.Agent.Stage = "Pre-Review Summary"
+		maxIterations := CalculateMaxIterations(len(changedFiles))
+		summary, err := r.Agent.RunReview(ctx, preReviewPrompt, dynamic, requestText, maxIterations, r.Config.MaxTokens)
+		if err != nil {
+			return "", fmt.Errorf("pre-review summary phase failed: %w", err)
+		}
+
+		if err := r.Agent.reporter.ReportStageReview("Pre-Review Summary", summary); err != nil {
+			r.Agent.reporter.ReportWarning("Failed to display pre-review summary", err)
+		}
+
+		r.Agent.llm = originalLLM
+
+		var sb strings.Builder
+		sb.WriteString("### Pre-Review Summary\n")
+		sb.WriteString(summary)
+		sb.WriteString("\n\n")
+		sb.WriteString(requestText)
+		requestText = sb.String()
+	}
+
+	if r.Config.PreReviewPromptFile != "" {
+		r.Agent.Stage = "AI Code Review"
+	} else {
+		r.Agent.Stage = ""
+	}
 	maxIterations := CalculateMaxIterations(len(changedFiles))
 	return r.Agent.RunReview(ctx, r.StablePrompt, dynamic, requestText, maxIterations, r.Config.MaxTokens)
 }

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -33,6 +33,8 @@ type Reviewer struct {
 	ApprovalEvaluationPrompt string
 	mcpManager               *mcp.Manager
 	llmFactory               func(ctx context.Context, provider, modelName, apiKey, baseURL string, options map[string]any) (llm.Model, error)
+	PreReviewMetrics         *SessionMetrics
+	CodeReviewMetrics        SessionMetrics
 }
 
 // NewReviewer instantiates a Reviewer based on the provided configuration.
@@ -182,11 +184,15 @@ func (r *Reviewer) Run(ctx context.Context, changedFiles []string, requestText s
 		}()
 
 		r.Agent.Stage = "Pre-Review Summary"
+		r.Agent.ResetMetrics()
 		maxIterations := CalculateMaxIterations(len(changedFiles))
 		summary, err := r.Agent.RunReview(ctx, preReviewPrompt, dynamic, requestText, maxIterations, r.Config.MaxTokens)
 		if err != nil {
 			return "", fmt.Errorf("pre-review summary phase failed: %w", err)
 		}
+
+		preMetrics := r.Agent.GetMetrics()
+		r.PreReviewMetrics = &preMetrics
 
 		if err := r.Agent.reporter.ReportStageReview("Pre-Review Summary", summary); err != nil {
 			r.Agent.reporter.ReportWarning("Failed to display pre-review summary", err)
@@ -207,8 +213,14 @@ func (r *Reviewer) Run(ctx context.Context, changedFiles []string, requestText s
 	} else {
 		r.Agent.Stage = ""
 	}
+	r.Agent.ResetMetrics()
 	maxIterations := CalculateMaxIterations(len(changedFiles))
-	return r.Agent.RunReview(ctx, r.StablePrompt, dynamic, requestText, maxIterations, r.Config.MaxTokens)
+	reviewResult, err := r.Agent.RunReview(ctx, r.StablePrompt, dynamic, requestText, maxIterations, r.Config.MaxTokens)
+	if err != nil {
+		return "", err
+	}
+	r.CodeReviewMetrics = r.Agent.GetMetrics()
+	return reviewResult, nil
 }
 
 const postReviewSystemInstruction = "You have completed the automated code review. " +
@@ -413,5 +425,23 @@ func (r *Reviewer) RunInteractivePostReview(ctx context.Context) error {
 		}
 
 		r.Agent.reporter.ReportPostReviewReply(reply)
+	}
+}
+
+// GetMetrics returns the captured metrics for both phases.
+func (r *Reviewer) GetMetrics() ReviewMetrics {
+	var phases []PhaseMetrics
+	if r.PreReviewMetrics != nil {
+		phases = append(phases, PhaseMetrics{
+			Phase:   "pre_review",
+			Metrics: *r.PreReviewMetrics,
+		})
+	}
+	phases = append(phases, PhaseMetrics{
+		Phase:   "review",
+		Metrics: r.CodeReviewMetrics,
+	})
+	return ReviewMetrics{
+		Phases: phases,
 	}
 }

--- a/core/reviewer.go
+++ b/core/reviewer.go
@@ -414,6 +414,8 @@ func (r *Reviewer) RunInteractivePostReview(ctx context.Context) error {
 			continue
 		}
 
+		r.Agent.reporter.ReportPostReviewUserQuery(cleanInput)
+
 		var spinner *terminalSpinner
 		if r.Config.Render == "tui" {
 			spinner = newTerminalSpinner(errWriter)

--- a/core/reviewer_test.go
+++ b/core/reviewer_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -174,4 +176,128 @@ func TestReviewer_RunInteractivePostReview_Cancellation(t *testing.T) {
 	err := reviewer.RunInteractivePostReview(ctx)
 	// Context cancellation should break the loop cleanly returning nil error
 	require.NoError(t, err)
+}
+
+func TestReviewer_Run_PreReviewSummary(t *testing.T) {
+	tmpDir := t.TempDir()
+	preReviewPromptFile := filepath.Join(tmpDir, "pre-review-prompt.md")
+	preReviewPromptContent := "Pre-review prompt content here."
+	err := os.WriteFile(preReviewPromptFile, []byte(preReviewPromptContent), 0o644)
+	require.NoError(t, err)
+
+	cfg := config.NewDefaultConfig()
+	cfg.PreReviewPromptFile = preReviewPromptFile
+
+	lm := &mockLLM{
+		responses: []*llm.Response{
+			textResponse("This is the generated pre-review summary report."),
+			textResponse("This is the final AI code review."),
+		},
+	}
+	dispatcher := newMockDispatcher()
+	spy := &spyReporter{}
+
+	reviewer := &Reviewer{
+		Agent:                    NewAgent(lm, dispatcher, WithReporter(spy)),
+		Config:                   cfg,
+		StablePrompt:             "stable system review instructions",
+		Guidelines:               "general rules",
+		RootDir:                  tmpDir,
+		ApprovalEvaluationPrompt: "approval rules",
+	}
+
+	result, err := reviewer.Run(context.Background(), []string{"file1.go"}, "original request text")
+	require.NoError(t, err)
+	require.Equal(t, "This is the final AI code review.", result)
+
+	// Verify that the LLM was called exactly twice
+	require.Equal(t, 2, len(lm.calls))
+
+	// Verify the first call (Pre-Review Summary phase)
+	firstCallMsgs := lm.calls[0]
+	// The first message is the stable pre-review prompt (Zone 1)
+	require.Equal(t, llm.RoleSystem, firstCallMsgs[0].Role)
+	require.Equal(t, preReviewPromptContent, firstCallMsgs[0].Text)
+	// The user request was passed as input to the pre-review phase
+	require.Equal(t, llm.RoleUser, firstCallMsgs[len(firstCallMsgs)-1].Role)
+	require.Equal(t, "original request text", firstCallMsgs[len(firstCallMsgs)-1].Text)
+
+	// Verify the second call (AI Code Review phase)
+	secondCallMsgs := lm.calls[1]
+	// The user request in the second phase should contain the pre-review summary prepended
+	lastMsg := secondCallMsgs[len(secondCallMsgs)-1]
+	require.Equal(t, llm.RoleUser, lastMsg.Role)
+	require.Contains(t, lastMsg.Text, "### Pre-Review Summary")
+	require.Contains(t, lastMsg.Text, "This is the generated pre-review summary report.")
+	require.Contains(t, lastMsg.Text, "original request text")
+
+	// Verify that stage transitions were reported correctly
+	require.Equal(t, 2, len(spy.stageIterations))
+	require.Equal(t, "Pre-Review Summary", spy.stageIterations[0].stage)
+	require.Equal(t, 1, spy.stageIterations[0].iter)
+	require.Equal(t, "AI Code Review", spy.stageIterations[1].stage)
+	require.Equal(t, 1, spy.stageIterations[1].iter)
+
+	require.Equal(t, 2, len(spy.stageFinalReviews))
+	require.Equal(t, "Pre-Review Summary", spy.stageFinalReviews[0])
+	require.Equal(t, "AI Code Review", spy.stageFinalReviews[1])
+}
+
+func TestReviewer_Run_PreReviewModelOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	preReviewPromptFile := filepath.Join(tmpDir, "pre-review-prompt.md")
+	preReviewPromptContent := "Pre-review prompt."
+	err := os.WriteFile(preReviewPromptFile, []byte(preReviewPromptContent), 0o644)
+	require.NoError(t, err)
+
+	cfg := config.NewDefaultConfig()
+	cfg.PreReviewPromptFile = preReviewPromptFile
+	cfg.Model = "main-model"
+	cfg.PreReviewModel = "pre-review-model-override"
+	cfg.Provider = "google"
+
+	lm := &mockLLM{
+		responses: []*llm.Response{
+			textResponse("This is the final AI code review."),
+		},
+	}
+	preLLM := &mockLLM{
+		responses: []*llm.Response{
+			textResponse("This is the generated pre-review summary report from overridden model."),
+		},
+	}
+
+	dispatcher := newMockDispatcher()
+	spy := &spyReporter{}
+
+	reviewer := &Reviewer{
+		Agent:                    NewAgent(lm, dispatcher, WithReporter(spy)),
+		Config:                   cfg,
+		StablePrompt:             "stable system review instructions",
+		Guidelines:               "general rules",
+		RootDir:                  tmpDir,
+		ApprovalEvaluationPrompt: "approval rules",
+	}
+
+	// Setup custom factory to return preLLM when pre-review-model-override is requested
+	var preReviewModelUsed bool
+	reviewer.llmFactory = func(ctx context.Context, provider, modelName, apiKey, baseURL string, options map[string]any) (llm.Model, error) {
+		if modelName == "pre-review-model-override" {
+			preReviewModelUsed = true
+			return preLLM, nil
+		}
+		return lm, nil
+	}
+
+	result, err := reviewer.Run(context.Background(), []string{"file1.go"}, "original request text")
+	require.NoError(t, err)
+	require.Equal(t, "This is the final AI code review.", result)
+
+	// Verify that the custom model was indeed constructed and used
+	require.True(t, preReviewModelUsed, "The pre-review model override should have been constructed")
+	require.Equal(t, 1, len(preLLM.calls))
+	require.Equal(t, 1, len(lm.calls))
+
+	// Verify the request to the main model contains the pre-review summary from the override model
+	require.Contains(t, lm.calls[0][len(lm.calls[0])-1].Text, "This is the generated pre-review summary report from overridden model.")
 }

--- a/core/reviewer_test.go
+++ b/core/reviewer_test.go
@@ -84,7 +84,13 @@ func TestReviewer_RunInteractivePostReview_ChatFlight(t *testing.T) {
 
 	lm := &mockLLM{
 		responses: []*llm.Response{
-			textResponse("Cassandra answer to query 1"),
+			{
+				Text: "Cassandra answer to query 1",
+				Usage: llm.Usage{
+					PromptTokens: 300,
+					OutputTokens: 400,
+				},
+			},
 		},
 	}
 	dispatcher := newMockDispatcher()
@@ -145,6 +151,16 @@ func TestReviewer_RunInteractivePostReview_ChatFlight(t *testing.T) {
 	}
 	require.True(t, historyUserSeen, "User query must be appended to history")
 	require.True(t, historyAssistantSeen, "Cassandra answer must be appended to history")
+
+	// Verify that discussion metrics were tracked correctly
+	metrics := reviewer.GetMetrics()
+	require.Equal(t, 2, len(metrics.Phases)) // code review + discussion
+
+	require.Equal(t, "review", metrics.Phases[0].Phase)
+	require.Equal(t, "review_discussion", metrics.Phases[1].Phase)
+	require.Equal(t, 300, metrics.Phases[1].Metrics.Tokens.Input)
+	require.Equal(t, 400, metrics.Phases[1].Metrics.Tokens.Output)
+	require.Equal(t, 1, metrics.Phases[1].Metrics.Iterations)
 }
 
 func TestReviewer_RunInteractivePostReview_Cancellation(t *testing.T) {

--- a/core/reviewer_test.go
+++ b/core/reviewer_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -154,13 +155,12 @@ func TestReviewer_RunInteractivePostReview_ChatFlight(t *testing.T) {
 
 	// Verify that discussion metrics were tracked correctly
 	metrics := reviewer.GetMetrics()
-	require.Equal(t, 2, len(metrics.Phases)) // code review + discussion
+	require.Equal(t, 1, len(metrics.Phases))
 
-	require.Equal(t, "review", metrics.Phases[0].Phase)
-	require.Equal(t, "review_discussion", metrics.Phases[1].Phase)
-	require.Equal(t, 300, metrics.Phases[1].Metrics.Tokens.Input)
-	require.Equal(t, 400, metrics.Phases[1].Metrics.Tokens.Output)
-	require.Equal(t, 1, metrics.Phases[1].Metrics.Iterations)
+	require.Equal(t, "review_discussion", metrics.Phases[0].Phase)
+	require.Equal(t, 300, metrics.Phases[0].Metrics.Tokens.Input)
+	require.Equal(t, 400, metrics.Phases[0].Metrics.Tokens.Output)
+	require.Equal(t, 1, metrics.Phases[0].Metrics.Iterations)
 }
 
 func TestReviewer_RunInteractivePostReview_Cancellation(t *testing.T) {
@@ -342,4 +342,142 @@ func TestReviewer_Run_PreReviewModelOverride(t *testing.T) {
 
 	// Verify the request to the main model contains the pre-review summary from the override model
 	require.Contains(t, lm.calls[0][len(lm.calls[0])-1].Text, "This is the generated pre-review summary report from overridden model.")
+}
+
+func TestReviewer_MetricsPreservedOnError(t *testing.T) {
+	t.Run("PreReviewError", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		preReviewPromptFile := filepath.Join(tmpDir, "pre-review-prompt.md")
+		err := os.WriteFile(preReviewPromptFile, []byte("Pre-review prompt."), 0o644)
+		require.NoError(t, err)
+
+		cfg := config.NewDefaultConfig()
+		cfg.PreReviewPromptFile = preReviewPromptFile
+		cfg.Provider = "google"
+
+		lm := &mockLLM{
+			responses: []*llm.Response{
+				{
+					Text: "Pre-review response requesting tool",
+					ToolCalls: []llm.ToolCall{
+						{
+							ID:        "call1",
+							Name:      "read_file",
+							Arguments: `{"file_path":"file1.go"}`,
+						},
+					},
+					Usage: llm.Usage{
+						PromptTokens: 50,
+						OutputTokens: 100,
+					},
+				},
+			},
+		}
+
+		reviewer := &Reviewer{
+			Agent:                    NewAgent(lm, newMockDispatcher(), WithReporter(&spyReporter{})),
+			Config:                   cfg,
+			StablePrompt:             "stable system review instructions",
+			Guidelines:               "general rules",
+			RootDir:                  tmpDir,
+			ApprovalEvaluationPrompt: "approval rules",
+		}
+
+		// Run with short context / constraints so it fails, or it will fail because the mock has no more responses
+		_, err = reviewer.Run(context.Background(), []string{"file1.go"}, "original request text")
+		require.Error(t, err)
+
+		metrics := reviewer.GetMetrics()
+		require.Equal(t, 1, len(metrics.Phases))
+		require.Equal(t, "pre_review", metrics.Phases[0].Phase)
+		require.Equal(t, 50, metrics.Phases[0].Metrics.Tokens.Input)
+		require.Equal(t, 100, metrics.Phases[0].Metrics.Tokens.Output)
+	})
+
+	t.Run("CodeReviewError", func(t *testing.T) {
+		cfg := config.NewDefaultConfig()
+		cfg.Provider = "google"
+
+		lm := &mockLLM{
+			responses: []*llm.Response{
+				{
+					Text: "Review response requesting tool",
+					ToolCalls: []llm.ToolCall{
+						{
+							ID:        "call1",
+							Name:      "read_file",
+							Arguments: `{"file_path":"file1.go"}`,
+						},
+					},
+					Usage: llm.Usage{
+						PromptTokens: 500,
+						OutputTokens: 1000,
+					},
+				},
+			},
+		}
+
+		reviewer := &Reviewer{
+			Agent:                    NewAgent(lm, newMockDispatcher(), WithReporter(&spyReporter{})),
+			Config:                   cfg,
+			StablePrompt:             "stable system review instructions",
+			Guidelines:               "general rules",
+			RootDir:                  t.TempDir(),
+			ApprovalEvaluationPrompt: "approval rules",
+		}
+
+		_, err := reviewer.Run(context.Background(), []string{"file1.go"}, "original request text")
+		require.Error(t, err)
+
+		metrics := reviewer.GetMetrics()
+		require.Equal(t, 1, len(metrics.Phases))
+		require.Equal(t, "review", metrics.Phases[0].Phase)
+		require.Equal(t, 500, metrics.Phases[0].Metrics.Tokens.Input)
+		require.Equal(t, 1000, metrics.Phases[0].Metrics.Tokens.Output)
+	})
+
+	t.Run("ChatFlightError", func(t *testing.T) {
+		cfg := config.NewDefaultConfig()
+		cfg.Render = "markdown"
+
+		lm := &mockLLM{
+			responses: []*llm.Response{
+				{
+					Text: "Chat response requesting tool",
+					ToolCalls: []llm.ToolCall{
+						{
+							ID:        "call1",
+							Name:      "read_file",
+							Arguments: `{"file_path":"file1.go"}`,
+						},
+					},
+					Usage: llm.Usage{
+						PromptTokens: 20,
+						OutputTokens: 30,
+					},
+				},
+			},
+		}
+
+		reviewer := &Reviewer{
+			Agent:                    NewAgent(lm, newMockDispatcher(), WithReporter(&spyReporter{})),
+			Config:                   cfg,
+			StablePrompt:             "stable system review instructions",
+			Guidelines:               "general rules",
+			RootDir:                  t.TempDir(),
+			ApprovalEvaluationPrompt: "approval rules",
+		}
+
+		ctx := context.WithValue(context.Background(), replStdinKey{}, strings.NewReader("query 1\n"))
+		ctx = context.WithValue(ctx, replStderrKey{}, io.Discard)
+
+		err := reviewer.RunInteractivePostReview(ctx)
+		require.Error(t, err)
+
+		metrics := reviewer.GetMetrics()
+		require.Equal(t, 1, len(metrics.Phases))
+		require.Equal(t, "review_discussion", metrics.Phases[0].Phase)
+		require.Equal(t, 20, metrics.Phases[0].Metrics.Tokens.Input)
+		require.Equal(t, 30, metrics.Phases[0].Metrics.Tokens.Output)
+	})
 }

--- a/core/reviewer_test.go
+++ b/core/reviewer_test.go
@@ -190,8 +190,20 @@ func TestReviewer_Run_PreReviewSummary(t *testing.T) {
 
 	lm := &mockLLM{
 		responses: []*llm.Response{
-			textResponse("This is the generated pre-review summary report."),
-			textResponse("This is the final AI code review."),
+			{
+				Text: "This is the generated pre-review summary report.",
+				Usage: llm.Usage{
+					PromptTokens: 100,
+					OutputTokens: 200,
+				},
+			},
+			{
+				Text: "This is the final AI code review.",
+				Usage: llm.Usage{
+					PromptTokens: 1000,
+					OutputTokens: 2000,
+				},
+			},
 		},
 	}
 	dispatcher := newMockDispatcher()
@@ -241,6 +253,20 @@ func TestReviewer_Run_PreReviewSummary(t *testing.T) {
 	require.Equal(t, 2, len(spy.stageFinalReviews))
 	require.Equal(t, "Pre-Review Summary", spy.stageFinalReviews[0])
 	require.Equal(t, "AI Code Review", spy.stageFinalReviews[1])
+
+	// Verify that metrics were collected for both phases independently
+	metrics := reviewer.GetMetrics()
+	require.Equal(t, 2, len(metrics.Phases))
+
+	require.Equal(t, "pre_review", metrics.Phases[0].Phase)
+	require.Equal(t, 100, metrics.Phases[0].Metrics.Tokens.Input)
+	require.Equal(t, 200, metrics.Phases[0].Metrics.Tokens.Output)
+	require.Equal(t, 1, metrics.Phases[0].Metrics.Iterations)
+
+	require.Equal(t, "review", metrics.Phases[1].Phase)
+	require.Equal(t, 1000, metrics.Phases[1].Metrics.Tokens.Input)
+	require.Equal(t, 2000, metrics.Phases[1].Metrics.Tokens.Output)
+	require.Equal(t, 1, metrics.Phases[1].Metrics.Iterations)
 }
 
 func TestReviewer_Run_PreReviewModelOverride(t *testing.T) {

--- a/core/reviewer_test.go
+++ b/core/reviewer_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -479,5 +480,107 @@ func TestReviewer_MetricsPreservedOnError(t *testing.T) {
 		require.Equal(t, "review_discussion", metrics.Phases[0].Phase)
 		require.Equal(t, 20, metrics.Phases[0].Metrics.Tokens.Input)
 		require.Equal(t, 30, metrics.Phases[0].Metrics.Tokens.Output)
+	})
+}
+
+func TestReviewer_RunInteractivePostReview_MultiTurnMetrics(t *testing.T) {
+	cfg := config.NewDefaultConfig()
+	cfg.Render = "markdown"
+
+	lm := &mockLLM{
+		responses: []*llm.Response{
+			{
+				Text: "Reply 1",
+				Usage: llm.Usage{
+					PromptTokens: 100,
+					OutputTokens: 50,
+				},
+			},
+			{
+				Text: "Reply 2",
+				Usage: llm.Usage{
+					PromptTokens: 150,
+					OutputTokens: 80,
+				},
+			},
+		},
+	}
+
+	reviewer := &Reviewer{
+		Agent:                    NewAgent(lm, newMockDispatcher(), WithReporter(&spyReporter{})),
+		Config:                   cfg,
+		StablePrompt:             "stable system review instructions",
+		Guidelines:               "general rules",
+		RootDir:                  t.TempDir(),
+		ApprovalEvaluationPrompt: "approval rules",
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		_, _ = pw.Write([]byte("query 1\n"))
+		time.Sleep(20 * time.Millisecond)
+		_, _ = pw.Write([]byte("query 2\n"))
+		time.Sleep(20 * time.Millisecond)
+		_, _ = pw.Write([]byte("exit\n"))
+		_ = pw.Close()
+	}()
+
+	ctx := context.WithValue(context.Background(), replStdinKey{}, pr)
+	ctx = context.WithValue(ctx, replStderrKey{}, io.Discard)
+
+	err := reviewer.RunInteractivePostReview(ctx)
+	require.NoError(t, err)
+
+	metrics := reviewer.GetMetrics()
+	require.Equal(t, 1, len(metrics.Phases))
+	require.Equal(t, "review_discussion", metrics.Phases[0].Phase)
+	require.Equal(t, 250, metrics.Phases[0].Metrics.Tokens.Input)
+	require.Equal(t, 130, metrics.Phases[0].Metrics.Tokens.Output)
+	require.Equal(t, 2, metrics.Phases[0].Metrics.Iterations)
+}
+
+func TestReviewer_Run_PreReviewErrors(t *testing.T) {
+	t.Run("PromptFileReadError", func(t *testing.T) {
+		cfg := config.NewDefaultConfig()
+		cfg.PreReviewPromptFile = "/nonexistent/path/to/prompt.md"
+
+		reviewer := &Reviewer{
+			Agent:      NewAgent(&mockLLM{}, newMockDispatcher(), WithReporter(&spyReporter{})),
+			Config:     cfg,
+			Guidelines: "general guidelines",
+			RootDir:    t.TempDir(),
+		}
+
+		_, err := reviewer.Run(context.Background(), []string{"file1.go"}, "req")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to read pre-review prompt file")
+	})
+
+	t.Run("PreReviewLLMFactoryError", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		promptFile := filepath.Join(tmpDir, "prompt.md")
+		err := os.WriteFile(promptFile, []byte("Pre-review prompt"), 0o644)
+		require.NoError(t, err)
+
+		cfg := config.NewDefaultConfig()
+		cfg.PreReviewPromptFile = promptFile
+		cfg.PreReviewModel = "model-override"
+		cfg.Model = "model-main"
+
+		originalLM := &mockLLM{}
+		reviewer := &Reviewer{
+			Agent:      NewAgent(originalLM, newMockDispatcher(), WithReporter(&spyReporter{})),
+			Config:     cfg,
+			Guidelines: "general guidelines",
+			RootDir:    tmpDir,
+			llmFactory: func(ctx context.Context, provider, modelName, apiKey, baseURL string, options map[string]any) (llm.Model, error) {
+				return nil, errors.New("factory init failure")
+			},
+		}
+
+		_, err = reviewer.Run(context.Background(), []string{"file1.go"}, "req")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to initialize pre-review LLM")
+		require.Equal(t, originalLM, reviewer.Agent.llm)
 	})
 }

--- a/core/tui.go
+++ b/core/tui.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -16,6 +17,7 @@ import (
 	"github.com/charmbracelet/lipgloss/table"
 	"github.com/menny/cassandra/core/config"
 	"github.com/menny/cassandra/llm"
+	"golang.org/x/term"
 )
 
 // TUI message types
@@ -500,8 +502,26 @@ func (r *tuiReporter) ReportPostReviewReply(message string) {
 }
 
 func (r *tuiReporter) ReportPostReviewUserQuery(query string) {
+	width := 80
+	if f, ok := r.stderr.(*os.File); ok {
+		if w, _, err := term.GetSize(int(f.Fd())); err == nil && w > 0 {
+			width = w
+		}
+	}
+	wrapWidth := width - 8
+	if wrapWidth < 40 {
+		wrapWidth = 40
+	}
+	rendered := renderMarkdownWithWidth(query, wrapWidth)
+
+	// Trim trailing spaces from each line to prevent box stretching
+	lines := strings.Split(rendered, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRightFunc(line, unicode.IsSpace)
+	}
+	content := strings.TrimSpace(strings.Join(lines, "\n"))
+
 	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("108")).Render("💬 User:")
-	content := strings.TrimSpace(renderMarkdown(query, r.stderr))
 	boxContent := title + "\n" + content
 	styledBox := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).

--- a/core/tui.go
+++ b/core/tui.go
@@ -448,7 +448,7 @@ func NewTuiReporter(stdout, stderr io.Writer, cancel context.CancelFunc) Reporte
 
 // startLocked starts the Bubble Tea program loop.
 func (r *tuiReporter) startLocked() {
-	p := tea.NewProgram(r.model, tea.WithOutput(r.stderr))
+	p := tea.NewProgram(r.model, tea.WithOutput(r.stderr), tea.WithInput(strings.NewReader("")))
 	r.program = p
 	go func() {
 		if _, err := p.Run(); err != nil {

--- a/core/tui.go
+++ b/core/tui.go
@@ -499,6 +499,18 @@ func (r *tuiReporter) ReportPostReviewReply(message string) {
 	fmt.Fprint(r.stderr, renderMarkdown(message, r.stderr)+"\n")
 }
 
+func (r *tuiReporter) ReportPostReviewUserQuery(query string) {
+	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("108")).Render("💬 User:")
+	content := strings.TrimSpace(renderMarkdown(query, r.stderr))
+	boxContent := title + "\n" + content
+	styledBox := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("108")).
+		Padding(0, 1).
+		Render(boxContent)
+	fmt.Fprint(r.stderr, "\n"+styledBox+"\n")
+}
+
 func (r *tuiReporter) ReportConfig(cfg *config.Config, targetDir string) {
 	t := buildConfigTable(cfg, targetDir)
 

--- a/core/tui.go
+++ b/core/tui.go
@@ -36,7 +36,8 @@ type toolCallsMsg struct {
 }
 
 type iterationMsg struct {
-	iter int
+	iter  int
+	stage string
 }
 
 type llmStatusMsg struct {
@@ -49,6 +50,10 @@ type warningMsg struct {
 }
 
 type quitMsg struct{}
+
+type preReviewSummaryMsg struct {
+	summary string
+}
 
 // TUI state representation
 type mcpServerState struct {
@@ -72,6 +77,7 @@ type reviewerState struct {
 
 type iterationState struct {
 	iter          int
+	stage         string
 	llmStatus     string
 	llmWaiting    bool
 	reviewerState *reviewerState
@@ -79,16 +85,17 @@ type iterationState struct {
 }
 
 type tuiModel struct {
-	mcpServers  map[string]*mcpServerState
-	mcpList     []string
-	iterations  []*iterationState
-	warnings    []string
-	quitting    bool
-	spinner     spinner.Model
-	viewport    viewport.Model
-	ready       bool
-	configText  string
-	userAborted bool
+	mcpServers       map[string]*mcpServerState
+	mcpList          []string
+	iterations       []*iterationState
+	warnings         []string
+	quitting         bool
+	spinner          spinner.Model
+	viewport         viewport.Model
+	ready            bool
+	configText       string
+	userAborted      bool
+	preReviewSummary string
 }
 
 func (m *tuiModel) Init() tea.Cmd {
@@ -211,6 +218,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case iterationMsg:
 		m.iterations = append(m.iterations, &iterationState{
 			iter:       msg.iter,
+			stage:      msg.stage,
 			llmStatus:  "Waiting for LLM reply...",
 			llmWaiting: true,
 		})
@@ -226,6 +234,10 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case warningMsg:
 		m.warnings = append(m.warnings, msg.warning)
+		autoScroll = true
+
+	case preReviewSummaryMsg:
+		m.preReviewSummary = msg.summary
 		autoScroll = true
 
 	case quitMsg:
@@ -295,8 +307,19 @@ func (m *tuiModel) renderContent() string {
 	}
 
 	// Section 2: LLM Loop Progress (Iteration Blocks)
+	var renderedSummary bool
 	for _, it := range m.iterations {
-		sb.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("178")).Render(fmt.Sprintf("🔍 [Iteration %d]", it.iter)) + "\n")
+		if it.stage == "AI Code Review" && !renderedSummary && m.preReviewSummary != "" {
+			sb.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("108")).Render("📋 Pre-Review Summary:") + "\n")
+			sb.WriteString(indentText(renderMarkdown(m.preReviewSummary, os.Stderr), 2) + "\n\n")
+			renderedSummary = true
+		}
+
+		label := fmt.Sprintf("🔍 [Iteration %d]", it.iter)
+		if it.stage != "" {
+			label = fmt.Sprintf("🔍 [%s - Iteration %d]", it.stage, it.iter)
+		}
+		sb.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("178")).Render(label) + "\n")
 
 		if it.llmWaiting {
 			sb.WriteString(fmt.Sprintf("  %s %s\n", m.spinner.View(), it.llmStatus))
@@ -359,6 +382,11 @@ func (m *tuiModel) renderContent() string {
 			}
 			sb.WriteString("\n")
 		}
+	}
+
+	if !renderedSummary && m.preReviewSummary != "" {
+		sb.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("108")).Render("📋 Pre-Review Summary:") + "\n")
+		sb.WriteString(indentText(renderMarkdown(m.preReviewSummary, os.Stderr), 2) + "\n\n")
 	}
 
 	// Section 3: Warnings
@@ -543,6 +571,10 @@ func (r *tuiReporter) ReportIteration(iter int) {
 	r.send(iterationMsg{iter: iter})
 }
 
+func (r *tuiReporter) ReportStageIteration(stage string, iter int) {
+	r.send(iterationMsg{iter: iter, stage: stage})
+}
+
 func (r *tuiReporter) ReportToolCalls(tcs []llm.ToolCall) {
 	r.send(toolCallsMsg{tcs: tcs})
 	r.send(llmStatusMsg{status: "Executing tool calls...", llmWaiting: false})
@@ -560,6 +592,10 @@ func (r *tuiReporter) ReportUsageSummary(total llm.Usage) {
 
 func (r *tuiReporter) ReportFinalReview() {
 	r.send(llmStatusMsg{status: "Formulating final review...", llmWaiting: true})
+}
+
+func (r *tuiReporter) ReportStageFinalReview(stage string) {
+	r.send(llmStatusMsg{status: fmt.Sprintf("Formulating final %s...", strings.ToLower(stage)), llmWaiting: true})
 }
 
 func (r *tuiReporter) ReportExtraction() {
@@ -605,6 +641,11 @@ func (r *tuiReporter) ReportReview(result string) error {
 	return nil
 }
 
+func (r *tuiReporter) ReportStageReview(stage, result string) error {
+	r.send(preReviewSummaryMsg{summary: result})
+	return nil
+}
+
 func (r *tuiReporter) ReportReviewWritten(file string) {
 	fmt.Fprintf(r.stderr, "📝 Review written to %s\n", file)
 }
@@ -642,4 +683,15 @@ func (r *tuiReporter) ReportError(err error) {
 
 func (r *tuiReporter) NotifyUser() {
 	fmt.Fprint(r.stderr, "\a")
+}
+
+func indentText(text string, indent int) string {
+	prefix := strings.Repeat(" ", indent)
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = prefix + line
+		}
+	}
+	return strings.Join(lines, "\n")
 }

--- a/core/tui_test.go
+++ b/core/tui_test.go
@@ -1,0 +1,88 @@
+package core
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTUIReporter_PostReviewMethods(t *testing.T) {
+	var stderr bytes.Buffer
+	r := NewTuiReporter(&stderr, &stderr, nil)
+
+	t.Run("ReportPostReviewUserQuery formats user query box", func(t *testing.T) {
+		stderr.Reset()
+		r.ReportPostReviewUserQuery("How does auth work?")
+		require.Contains(t, stderr.String(), "User:")
+		require.Contains(t, stderr.String(), "How does auth work?")
+	})
+
+	t.Run("ReportPostReviewReply renders reply markdown", func(t *testing.T) {
+		stderr.Reset()
+		r.ReportPostReviewReply("Auth uses JWT.")
+		require.Contains(t, stderr.String(), "Auth uses JWT.")
+	})
+}
+
+func TestTUIModel_Update_StageMessages(t *testing.T) {
+	t.Run("iterationMsg with stage updates model iterations", func(t *testing.T) {
+		m := &tuiModel{
+			mcpServers: make(map[string]*mcpServerState),
+		}
+
+		updatedModel, _ := m.Update(iterationMsg{iter: 1, stage: "Pre-Review Summary"})
+		tm := updatedModel.(*tuiModel)
+		require.Equal(t, 1, len(tm.iterations))
+		require.Equal(t, 1, tm.iterations[0].iter)
+		require.Equal(t, "Pre-Review Summary", tm.iterations[0].stage)
+	})
+
+	t.Run("preReviewSummaryMsg updates preReviewSummary state", func(t *testing.T) {
+		m := &tuiModel{
+			mcpServers: make(map[string]*mcpServerState),
+		}
+
+		updatedModel, _ := m.Update(preReviewSummaryMsg{summary: "Pre-review findings"})
+		tm := updatedModel.(*tuiModel)
+		require.Equal(t, "Pre-review findings", tm.preReviewSummary)
+	})
+}
+
+func TestTUIModel_RenderContent_PreReviewSummary(t *testing.T) {
+	t.Run("renders summary before AI Code Review stage iteration", func(t *testing.T) {
+		m := &tuiModel{
+			preReviewSummary: "This PR adds JWT auth.",
+			iterations: []*iterationState{
+				{iter: 1, stage: "Pre-Review Summary", llmStatus: "Done"},
+				{iter: 1, stage: "AI Code Review", llmStatus: "Waiting for LLM reply..."},
+			},
+		}
+
+		content := m.renderContent()
+		require.Contains(t, content, "📋 Pre-Review Summary:")
+		require.Contains(t, content, "This PR adds JWT auth.")
+		require.Contains(t, content, "🔍 [Pre-Review Summary - Iteration 1]")
+		require.Contains(t, content, "🔍 [AI Code Review - Iteration 1]")
+	})
+
+	t.Run("renders summary at end if AI Code Review stage iteration absent", func(t *testing.T) {
+		m := &tuiModel{
+			preReviewSummary: "Standalone pre-review summary text.",
+			iterations: []*iterationState{
+				{iter: 1, stage: "Pre-Review Summary", llmStatus: "Done"},
+			},
+		}
+
+		content := m.renderContent()
+		require.Contains(t, content, "📋 Pre-Review Summary:")
+		require.Contains(t, content, "Standalone pre-review summary text.")
+	})
+}
+
+func TestIndentText(t *testing.T) {
+	input := "line 1\nline 2\n\nline 3"
+	got := indentText(input, 2)
+	expected := "  line 1\n  line 2\n\n  line 3"
+	require.Equal(t, expected, got)
+}


### PR DESCRIPTION
## Summary

Introduces a two-stage code review pipeline (Pre-Review Summary followed by AI Code Review), phase-segregated session metrics, and CLI/TUI UX enhancements for post-review discussions.

### Key Changes

- **Pre-Review Summary Stage**: Added an optional initial agent stage (`Pre-Review Summary`) that produces a neutral summary of changes (TL;DR, Purpose, Heads Up, Scope, Key Changes) before passing it to the main review phase. Controlled via `--pre-review-prompt` and `--pre-review-model`.
- **Phase-Specific Session Metrics**: Segregated session metrics tracking across `pre_review`, `review`, and `review_discussion` phases, including error resilience to preserve captured metrics on failure.
- **TUI & Console Enhancements**: Render stage indicators in iteration progress headers and format user queries in styled boxes during interactive chat sessions.

## Testing

- Passed unit tests (`bazelisk test //...`)
- Verified formatting (`bazelisk run //:format`) and linting (`golangci-lint` via rules_go)